### PR TITLE
fix: add crates.io publish and fix repo references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,3 +133,19 @@ jobs:
           tag_name: ${{ needs.check-tag.outputs.tag }}
           generate_release_notes: true
           files: whetstone-*.tar.gz
+
+  publish-crate:
+    name: Publish to crates.io
+    needs: [check-tag, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Publish
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "whetstone"
-version = "0.5.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ whetstone setup ──┬── Headroom (context compression proxy)
 
 ```bash
 cd ~/my-project
-curl -fsSL https://raw.githubusercontent.com/zackkitzmiller/whetstone/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/z19r/whetstone/main/install.sh | bash
 ```
 
 This downloads the prebuilt binary for your OS/arch, installs it to
@@ -186,7 +186,7 @@ just release-publish minor         # Bump, commit, tag, and push
 
 ```bash
 # 1. Install whetstone
-curl -fsSL https://raw.githubusercontent.com/zackkitzmiller/whetstone/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/z19r/whetstone/main/install.sh | bash
 
 # 2. Or, if already installed, go to your project (must be a git repo)
 cd ~/my-project

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 # fetches assets to ~/.whetstone/assets/, then runs `whetstone setup`.
 set -euo pipefail
 
-REPO="zackkitzmiller/whetstone"
+REPO="z19r/whetstone"
 BIN_DIR="${HOME}/.local/bin"
 ASSETS_DIR="${HOME}/.whetstone/assets"
 


### PR DESCRIPTION
## Summary
- Add `publish-crate` job to release workflow — runs `cargo publish` after GitHub Release is created, using `CARGO_REGISTRY_TOKEN` secret
- Fix repo references from `zackkitzmiller/whetstone` to `z19r/whetstone` in `install.sh` and `README.md`
- Cargo.lock version bump to 2.0.0

## Test plan
- [ ] Verify `CARGO_REGISTRY_TOKEN` secret is set in repo settings
- [ ] Merge to main with a VERSION bump to trigger the full release pipeline
- [ ] Confirm crate appears at https://crates.io/crates/whetstone after release
- [ ] Confirm `install.sh` downloads from correct repo