### PR TITLE
Fix/populate bundled skills

### DIFF
--- a/.claude/skills/api-docs/SKILL.md
+++ b/.claude/skills/api-docs/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: api-docs
+description: "Fetch and cache current API documentation for libraries and services. Use when the user says 'api-docs', 'fetch docs', or 'current API'."
+---
+
+# 📄 API-Docs — Documentation fetcher
+
+## Activation
+
+When this skill activates, output:
+
+`📄 API-Docs — Fetching documentation...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User needs current API docs** | ACTIVE |
+| **User says "api-docs", "fetch docs", "current API"** | ACTIVE |
+| **User is just writing code** | DORMANT |
+
+## Protocol
+
+1. Identify the library or API the user needs docs for
+2. Fetch the latest documentation from official sources
+3. Extract the relevant sections based on the user's task
+4. Cache the docs locally for the session to avoid re-fetching
+5. Present a concise summary with links to full documentation
+
+## Ownership
+- "api-docs" / "fetch docs" / "current API" = API-Docs only

--- a/.claude/skills/compress/SKILL.md
+++ b/.claude/skills/compress/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: compress
+description: "Headroom proxy management — check compression stats, troubleshoot proxy, manage token savings. Use when the user says 'headroom', 'compression', 'token savings', or 'proxy status'."
+---
+
+# ⚙️ Compress — Headroom proxy management
+
+## Activation
+
+When this skill activates, output:
+
+`⚙️ Compress — Checking Headroom proxy...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks about compression or proxy status** | ACTIVE |
+| **User says "headroom", "compression", "token savings", "proxy status"** | ACTIVE |
+| **Headroom is just running in the background** | DORMANT |
+
+## Protocol
+
+1. Check if Headroom proxy is running: `curl -s http://localhost:8787/health`
+2. Get compression stats: `headroom stats`
+3. Report: tokens saved, compression ratio, cache hit rate
+4. If proxy is down, offer to restart: `headroom start`
+5. Troubleshoot common issues: port conflicts, auth errors, stale processes
+
+## Ownership
+- "headroom" / "compression" / "token savings" / "proxy status" = Compress only

--- a/.claude/skills/consolidate/SKILL.md
+++ b/.claude/skills/consolidate/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: consolidate
+description: "Cross-project diary consolidation — summarize weekly patterns across all projects. Use when the user says 'consolidate', 'weekly summary', or 'cross-project patterns'."
+---
+
+# 📊 Consolidate — Cross-project patterns
+
+## Activation
+
+When this skill activates, output:
+
+`📊 Consolidate — Analyzing cross-project patterns...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks for weekly summary across projects** | ACTIVE |
+| **User says "consolidate", "weekly summary", "cross-project patterns"** | ACTIVE |
+| **User is working on a single project** | DORMANT |
+
+## Protocol
+
+1. Query all projects from the database: `python db/memstack-db.py get-sessions --all --limit 20`
+2. Group sessions by project and date range
+3. Identify cross-project patterns: recurring blockers, technology overlap, skill reuse
+4. Generate a consolidated summary with insights
+5. Highlight decisions that affect multiple projects
+
+## Ownership
+- "consolidate" / "weekly summary" / "cross-project patterns" = Consolidate only

--- a/.claude/skills/context-db/SKILL.md
+++ b/.claude/skills/context-db/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: context-db
+description: "Fact store for project context — manage persistent project facts for token savings. Use when the user says 'context-db', 'fact store', 'project facts', or 'token savings'."
+---
+
+# 🗄️ Context-DB — Project fact store
+
+## Activation
+
+When this skill activates, output:
+
+`🗄️ Context-DB — Managing project facts...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks to store or retrieve project facts** | ACTIVE |
+| **User says "context-db", "fact store", "project facts"** | ACTIVE |
+| **User is just working normally** | DORMANT |
+
+## Protocol
+
+1. **Store fact**: `python db/memstack-db.py set-context '<json>'`
+2. **Retrieve facts**: `python db/memstack-db.py get-context <project>`
+3. Facts reduce token usage by avoiding re-discovery of project details each session
+4. Store: tech stack, key file paths, architecture decisions, team conventions
+
+## Ownership
+- "context-db" / "fact store" / "project facts" = Context-DB only

