### PR TITLE
fix: update components independently of whetstone version

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -109,7 +109,7 @@ fn prompt_memory_provider(full: bool) -> Result<MemoryProvider> {
     Ok(choices[idx])
 }
 
-fn detect_installed_provider() -> Result<MemoryProvider> {
+pub(crate) fn detect_installed_provider() -> Result<MemoryProvider> {
     let settings_path = dirs::home_dir()
         .context("home directory")?
         .join(".claude/settings.json");
@@ -128,7 +128,11 @@ fn detect_installed_provider() -> Result<MemoryProvider> {
     }
 }
 
-fn install_general_assets(assets: &Path, full: bool, headroom_extras: &str) -> Result<()> {
+pub(crate) fn install_general_assets(
+    assets: &Path,
+    full: bool,
+    headroom_extras: &str,
+) -> Result<()> {
     let project_dir = std::env::current_dir()?;
     let claude_dir = project_dir.join(".claude");
 
@@ -144,7 +148,7 @@ fn install_general_assets(assets: &Path, full: bool, headroom_extras: &str) -> R
     Ok(())
 }
 
-fn install_provider(provider: MemoryProvider) -> Result<()> {
+pub(crate) fn install_provider(provider: MemoryProvider) -> Result<()> {
     match provider {
         MemoryProvider::Icm => install_icm(),
         MemoryProvider::AutoMem => install_automem(),

--- a/src/update.rs
+++ b/src/update.rs
@@ -3,8 +3,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::ui;
-use crate::version;
+use crate::memory::MemoryProvider;
+use crate::{headroom, rtk, setup, ui, version};
 
 const REMOTE_VERSION_URL: &str = "https://raw.githubusercontent.com/z19r/whetstone/main/VERSION";
 const CACHE_TTL_SECS: u64 = 12 * 60 * 60;
@@ -49,9 +49,38 @@ fn fetch_remote_version() -> Result<String> {
     version::extract_semver(body.trim()).context("no valid semver in remote VERSION")
 }
 
+fn read_configured_extras() -> String {
+    let config_path = std::env::current_dir()
+        .ok()
+        .map(|d| d.join(".claude/config.local.json"));
+
+    if let Some(path) = config_path {
+        if let Ok(content) = fs::read_to_string(path) {
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(extras) = val
+                    .get("headroom")
+                    .and_then(|h| h.get("required_extras"))
+                    .and_then(|e| e.as_array())
+                {
+                    let joined: Vec<String> = extras
+                        .iter()
+                        .filter_map(|v| v.as_str())
+                        .map(|s| s.trim_matches(|c| c == '[' || c == ']').to_string())
+                        .collect();
+                    if !joined.is_empty() {
+                        return joined.join(",");
+                    }
+                }
+            }
+        }
+    }
+
+    "all".to_string()
+}
+
 pub fn run(full: bool) -> Result<()> {
     let current = version::current().to_string();
-    ui::info(&format!("current version: {current}"));
+    ui::info(&format!("current whetstone version: {current}"));
 
     let remote = if let Some((cached_ver, ts)) = read_cache() {
         if now_epoch() - ts < CACHE_TTL_SECS {
@@ -68,19 +97,46 @@ pub fn run(full: bool) -> Result<()> {
         ver
     };
 
-    ui::info(&format!("latest version: {remote}"));
+    ui::info(&format!("latest whetstone version: {remote}"));
 
     if version::is_older(&current, &remote) {
-        ui::info(&format!("update available: {current} -> {remote}"));
-        ui::info("run: curl -fsSL https://raw.githubusercontent.com/z19r/whetstone/main/install.sh | bash");
-
-        if full {
-            ui::info("--full passed: re-running setup after update");
-            ui::warn("self-update via binary download not yet implemented");
-        }
+        ui::warn(&format!(
+            "whetstone update available: {current} -> {remote}"
+        ));
+        ui::info(
+            "run: curl -fsSL https://raw.githubusercontent.com/z19r/whetstone/main/install.sh | bash",
+        );
     } else {
-        ui::ok("already up to date");
+        ui::ok("whetstone up to date");
     }
 
+    update_components(full)?;
+
+    Ok(())
+}
+
+fn update_components(full: bool) -> Result<()> {
+    let extras = read_configured_extras();
+
+    ui::info("checking headroom...");
+    headroom::install(&extras, full)?;
+
+    ui::info("checking rtk...");
+    rtk::install(full)?;
+
+    let provider = setup::detect_installed_provider()?;
+    if provider != MemoryProvider::Skip {
+        ui::info(&format!("checking {}...", provider.name()));
+        setup::install_provider(provider)?;
+    }
+
+    if full {
+        if let Ok(assets) = setup::resolve_assets_dir() {
+            ui::info("refreshing bundled assets...");
+            setup::install_general_assets(&assets, true, &extras)?;
+        }
+    }
+
+    ui::ok("all components checked");
     Ok(())
 }


### PR DESCRIPTION
## Summary
- `whetstone update` now checks headroom, RTK, and memory provider regardless of whether whetstone itself needs an update
- `--full` forces upgrades on all components and refreshes bundled assets
- Reads headroom extras from `config.local.json` when available, falls back to `"all"`

Previously the entire component update path was gated behind `version::is_older()` for whetstone itself — if whetstone was current, nothing else got checked.

## Test plan
- [ ] `cargo test` passes (17 tests)
- [ ] `cargo clippy` clean
- [ ] `whetstone update` with current whetstone version still checks headroom/RTK/ICM
- [ ] `whetstone update --full` force-upgrades all components and refreshes assets