### PR TITLE
feat: full-monty update system with passive upgrade banner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +564,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,7 +616,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -656,6 +683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +717,18 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -727,6 +772,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -945,6 +999,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1170,6 +1235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,10 +1272,13 @@ dependencies = [
  "console",
  "dialoguer",
  "dirs",
+ "flate2",
+ "indicatif",
  "rusqlite",
  "semver",
  "serde",
  "serde_json",
+ "tar",
  "ureq",
  "which",
 ]
@@ -1538,6 +1616,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ which = "6"
 dirs = "5"
 chrono = { version = "0.4", features = ["serde"] }
 anyhow = "1"
+indicatif = "0.17"
+flate2 = "1"
+tar = "0.4"
 
 [profile.release]
 lto = true

--- a/src/headroom.rs
+++ b/src/headroom.rs
@@ -23,7 +23,7 @@ fn package_spec(extras: &str) -> String {
     }
 }
 
-fn installed_version() -> Option<String> {
+pub fn installed_version() -> Option<String> {
     let output = Command::new("headroom").arg("--version").output().ok()?;
     if !output.status.success() {
         return None;
@@ -52,6 +52,22 @@ pub fn install(extras: &str, force: bool) -> Result<()> {
         None => bail!("headroom installation failed — check uv output above"),
     }
     Ok(())
+}
+
+pub fn update() -> Result<ui::ComponentStatus> {
+    let Some(old_ver) = installed_version() else {
+        return Ok(ui::ComponentStatus::NotInstalled);
+    };
+
+    let spec = package_spec("all");
+    run_uv_install(&spec, true)?;
+
+    let new_ver = installed_version().unwrap_or_else(|| old_ver.clone());
+    if new_ver != old_ver {
+        Ok(ui::ComponentStatus::Updated(old_ver, new_ver))
+    } else {
+        Ok(ui::ComponentStatus::UpToDate(old_ver))
+    }
 }
 
 fn run_uv_install(spec: &str, upgrade: bool) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,20 @@ mod wrapper;
 use clap::Parser;
 use cli::{Cli, Command};
 
+fn show_upgrade_banner(cmd: &Option<Command>) {
+    let skip = matches!(cmd, Some(Command::Update { .. } | Command::Version));
+    if skip {
+        return;
+    }
+    if let Some((current, latest)) = update::check_cached_upgrade() {
+        ui::upgrade_banner(&current, &latest);
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
+
+    show_upgrade_banner(&cli.command);
 
     match cli.command {
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,8 @@ fn show_upgrade_banner(cmd: &Option<Command>) {
     if skip {
         return;
     }
-    if let Some((current, latest)) = update::check_cached_upgrade() {
-        ui::upgrade_banner(&current, &latest);
-    }
+    let outdated = update::check_cached_upgrade();
+    ui::upgrade_banner(&outdated);
 }
 
 fn main() {

--- a/src/rtk.rs
+++ b/src/rtk.rs
@@ -8,7 +8,7 @@ const MIN_VERSION: &str = "0.7.0";
 const INSTALL_URL: &str =
     "https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh";
 
-fn installed_version() -> Option<String> {
+pub fn installed_version() -> Option<String> {
     let output = Command::new("rtk").arg("--version").output().ok()?;
     if !output.status.success() {
         return None;
@@ -41,6 +41,35 @@ pub fn install(force: bool) -> Result<()> {
         ui::info("installing rtk");
     }
 
+    run_install()?;
+
+    match installed_version() {
+        Some(ver) if is_rtk_ai() => ui::ok(&format!("rtk {ver}")),
+        _ => bail!("rtk installation completed but rtk-ai not detected"),
+    }
+    Ok(())
+}
+
+pub fn update() -> Result<ui::ComponentStatus> {
+    let Some(old_ver) = installed_version() else {
+        return Ok(ui::ComponentStatus::NotInstalled);
+    };
+    if !is_rtk_ai() {
+        return Ok(ui::ComponentStatus::Failed(
+            "not rtk-ai (collision?)".into(),
+        ));
+    }
+    run_install()?;
+
+    let new_ver = installed_version().unwrap_or_else(|| old_ver.clone());
+    if new_ver != old_ver {
+        Ok(ui::ComponentStatus::Updated(old_ver, new_ver))
+    } else {
+        Ok(ui::ComponentStatus::UpToDate(old_ver))
+    }
+}
+
+fn run_install() -> Result<()> {
     let status = Command::new("sh")
         .arg("-c")
         .arg(format!("curl -fsSL {INSTALL_URL} | sh"))
@@ -48,11 +77,6 @@ pub fn install(force: bool) -> Result<()> {
 
     if !status.success() {
         bail!("rtk installation failed");
-    }
-
-    match installed_version() {
-        Some(ver) if is_rtk_ai() => ui::ok(&format!("rtk {ver}")),
-        _ => bail!("rtk installation completed but rtk-ai not detected"),
     }
     Ok(())
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,9 @@
 use console::style;
 use dialoguer::{Confirm, Select};
+use indicatif::{ProgressBar, ProgressStyle};
 use std::io::{self, IsTerminal};
+
+const BOX_WIDTH: usize = 48;
 
 pub fn info(msg: &str) {
     eprintln!("{} {msg}", style("[INFO]").blue().bold());
@@ -44,4 +47,143 @@ pub fn select<T: std::fmt::Display>(prompt: &str, items: &[T], default: usize) -
         .default(default)
         .interact()
         .unwrap_or(default)
+}
+
+pub fn upgrade_banner(current: &str, latest: &str) {
+    let arrow_line = format!("{} → {}", current, latest);
+    let action_line = "Run: whetstone update";
+    let title = "UPGRADE AVAILABLE";
+
+    let inner = BOX_WIDTH - 4;
+    let border = "─".repeat(inner + 2);
+
+    eprintln!();
+    eprintln!(
+        "  {}{}{}",
+        style("┌").cyan(),
+        style(&border).cyan(),
+        style("┐").cyan()
+    );
+    eprintln!(
+        "  {}{}{}",
+        style("│").cyan(),
+        " ".repeat(inner + 2),
+        style("│").cyan()
+    );
+    eprintln!(
+        "  {} {} {}{}",
+        style("│").cyan(),
+        style(format!("⬆  {title}")).yellow().bold(),
+        " ".repeat(inner.saturating_sub(title.chars().count() + 4)),
+        style("│").cyan()
+    );
+    eprintln!(
+        "  {}{}{}",
+        style("│").cyan(),
+        " ".repeat(inner + 2),
+        style("│").cyan()
+    );
+    eprintln!(
+        "  {} {} {}{}",
+        style("│").cyan(),
+        style(&arrow_line).white().bold(),
+        " ".repeat(inner.saturating_sub(arrow_line.chars().count() + 1)),
+        style("│").cyan()
+    );
+    eprintln!(
+        "  {} {} {}{}",
+        style("│").cyan(),
+        style(action_line).dim(),
+        " ".repeat(inner.saturating_sub(action_line.chars().count() + 1)),
+        style("│").cyan()
+    );
+    eprintln!(
+        "  {}{}{}",
+        style("│").cyan(),
+        " ".repeat(inner + 2),
+        style("│").cyan()
+    );
+    eprintln!(
+        "  {}{}{}",
+        style("└").cyan(),
+        style(&border).cyan(),
+        style("┘").cyan()
+    );
+    eprintln!();
+}
+
+pub fn section(title: &str) {
+    let line = "─".repeat(40);
+    eprintln!();
+    eprintln!("  {} {}", style(title).bold(), style(&line).dim());
+    eprintln!();
+}
+
+#[derive(Debug)]
+pub enum ComponentStatus {
+    UpToDate(String),
+    Updated(String, String),
+    NotInstalled,
+    Failed(String),
+}
+
+pub fn component_line(name: &str, status: &ComponentStatus) {
+    let label = format!("{:.<16}", format!("{name} "));
+    match status {
+        ComponentStatus::UpToDate(ver) => {
+            eprintln!(
+                "  {} {} {}",
+                style("●").green(),
+                style(&label).bold(),
+                style(format!("{ver} (up to date)")).dim()
+            );
+        }
+        ComponentStatus::Updated(from, to) => {
+            eprintln!(
+                "  {} {} {} → {}",
+                style("●").green(),
+                style(&label).bold(),
+                style(from).dim(),
+                style(to).green().bold()
+            );
+        }
+        ComponentStatus::NotInstalled => {
+            eprintln!(
+                "  {} {} {}",
+                style("○").dim(),
+                style(&label).bold(),
+                style("not installed").dim()
+            );
+        }
+        ComponentStatus::Failed(reason) => {
+            eprintln!(
+                "  {} {} {}",
+                style("✗").red(),
+                style(&label).bold(),
+                style(reason).red()
+            );
+        }
+    }
+}
+
+pub fn summary_ok(msg: &str) {
+    eprintln!();
+    eprintln!("  {} {}", style("✓").green().bold(), style(msg).green());
+    eprintln!();
+}
+
+pub fn summary_info(msg: &str) {
+    eprintln!();
+    eprintln!("  {} {}", style("ℹ").blue().bold(), style(msg).bold());
+    eprintln!();
+}
+
+pub fn spinner(msg: &str) -> ProgressBar {
+    let pb = ProgressBar::new_spinner();
+    let style = ProgressStyle::with_template("  {spinner:.cyan} {msg}")
+        .unwrap_or_else(|_| ProgressStyle::default_spinner());
+    pb.set_style(style.tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]));
+    pb.set_message(msg.to_string());
+    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+    pb
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -49,12 +49,33 @@ pub fn select<T: std::fmt::Display>(prompt: &str, items: &[T], default: usize) -
         .unwrap_or(default)
 }
 
-pub fn upgrade_banner(current: &str, latest: &str) {
-    let arrow_line = format!("{} → {}", current, latest);
-    let action_line = "Run: whetstone update";
-    let title = "UPGRADE AVAILABLE";
+pub fn upgrade_banner(components: &[crate::update::OutdatedComponent]) {
+    if components.is_empty() {
+        return;
+    }
 
-    let inner = BOX_WIDTH - 4;
+    let title = "UPDATES AVAILABLE";
+    let action_line = "Run: whetstone update";
+
+    let mut content_lines: Vec<String> = Vec::new();
+    for c in components {
+        content_lines.push(format!("{}: {} → {}", c.name, c.current, c.latest));
+    }
+
+    let max_content = content_lines
+        .iter()
+        .map(|l| l.chars().count())
+        .max()
+        .unwrap_or(0);
+    let min_width = [
+        title.chars().count() + 4,
+        action_line.chars().count(),
+        max_content,
+    ]
+    .into_iter()
+    .max()
+    .unwrap_or(0);
+    let inner = min_width.max(BOX_WIDTH - 4);
     let border = "─".repeat(inner + 2);
 
     eprintln!();
@@ -83,11 +104,19 @@ pub fn upgrade_banner(current: &str, latest: &str) {
         " ".repeat(inner + 2),
         style("│").cyan()
     );
+    for line in &content_lines {
+        eprintln!(
+            "  {} {} {}{}",
+            style("│").cyan(),
+            style(line).white().bold(),
+            " ".repeat(inner.saturating_sub(line.chars().count() + 1)),
+            style("│").cyan()
+        );
+    }
     eprintln!(
-        "  {} {} {}{}",
+        "  {}{}{}",
         style("│").cyan(),
-        style(&arrow_line).white().bold(),
-        " ".repeat(inner.saturating_sub(arrow_line.chars().count() + 1)),
+        " ".repeat(inner + 2),
         style("│").cyan()
     );
     eprintln!(

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,12 +1,13 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use std::fs;
+use std::io::Read;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::ui;
-use crate::version;
+use crate::{headroom, rtk, ui, version};
 
 const REMOTE_VERSION_URL: &str = "https://raw.githubusercontent.com/z19r/whetstone/main/VERSION";
+const RELEASE_URL_BASE: &str = "https://github.com/z19r/whetstone/releases/download";
 const CACHE_TTL_SECS: u64 = 12 * 60 * 60;
 
 fn cache_path() -> Result<PathBuf> {
@@ -49,37 +50,171 @@ fn fetch_remote_version() -> Result<String> {
     version::extract_semver(body.trim()).context("no valid semver in remote VERSION")
 }
 
-pub fn run(full: bool) -> Result<()> {
+pub fn check_cached_upgrade() -> Option<(String, String)> {
+    let (cached_ver, ts) = read_cache()?;
+    if now_epoch() - ts > CACHE_TTL_SECS {
+        return None;
+    }
     let current = version::current().to_string();
-    ui::info(&format!("current version: {current}"));
-
-    let remote = if let Some((cached_ver, ts)) = read_cache() {
-        if now_epoch() - ts < CACHE_TTL_SECS {
-            ui::info("using cached version check");
-            cached_ver
-        } else {
-            let ver = fetch_remote_version()?;
-            write_cache(&ver);
-            ver
-        }
+    if version::is_older(&current, &cached_ver) {
+        Some((current, cached_ver))
     } else {
-        let ver = fetch_remote_version()?;
-        write_cache(&ver);
-        ver
+        None
+    }
+}
+
+fn detect_target() -> Option<&'static str> {
+    let arch = std::env::consts::ARCH;
+    let os = std::env::consts::OS;
+
+    match (os, arch) {
+        ("linux", "x86_64") => Some("x86_64-unknown-linux-gnu"),
+        ("linux", "aarch64") => Some("aarch64-unknown-linux-gnu"),
+        ("macos", "x86_64") => Some("x86_64-apple-darwin"),
+        ("macos", "aarch64") => Some("aarch64-apple-darwin"),
+        _ => None,
+    }
+}
+
+fn self_update(latest: &str) -> Result<ui::ComponentStatus> {
+    let current = version::current().to_string();
+
+    if !version::is_older(&current, latest) {
+        return Ok(ui::ComponentStatus::UpToDate(current));
+    }
+
+    let target = detect_target().context("unsupported platform for self-update")?;
+    let url = format!("{RELEASE_URL_BASE}/v{latest}/whetstone-{target}.tar.gz");
+
+    let sp = ui::spinner(&format!("downloading whetstone {latest}"));
+
+    let resp = ureq::get(&url)
+        .call()
+        .with_context(|| format!("downloading {url}"))?;
+
+    let mut compressed = Vec::new();
+    resp.into_reader()
+        .read_to_end(&mut compressed)
+        .context("reading release tarball")?;
+
+    sp.finish_and_clear();
+
+    let decoder = flate2::read::GzDecoder::new(compressed.as_slice());
+    let mut archive = tar::Archive::new(decoder);
+
+    let current_exe = std::env::current_exe().context("locating current binary")?;
+    let parent = current_exe
+        .parent()
+        .context("no parent dir for current binary")?;
+    let staging = parent.join(".whetstone-update");
+
+    for entry in archive.entries().context("reading tar entries")? {
+        let mut entry = entry.context("reading tar entry")?;
+        let path = entry.path().context("reading entry path")?;
+        if path.file_name().and_then(|n| n.to_str()) == Some("whetstone") {
+            entry
+                .unpack(&staging)
+                .context("extracting whetstone binary")?;
+            break;
+        }
+    }
+
+    if !staging.exists() {
+        bail!("whetstone binary not found in release tarball");
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) = fs::set_permissions(&staging, fs::Permissions::from_mode(0o755)) {
+            let _ = fs::remove_file(&staging);
+            return Err(e).context("setting permissions on new binary");
+        }
+    }
+
+    let mut backup_name = current_exe
+        .file_name()
+        .context("no file name on current_exe")?
+        .to_os_string();
+    backup_name.push(".old");
+    let backup = current_exe.with_file_name(backup_name);
+
+    if let Err(e) = fs::rename(&current_exe, &backup) {
+        let _ = fs::remove_file(&staging);
+        return Err(e).context("backing up current binary");
+    }
+
+    if let Err(e) = fs::rename(&staging, &current_exe) {
+        let _ = fs::rename(&backup, &current_exe);
+        let _ = fs::remove_file(&staging);
+        return Err(e).context("replacing binary with new version");
+    }
+
+    let _ = fs::remove_file(&backup);
+    write_cache(latest);
+
+    Ok(ui::ComponentStatus::Updated(current, latest.to_string()))
+}
+
+pub fn run(_full: bool) -> Result<()> {
+    ui::section("whetstone update");
+
+    let sp = ui::spinner("checking for updates");
+    let latest = fetch_remote_version()?;
+    write_cache(&latest);
+    sp.finish_and_clear();
+
+    let current = version::current().to_string();
+    let mut updated_count = 0u32;
+
+    let whetstone_status = match self_update(&latest) {
+        Ok(status) => status,
+        Err(e) => ui::ComponentStatus::Failed(format!("{e:#}")),
     };
+    if matches!(&whetstone_status, ui::ComponentStatus::Updated(_, _)) {
+        updated_count += 1;
+    }
+    ui::component_line("whetstone", &whetstone_status);
 
-    ui::info(&format!("latest version: {remote}"));
+    let rtk_status = match rtk::update() {
+        Ok(status) => status,
+        Err(e) => ui::ComponentStatus::Failed(format!("{e:#}")),
+    };
+    if matches!(&rtk_status, ui::ComponentStatus::Updated(_, _)) {
+        updated_count += 1;
+    }
+    ui::component_line("rtk", &rtk_status);
 
-    if version::is_older(&current, &remote) {
-        ui::info(&format!("update available: {current} -> {remote}"));
-        ui::info("run: curl -fsSL https://raw.githubusercontent.com/z19r/whetstone/main/install.sh | bash");
+    let headroom_status = match headroom::update() {
+        Ok(status) => status,
+        Err(e) => ui::ComponentStatus::Failed(format!("{e:#}")),
+    };
+    if matches!(&headroom_status, ui::ComponentStatus::Updated(_, _)) {
+        updated_count += 1;
+    }
+    ui::component_line("headroom", &headroom_status);
 
-        if full {
-            ui::info("--full passed: re-running setup after update");
-            ui::warn("self-update via binary download not yet implemented");
+    let memory_status = ui::ComponentStatus::UpToDate("embedded".into());
+    ui::component_line("memory (ICM)", &memory_status);
+
+    if updated_count > 0 {
+        ui::summary_ok(&format!("Updated {updated_count} component(s)"));
+
+        if matches!(&whetstone_status, ui::ComponentStatus::Updated(_, _)) {
+            ui::info(&format!(
+                "whetstone updated from {current} → {latest} — restart your shell to use it"
+            ));
         }
     } else {
-        ui::ok("already up to date");
+        let has_failures = matches!(&whetstone_status, ui::ComponentStatus::Failed(_))
+            || matches!(&rtk_status, ui::ComponentStatus::Failed(_))
+            || matches!(&headroom_status, ui::ComponentStatus::Failed(_));
+
+        if has_failures {
+            ui::summary_info("Some components failed to update — see errors above");
+        } else {
+            ui::summary_ok("Everything is up to date");
+        }
     }
 
     Ok(())

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
@@ -9,6 +10,26 @@ use crate::{headroom, rtk, ui, version};
 const REMOTE_VERSION_URL: &str = "https://raw.githubusercontent.com/z19r/whetstone/main/VERSION";
 const RELEASE_URL_BASE: &str = "https://github.com/z19r/whetstone/releases/download";
 const CACHE_TTL_SECS: u64 = 12 * 60 * 60;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct VersionCache {
+    whetstone_latest: String,
+    #[serde(default)]
+    rtk_latest: Option<String>,
+    #[serde(default)]
+    rtk_current: Option<String>,
+    #[serde(default)]
+    headroom_latest: Option<String>,
+    #[serde(default)]
+    headroom_current: Option<String>,
+    timestamp: u64,
+}
+
+pub struct OutdatedComponent {
+    pub name: &'static str,
+    pub current: String,
+    pub latest: String,
+}
 
 fn cache_path() -> Result<PathBuf> {
     let home = dirs::home_dir().context("could not determine home directory")?;
@@ -24,19 +45,32 @@ fn now_epoch() -> u64 {
         .as_secs()
 }
 
-fn read_cache() -> Option<(String, u64)> {
+fn read_cache() -> Option<VersionCache> {
     let path = cache_path().ok()?;
-    let content = fs::read_to_string(path).ok()?;
+    let content = fs::read_to_string(&path).ok()?;
+
+    if let Ok(cache) = serde_json::from_str::<VersionCache>(&content) {
+        return Some(cache);
+    }
+
     let mut lines = content.lines();
     let ver = lines.next()?.trim().to_string();
     let ts: u64 = lines.next()?.trim().parse().ok()?;
-    Some((ver, ts))
+    Some(VersionCache {
+        whetstone_latest: ver,
+        rtk_latest: None,
+        rtk_current: None,
+        headroom_latest: None,
+        headroom_current: None,
+        timestamp: ts,
+    })
 }
 
-fn write_cache(version: &str) {
+fn write_cache(cache: &VersionCache) {
     if let Ok(path) = cache_path() {
-        let content = format!("{version}\n{}", now_epoch());
-        let _ = fs::write(path, content);
+        if let Ok(json) = serde_json::to_string(cache) {
+            let _ = fs::write(path, json);
+        }
     }
 }
 
@@ -50,17 +84,46 @@ fn fetch_remote_version() -> Result<String> {
     version::extract_semver(body.trim()).context("no valid semver in remote VERSION")
 }
 
-pub fn check_cached_upgrade() -> Option<(String, String)> {
-    let (cached_ver, ts) = read_cache()?;
-    if now_epoch() - ts > CACHE_TTL_SECS {
-        return None;
+pub fn check_cached_upgrade() -> Vec<OutdatedComponent> {
+    let mut outdated = Vec::new();
+
+    let Some(cache) = read_cache() else {
+        return outdated;
+    };
+    if now_epoch().saturating_sub(cache.timestamp) > CACHE_TTL_SECS {
+        return outdated;
     }
-    let current = version::current().to_string();
-    if version::is_older(&current, &cached_ver) {
-        Some((current, cached_ver))
-    } else {
-        None
+
+    let current_whetstone = version::current().to_string();
+    if version::is_older(&current_whetstone, &cache.whetstone_latest) {
+        outdated.push(OutdatedComponent {
+            name: "whetstone",
+            current: current_whetstone,
+            latest: cache.whetstone_latest.clone(),
+        });
     }
+
+    if let (Some(current), Some(latest)) = (&cache.rtk_current, &cache.rtk_latest) {
+        if version::is_older(current, latest) {
+            outdated.push(OutdatedComponent {
+                name: "rtk",
+                current: current.clone(),
+                latest: latest.clone(),
+            });
+        }
+    }
+
+    if let (Some(current), Some(latest)) = (&cache.headroom_current, &cache.headroom_latest) {
+        if version::is_older(current, latest) {
+            outdated.push(OutdatedComponent {
+                name: "headroom",
+                current: current.clone(),
+                latest: latest.clone(),
+            });
+        }
+    }
+
+    outdated
 }
 
 fn detect_target() -> Option<&'static str> {
@@ -151,7 +214,6 @@ fn self_update(latest: &str) -> Result<ui::ComponentStatus> {
     }
 
     let _ = fs::remove_file(&backup);
-    write_cache(latest);
 
     Ok(ui::ComponentStatus::Updated(current, latest.to_string()))
 }
@@ -161,10 +223,11 @@ pub fn run(_full: bool) -> Result<()> {
 
     let sp = ui::spinner("checking for updates");
     let latest = fetch_remote_version()?;
-    write_cache(&latest);
     sp.finish_and_clear();
 
     let current = version::current().to_string();
+    let rtk_before = rtk::installed_version();
+    let headroom_before = headroom::installed_version();
     let mut updated_count = 0u32;
 
     let whetstone_status = match self_update(&latest) {
@@ -196,6 +259,15 @@ pub fn run(_full: bool) -> Result<()> {
 
     let memory_status = ui::ComponentStatus::UpToDate("embedded".into());
     ui::component_line("memory (ICM)", &memory_status);
+
+    write_cache(&VersionCache {
+        whetstone_latest: latest.clone(),
+        rtk_current: rtk_before,
+        rtk_latest: rtk::installed_version(),
+        headroom_current: headroom_before,
+        headroom_latest: headroom::installed_version(),
+        timestamp: now_epoch(),
+    });
 
     if updated_count > 0 {
         ui::summary_ok(&format!("Updated {updated_count} component(s)"));


### PR DESCRIPTION
## Summary
- `whetstone update` now self-updates the binary from GitHub releases and upgrades all components (RTK, Headroom, ICM) in one command
- Every whetstone command shows a styled UPGRADE AVAILABLE banner when a newer version is detected (12h cache)
- Charmbracelet-inspired TUI: box-drawn banners, spinners via indicatif, colored component status lines

## Changes
- **ui.rs**: `upgrade_banner()`, `section()`, `component_line()`, `spinner()`, `summary_ok/info()`
- **update.rs**: `check_cached_upgrade()` for passive banner, `self_update()` downloads tarball from GitHub releases and atomically replaces binary, `run()` orchestrates all component updates
- **rtk.rs**: `installed_version()` now pub, new `update()` returns `ComponentStatus`
- **headroom.rs**: `installed_version()` now pub, new `update()` returns `ComponentStatus`
- **main.rs**: `show_upgrade_banner()` runs before command dispatch (skipped for update/version)
- **Cargo.toml**: added `indicatif`, `flate2`, `tar`

## Review fixes applied
- Staging file cleanup on all error paths
- Windows-safe backup naming (`.push(".old")` instead of `.with_extension`)
- `let-else` idiom replacing `unwrap()` after `is_none()` guard
- `ProgressStyle` fallback instead of `unwrap()`
- Unicode-safe char counting for box padding
- `#[derive(Debug)]` on `ComponentStatus`

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 17 passing
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [x] `whetstone version` — no banner shown (correct)
- [ ] Manual: test `whetstone update` with stale cache to verify full flow
- [ ] Manual: verify banner renders on other commands when cache has newer version