--- a/.claude/skills/diary/SKILL.md
+++ b/.claude/skills/diary/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: diary
+description: "Session documentation with structured handoff — log sessions to SQLite with auto-extracted insights. Use when the user says 'save diary', 'log session', or 'wrapping up'."
+---
+
+# 📓 Diary — Session documentation
+
+## Activation
+
+When this skill activates, output:
+
+`📓 Diary — Logging session...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User says "save diary", "log session", "wrapping up"** | ACTIVE |
+| **End of significant work session** | ACTIVE |
+| **Mid-task or session start with nothing done** | DORMANT |
+
+## Protocol
+
+1. Summarize: project, date, accomplishments, files changed, commits, decisions, next steps
+2. Include **Session Handoff** section: what's in progress, uncommitted changes, exact pickup instruction, session context that would be lost
+3. Save session: `python db/memstack-db.py add-session '<json>'`
+4. Extract each decision as an insight: `python db/memstack-db.py add-insight '<json>'`
+5. Update project context: `python db/memstack-db.py set-context '<json>'`
+6. Save markdown backup to `memory/sessions/{date}-{project}.md`
+
+## Ownership
+- "save diary" / "log session" / "wrapping up" = Diary only (not Project, not Echo)
+- Do not activate mid-task or at session start when nothing has been done

--- a/.claude/skills/echo/SKILL.md
+++ b/.claude/skills/echo/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: echo
+description: "Semantic memory recall — search past sessions, decisions, and insights. Use when the user says 'recall', 'last session', 'do you remember', or 'continue from'."
+---
+
+# 🔊 Echo — Semantic memory recall
+
+## Activation
+
+When this skill activates, output:
+
+`🔊 Echo — Searching memory...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User references past sessions** | ACTIVE |
+| **User says "recall", "last session", "do you remember"** | ACTIVE |
+| **User says "save" or "log"** | DORMANT — that's Diary territory |
+
+## Protocol
+
+1. Run semantic vector search: `python skills/echo/search.py "<keywords>" --top-k 5`
+2. Run SQLite search: `python db/memstack-db.py search "<keywords>"`
+3. Run recent sessions: `python db/memstack-db.py get-sessions <project> --limit 5`
+4. Run insights: `python db/memstack-db.py get-insights <project>`
+5. Present findings with similarity scores, dates, accomplishments, and pending items
+6. If vector search fails, SQLite results are sufficient
+7. If all sources return nothing, check `memory/sessions/` as fallback
+
+## Ownership
+- "recall" / "remember" / "what did we do" = Echo only (not Diary, not Project)
+- "save" / "log" = Diary territory — do not activate Echo for saving

--- a/.claude/skills/familiar/SKILL.md
+++ b/.claude/skills/familiar/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: familiar
+description: "Multi-agent dispatch — split complex tasks across parallel sub-agents. Use when the user says 'dispatch', 'send familiar', or 'split task'."
+---
+
+# 👻 Familiar — Multi-agent dispatch
+
+## Activation
+
+When this skill activates, output:
+
+`👻 Familiar — Dispatching sub-agents...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks to split work across agents** | ACTIVE |
+| **User says "dispatch", "send familiar", "split task"** | ACTIVE |
+| **Single focused task** | DORMANT — do not activate |
+
+## Protocol
+
+1. Analyze the user's request and identify independent sub-tasks
+2. For each sub-task, dispatch a sub-agent with a focused prompt
+3. Collect results from all sub-agents
+4. Synthesize and present unified results to the user
+
+## Ownership
+- "dispatch" / "send familiar" / "split task" = Familiar only

--- a/.claude/skills/forge/SKILL.md
+++ b/.claude/skills/forge/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: forge
+description: "New skill creation — create new MemStack skills following the official Anthropic SKILL.md format. Use when the user says 'forge this', 'new skill', or 'create enchantment'."
+---
+
+# 🔨 Forge — New skill creation
+
+## Activation
+
+When this skill activates, output:
+
+`🔨 Forge — Creating new skill...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User wants to create a new skill** | ACTIVE |
+| **User says "forge this", "new skill", "create enchantment"** | ACTIVE |
+| **User is modifying an existing skill** | DORMANT — just edit directly |
+
+## Protocol
+
+1. Ask for: skill name, description, trigger phrases, and intended behavior
+2. Create directory: `skills/{name}/SKILL.md`
+3. Use the official Anthropic SKILL.md format with YAML frontmatter
+4. Include: Activation message, Context Guard table, Protocol steps, Ownership rules
+5. If the skill needs a companion rule, create `rules/{name}.md`
+6. Update the Skill Index in MEMSTACK.md
+
+## Template
+
+```markdown
+---
+name: {skill-name}
+description: "{one-line description with trigger phrases}"
+---
+
+# {emoji} {Name} — {short description}
+
+## Activation
+When this skill activates, output:
+`{emoji} {Name} — {action}...`
+
+## Context Guard
+| Context | Status |
+|---------|--------|
+| **{active condition}** | ACTIVE |
+| **{dormant condition}** | DORMANT |
+
+## Protocol
+1. ...
+
+## Ownership
+- "{trigger}" = {Name} only
+```
+
+## Ownership
+- "forge this" / "new skill" / "create enchantment" = Forge only

--- a/.claude/skills/governor/SKILL.md
+++ b/.claude/skills/governor/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: governor
+description: "Portfolio governance — enforce tier and phase constraints on projects. Use when the user says 'new project', 'what tier', 'scope', or 'project init'."
+---
+
+# 🏛️ Governor — Portfolio governance
+
+## Activation
+
+When this skill activates, output:
+
+`🏛️ Governor — Checking project governance...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User is initializing a new project** | ACTIVE |
+| **User says "new project", "what tier", "scope", "project init"** | ACTIVE |
+| **User is working within an established project** | DORMANT |
+
+## Protocol
+
+1. Determine project tier based on complexity and scope:
+   - **Tier 1 (Solo)**: Single developer, simple scope, <1 week
+   - **Tier 2 (Team)**: Multi-developer, moderate scope, 1-4 weeks
+   - **Tier 3 (Enterprise)**: Cross-team, complex scope, >1 month
+2. Apply phase constraints based on tier
+3. Set up appropriate governance files (STATE.md, CLAUDE.md sections)
+4. Advise on scope boundaries
+
+## Ownership
+- "new project" / "what tier" / "scope" / "project init" = Governor only

--- a/.claude/skills/grimoire/SKILL.md
+++ b/.claude/skills/grimoire/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: grimoire
+description: "CLAUDE.md management — update project context files with decisions and patterns. Use when the user says 'update context', 'update claude', or 'save library'."
+---
+
+# 📖 Grimoire — CLAUDE.md management
+
+## Activation
+
+When this skill activates, output:
+
+`📖 Grimoire — Updating project context...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks to update CLAUDE.md** | ACTIVE |
+| **User says "update context", "update claude", "save library"** | ACTIVE |
+| **User is just reading CLAUDE.md** | DORMANT |
+
+## Protocol
+
+1. Read the current `CLAUDE.md` file
+2. Identify what needs to be added or updated based on the user's request
+3. Merge new information without duplicating existing content
+4. Preserve the existing structure and formatting
+5. Add new sections as appropriate for decisions, patterns, or conventions
+
+## Ownership
+- "update context" / "update claude" / "save library" = Grimoire only

--- a/.claude/skills/humanize/SKILL.md
+++ b/.claude/skills/humanize/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: humanize
+description: "Remove AI writing patterns from text — make content sound natural and human-written. Use when the user says 'humanize', 'make it sound natural', or 'clean up writing'."
+---
+
+# ✍️ Humanize — Remove AI writing patterns
+
+## Activation
+
+When this skill activates, output:
+
+`✍️ Humanize — Cleaning up AI patterns...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks to humanize text** | ACTIVE |
+| **User says "humanize", "make it sound natural", "clean up writing"** | ACTIVE |
+| **User is writing code, not prose** | DORMANT |
+
+## Protocol
+
+1. Identify AI writing patterns:
+   - Overuse of "delve", "leverage", "utilize", "streamline", "robust"
+   - Excessive hedging ("It's important to note that...")
+   - Formulaic transitions ("Furthermore", "Moreover", "In conclusion")
+   - Unnaturally consistent paragraph length
+   - Lists where prose would be more natural
+   - Overly enthusiastic tone
+2. Rewrite to remove patterns while preserving meaning
+3. Vary sentence length and structure
+4. Use concrete, specific language over abstract
+5. Present the cleaned version with a brief summary of changes
+
+## Ownership
+- "humanize" / "make it sound natural" / "clean up writing" = Humanize only

--- a/.claude/skills/kdp-format/SKILL.md
+++ b/.claude/skills/kdp-format/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: kdp-format
+description: "Use when the user says 'kdp', 'format for kdp', 'format book', or 'manuscript' and needs print-ready output."
+---
+
+# 📚 KDP Format — Converting manuscript to KDP-ready .docx
+
+*Convert a markdown manuscript into a professionally formatted Word document for Amazon KDP.*
+
+> **⚠️ WARNING — Unit Systems in python-docx**
+>
+> - Property setters (e.g., `section.left_margin = Inches(0.75)`) handle unit conversion automatically
+> - Raw XML attributes use **TWIPS** (1 inch = 1440 twips), NOT EMU (1 inch = 914400 EMU)
+> - **NEVER** use `str(Inches(x))` in raw XML — it produces EMU values, which are 635× too large
+> - If you must use raw XML: `twips = int(inches * 1440)`
+
+## Activation
+
+When this skill activates, output:
+
+`📚 KDP Format — Converting manuscript to KDP-ready .docx...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks to format a manuscript for KDP** | ACTIVE — full conversion |
+| **User says "format for kdp" with a file path** | ACTIVE — full conversion |
+| **User mentions book formatting or manuscript** | ACTIVE — ask for file path |
+| **User is writing content, not formatting** | DORMANT — do not activate |
+| **Discussing KDP concepts generally** | DORMANT — do not activate |
+
+## Output Specifications
+
+| Property | Value |
+|----------|-------|
+| **Trim size** | 6" × 9" (standard trade paperback) |
+| **Body font** | Georgia 11pt |
+| **Heading font** | Arial (24pt chapters, 14pt sub, 13pt sections) |
+| **Code font** | Courier New 10pt, gray background |
+| **Margins** | Top 0.75", Bottom 0.75", Inside 0.75" (gutter), Outside 0.5" |
+| **Line spacing** | 1.3× body, 1.0× code/quotes |
+| **Paragraph indent** | 0.3" first-line (except first after heading) |
+
+## Protocol
+
+### Step 1: Get the manuscript path
+If the user hasn't provided a markdown file path, ask:
+> What is the path to your markdown manuscript file?
+
+### Step 2: Verify dependencies
+Ensure `python-docx` is available:
+```bash
+pip install python-docx
+```
+
+### Step 3: Build the document
+Use python-docx to convert the markdown manuscript following the output specifications above. Handle:
+- YAML frontmatter for title, author, ISBN metadata
+- Part headers (H1), chapter headers (H2), section headers (H3)
+- Body text with proper indentation
+- Blockquotes, code blocks, inline formatting
+- Scene breaks (horizontal rules → centered `* * *`)
+- Tables, hyperlinks
+
+### Step 4: Report results
+```
+📚 KDP Format — Complete!
+
+Generated: <output-path>
+Trim size: 6" × 9"
+Sections: Title page, Copyright, Table of Contents, Body
+Chapters: <count>
+Parts: <count>
+
+Next steps:
+1. Open in Word to verify formatting
+2. Check page count for KDP margin requirements
+3. Upload to KDP dashboard
+```
+
+## Ownership
+- "kdp" / "format for kdp" / "format book" / "manuscript" = KDP Format only

--- a/.claude/skills/project/SKILL.md
+++ b/.claude/skills/project/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: project
+description: "Session handoff and lifecycle management — save project state for future sessions. Use when the user says 'save project', 'handoff', or when context is running low."
+---
+
+# 💾 Project — Session handoff & lifecycle
+
+## Activation
+
+When this skill activates, output:
+
+`💾 Project — Saving project state...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User says "save project", "handoff"** | ACTIVE |
+| **Context window running low** | ACTIVE — suggest handoff |
+| **User says "save diary" or "log session"** | DORMANT — that's Diary territory |
+
+## Protocol
+
+1. Capture current project state: branch, uncommitted changes, recent commits
+2. Summarize active work: what was being done, what's pending
+3. Save context: `python db/memstack-db.py set-context '<json>'`
+4. Generate handoff document with pickup instructions
+5. If context is running low, proactively suggest saving state
+
+## Ownership
+- "save project" / "handoff" = Project only (not Diary, not Echo)

--- a/.claude/skills/quill/SKILL.md
+++ b/.claude/skills/quill/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: quill
+description: "Client quotation generator — create professional project quotes and proposals. Use when the user says 'create quotation', 'generate quote', or 'proposal'."
+---
+
+# ✒️ Quill — Client quotation generator
+
+## Activation
+
+When this skill activates, output:
+
+`✒️ Quill — Generating quotation...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks to create a quote or proposal** | ACTIVE |
+| **User says "create quotation", "generate quote", "proposal"** | ACTIVE |
+| **User is discussing pricing abstractly** | DORMANT |
+
+## Protocol
+
+1. Gather project details: scope, deliverables, timeline
+2. If Scan data is available, use it for effort estimates
+3. Structure the quotation with: overview, scope, deliverables, timeline, pricing, terms
+4. Format as a professional document
+5. Save to project directory
+
+## Ownership
+- "create quotation" / "generate quote" / "proposal" = Quill only

--- a/.claude/skills/scan/SKILL.md
+++ b/.claude/skills/scan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: scan
+description: "Project analysis and pricing — analyze codebase complexity and estimate project cost. Use when the user says 'scan project', 'estimate', or 'how much to charge'."
+---
+
+# 🔍 Scan — Project analysis & pricing
+
+## Activation
+
+When this skill activates, output:
+
+`🔍 Scan — Analyzing project...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks to analyze or estimate a project** | ACTIVE |
+| **User says "scan project", "estimate", "how much to charge"** | ACTIVE |
+| **User is just browsing code** | DORMANT |
+
+## Protocol
+
+1. Count files, lines of code, and languages used
+2. Identify frameworks, dependencies, and architecture patterns
+3. Assess complexity: simple / moderate / complex / enterprise
+4. Estimate effort in hours based on complexity
+5. Suggest pricing based on effort and market rates
+6. Present findings in a structured report
+
+## Ownership
+- "scan project" / "estimate" / "how much to charge" = Scan only

--- a/.claude/skills/shard/SKILL.md
+++ b/.claude/skills/shard/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: shard
+description: "Large file refactoring — split files over 1000 lines into well-structured modules. Use when the user says 'shard this', 'split file', or when files exceed 1K lines."
+---
+
+# 💎 Shard — Large file refactoring
+
+## Activation
+
+When this skill activates, output:
+
+`💎 Shard — Analyzing file for refactoring...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User says "shard this", "split file"** | ACTIVE |
+| **File over 1000 lines detected** | ACTIVE — suggest sharding |
+| **File is small or well-structured** | DORMANT |
+
+## Protocol
+
+1. Analyze the file: identify logical sections, dependencies, exports
+2. Propose a split plan with new file names and what goes where
+3. Identify shared imports and utilities to extract
+4. Execute the split, updating all import/require paths
+5. Verify no broken references
+6. Run build/tests to confirm nothing broke
+
+## Ownership
+- "shard this" / "split file" = Shard only

--- a/.claude/skills/sight/SKILL.md
+++ b/.claude/skills/sight/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: sight
+description: "Architecture visualization — generate diagrams of project structure, data flow, and system architecture. Use when the user says 'draw', 'diagram', 'visualize', or 'architecture'."
+---
+
+# 👁️ Sight — Architecture visualization
+
+## Activation
+
+When this skill activates, output:
+
+`👁️ Sight — Generating visualization...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks for a diagram or visualization** | ACTIVE |
+| **User says "draw", "diagram", "visualize", "architecture"** | ACTIVE |
+| **User is discussing architecture without requesting visuals** | DORMANT |
+
+## Protocol
+
+1. Analyze the target: project structure, data flow, API routes, component tree, etc.
+2. Choose the appropriate diagram type: flowchart, sequence, ERD, component, deployment
+3. Generate Mermaid diagram syntax
+4. Present the diagram with a brief explanation
+5. Offer to refine or generate alternative views
+
+## Supported Diagram Types
+- **Flowchart**: Process flows, decision trees
+- **Sequence**: API call chains, user interactions
+- **ERD**: Database relationships
+- **Component**: Module dependencies, architecture layers
+- **Deployment**: Infrastructure, service topology
+
+## Ownership
+- "draw" / "diagram" / "visualize" / "architecture" = Sight only

--- a/.claude/skills/state/SKILL.md
+++ b/.claude/skills/state/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: state
+description: "Living STATE.md — track current task, blockers, and next steps in a persistent state file. Use when the user says 'update state', 'project state', or 'where was I'."
+---
+
+# 📍 State — Living STATE.md management
+
+## Activation
+
+When this skill activates, output:
+
+`📍 State — Updating project state...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks about current state** | ACTIVE |
+| **User says "update state", "project state", "where was I"** | ACTIVE |
+| **User says "recall" or "remember"** | DORMANT — that's Echo territory |
+| **User says "save project" or "handoff"** | DORMANT — that's Project territory |
+
+## Protocol
+
+1. Read current `STATE.md` if it exists
+2. Update with: current task, blockers, next steps, recent changes
+3. Include timestamp and branch info
+4. Write updated `STATE.md` to project root
+
+## STATE.md Format
+```markdown
+# Project State
+**Updated:** {timestamp}
+**Branch:** {current branch}
+
+## Current Task
+{what's being worked on}
+
+## Blockers
+{anything blocking progress, or "None"}
+
+## Next Steps
+{ordered list of what to do next}
+
+## Recent Changes
+{summary of recent commits/modifications}
+```
+
+## Ownership
+- "update state" / "project state" / "where was I" = State only (not Echo, not Project)

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: verify
+description: "Pre-commit work verification — run checks and generate a pass/fail report before committing. Use when the user says 'verify', 'check this work', or 'does it pass'."
+---
+
+# ✅ Verify — Pre-commit verification
+
+## Activation
+
+When this skill activates, output:
+
+`✅ Verify — Running verification checks...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks to verify work before committing** | ACTIVE |
+| **User says "verify", "check this work", "does it pass"** | ACTIVE |
+| **Automated git push checks** | DORMANT — that's the pre-push hook |
+
+## Protocol
+
+1. Run the project's build command (detect from package.json, Makefile, justfile, etc.)
+2. Run the project's test suite if one exists
+3. Run linting if configured
+4. Check for uncommitted debug artifacts (console.log, debugger, TODO)
+5. Check for secrets or sensitive data in staged files
+6. Generate a pass/fail report:
+
+```
+✅ Verify — Report
+
+Build:    ✅ passed
+Tests:    ✅ 42 passed, 0 failed
+Lint:     ✅ no issues
+Debug:    ✅ no artifacts found
+Secrets:  ✅ clean
+
+Verdict: READY TO COMMIT
+```
+
+## Ownership
+- "verify" / "check this work" / "does it pass" = Verify only (not Seal hook)

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: work
+description: "Plan execution — create, update, and resume task plans with per-task status tracking. Use when the user says 'plan', 'todo', 'task', 'copy plan', 'append plan', or 'resume plan'."
+---
+
+# 📋 Work — Plan execution
+
+## Activation
+
+When this skill activates, output:
+
+`📋 Work — Managing task plan...`
+
+## Context Guard
+
+| Context | Status |
+|---------|--------|
+| **User asks to create/manage a plan** | ACTIVE |
+| **User says "plan", "todo", "task", "priorities"** | ACTIVE |
+| **User is executing a task (not managing the list)** | DORMANT |
+
+## Protocol
+
+- **Step 0 (silent)**: Before any plan operation, read `STATE.md`, `CLAUDE.md`, recent diary entries, and git state to compile context. Do not show this step to the user.
+- **New plan / "copy plan"**: Parse tasks, save each via `python db/memstack-db.py add-plan-task '<json>'`
+- **Update / "append plan"**: Update task status via `python db/memstack-db.py update-task '<json>'`
+- **Resume / "resume plan"**: Load plan via `python db/memstack-db.py get-plan <project>`, show status summary
+- **Quick query / "todo"**: Show all pending and in-progress tasks with status indicators
+
+## Status Values
+`pending` | `in_progress` | `completed` | `blocked`
+
+## Ownership
+- "plan" / "todo" / "task" / "priorities" = Work only
+- Do not activate when the user is executing a task (not managing the list)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Whetstone is an installer/configuration framework that brings three token optimi
 Users install by running `setup-whetstone.sh` from inside a git project. Global tools (Headroom, RTK) install once; MemStack skills and supporting files are copied per-project.
 
 **Bundled layout** in this repo:
-- `.claude/skills/` — 28 skill directories only (copied to project's `.claude/skills/`)
+- `.claude/skills/` — 20 skill directories only (copied to project's `.claude/skills/`)
 - `.claude/memstack/` — hooks, rules, commands, db, config (copied to project's `.claude/` directly)
 
 ## Commands

--- a/setup-whetstone.sh
+++ b/setup-whetstone.sh
@@ -300,17 +300,17 @@ install_memstack() {
     local bundled_skills="$REPO_ROOT/.claude/skills"
     local bundled_memstack="$REPO_ROOT/.claude/memstack"
 
-    # Copy skills (the 28 skill directories)
+    # Copy skills (the 20 skill directories)
     if [[ -d "$skills_dir" ]] && ls "$skills_dir"/*/ >/dev/null 2>&1; then
         ok "Skills already installed at $skills_dir"
     else
-        if [[ -d "$bundled_skills" ]]; then
+        if [[ -d "$bundled_skills" ]] && ls "$bundled_skills"/* >/dev/null 2>&1; then
             info "Copying skills into .claude/skills/..."
             mkdir -p "$skills_dir"
             cp -a "$bundled_skills"/* "$skills_dir/"
             ok "Skills copied"
         else
-            fail "Bundled skills not found at $bundled_skills — is your Whetstone clone intact?"
+            warn "No bundled skills found at $bundled_skills — skipping skill copy"
         fi
     fi
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation/config change; the only behavioral change is `setup-whetstone.sh` no longer fails hard when bundled skills are absent, which could silently skip skill installation if the repo is incomplete.
> 
> **Overview**
> Populates the repo’s bundled `.claude/skills/` with a set of MemStack skill `SKILL.md` definitions (e.g., `echo`, `diary`, `work`, `verify`, `scan`, etc.) so projects can be initialized with these skills.
> 
> Updates install messaging and behavior: `CLAUDE.md` and `setup-whetstone.sh` now refer to **20** bundled skill directories (instead of 28), and the installer now checks for non-empty bundled skills and **warns/skips** copying rather than failing when the bundle is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b9a22aecb7677c93d4e116938be8ce88e5e198e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->