### PR TITLE
fix: repair RTK setup and harden release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Format
-        run: cargo fmt --check
+      - name: Install just
+        run: cargo install just --locked
 
-      - name: Clippy
-        run: cargo clippy -- -D warnings
-
-      - name: Test
-        run: cargo test
+      - name: Release check
+        run: just release-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
     paths: [VERSION]
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,36 +11,57 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check-tag:
-    name: Check if release needed
+    name: Prepare release metadata
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.version.outputs.tag }}
-      needed: ${{ steps.version.outputs.needed }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Read version and check tag
+      - name: Read version
         id: version
         run: |
           VERSION=$(cat VERSION | tr -d '[:space:]')
           TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           if git rev-parse "${TAG}" >/dev/null 2>&1; then
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-            echo "Tag ${TAG} already exists, skipping release"
+            echo "Tag ${TAG} already exists; continuing in recovery mode"
           else
-            echo "needed=true" >> "$GITHUB_OUTPUT"
             echo "Will create release ${TAG}"
           fi
 
+  verify:
+    name: Verify release commit
+    needs: check-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install just
+        run: cargo install just --locked
+
+      - name: Release check
+        run: just release-check
+
   build:
     name: Build ${{ matrix.target }}
-    needs: check-tag
-    if: needs.check-tag.outputs.needed == 'true'
+    needs: [check-tag, verify]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -96,8 +116,7 @@ jobs:
 
   assets:
     name: Package assets
-    needs: check-tag
-    if: needs.check-tag.outputs.needed == 'true'
+    needs: [check-tag, verify]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -112,40 +131,132 @@ jobs:
           path: whetstone-assets.tar.gz
 
   release:
-    name: Create Release
-    needs: [check-tag, build, assets]
+    name: Create release
+    needs: [check-tag, verify, build, assets]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Create tag
-        run: |
-          git tag ${{ needs.check-tag.outputs.tag }}
-          git push origin ${{ needs.check-tag.outputs.tag }}
+        with:
+          fetch-depth: 0
 
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
 
-      - name: Create GitHub Release
+      - name: Create tag if needed
+        env:
+          TAG: ${{ needs.check-tag.outputs.tag }}
+        run: |
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
+      - name: Generate checksums
+        run: sha256sum whetstone-*.tar.gz > SHA256SUMS.txt
+
+      - name: Create or update GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.check-tag.outputs.tag }}
           generate_release_notes: true
-          files: whetstone-*.tar.gz
+          files: |
+            whetstone-*.tar.gz
+            SHA256SUMS.txt
 
-  publish-crate:
-    name: Publish to crates.io
+  verify-release:
+    name: Verify GitHub release
     needs: [check-tag, release]
     runs-on: ubuntu-latest
     steps:
+      - name: Inspect release metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.check-tag.outputs.tag }}
+        run: |
+          gh release view "$TAG"             --json tagName,isDraft,isPrerelease,assets > release.json
+          gh release download "$TAG" --pattern "SHA256SUMS.txt" --dir .
+          python3 - <<'PY2'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          data = json.load(open("release.json"))
+          required = {
+              "SHA256SUMS.txt",
+              "whetstone-assets.tar.gz",
+              "whetstone-aarch64-apple-darwin.tar.gz",
+              "whetstone-aarch64-unknown-linux-gnu.tar.gz",
+              "whetstone-x86_64-apple-darwin.tar.gz",
+              "whetstone-x86_64-unknown-linux-gnu.tar.gz",
+          }
+          assets = {asset["name"] for asset in data["assets"]}
+
+          if data["tagName"] != os.environ["TAG"]:
+              sys.exit("release tag mismatch")
+          if data["isDraft"]:
+              sys.exit("release is still a draft")
+          if data["isPrerelease"]:
+              sys.exit("release is unexpectedly marked prerelease")
+
+          missing = sorted(required - assets)
+          if missing:
+              names = ", ".join(missing)
+              sys.exit(f"missing release assets: {names}")
+
+          checksums = Path("SHA256SUMS.txt")
+          listed = set()
+          for line in checksums.read_text().splitlines():
+              parts = line.split(maxsplit=1)
+              if len(parts) == 2:
+                  listed.add(parts[1].lstrip('*'))
+
+          expected_archive_names = {
+              name for name in required if name.endswith('.tar.gz')
+          }
+          missing_checksums = sorted(expected_archive_names - listed)
+          if missing_checksums:
+              names = ", ".join(missing_checksums)
+              sys.exit(f"missing checksums for: {names}")
+          PY2
+
+  publish-crate:
+    name: Publish to crates.io
+    needs: [check-tag, verify, verify-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check crates.io version
+        id: crate
+        env:
+          VERSION: ${{ needs.check-tag.outputs.version }}
+        run: |
+          URL="https://crates.io/api/v1/crates/whetstone-cli/${VERSION}"
+          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" "$URL")
+          if [ "$STATUS" = "200" ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} is already published"
+          elif [ "$STATUS" = "404" ]; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} is not published yet"
+          else
+            echo "Unexpected crates.io status: $STATUS"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.crate.outputs.needed == 'true'
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.crate.outputs.needed == 'true'
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.crate.outputs.needed == 'true'
 
       - name: Publish
+        if: steps.crate.outputs.needed == 'true'
         run: cargo publish --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,11 @@ Single binary distribution. Users run `whetstone setup` from inside a git projec
 | `cargo test` | Run all tests (11 tests) |
 | `cargo clippy` | Run lints |
 | `cargo fmt` | Format Rust code |
-| `just build` | Build release binary |
+| `just build` | Build debug binary |
 | `just test` | Run tests |
-| `just release <bump>` | Bump VERSION and optionally tag |
-| `just release-publish <bump>` | Bump, commit, tag, and push |
+| `just release-check` | Format check, tests, and lints for releases |
+| `just release <bump>` | Verify, bump version, and open a release PR |
+| `just release-publish <bump>` | Deprecated legacy path |
 <!-- AUTO-GENERATED: end -->
 
 ## CLI Reference
@@ -47,8 +48,8 @@ whetstone proxy [args...]
 whetstone rtk [args...]
 whetstone version
 whetstone update [--full]
-whetstone release patch|minor|major|set X.Y.Z [--tag]
-whetstone release-publish patch|minor|major|set X.Y.Z [--tag]
+whetstone release patch|minor|major|set X.Y.Z
+whetstone release-publish patch|minor|major|set X.Y.Z # Deprecated
 whetstone db init|add-session|add-insight|search|get-sessions|...
 ```
 <!-- AUTO-GENERATED: end -->
@@ -98,7 +99,7 @@ src/
 ├── uninstall.rs     # Interactive component removal
 ├── wrapper.rs       # claude/proxy/rtk exec wrappers
 ├── update.rs        # 12h-cached remote version check
-├── release.rs       # Version bump, tag, publish
+├── release.rs       # Release preflight, version bump, and PR creation
 ├── db.rs            # SQLite ops for session/memory database
 ├── memory.rs        # MemoryProvider enum (ICM, AutoMem, Skip)
 ├── hooks.rs         # Hook script copy + settings.json merge

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,262 @@
+# Releasing Whetstone
+
+This file describes:
+
+1. the supported release process today
+2. the safeguards built into it
+3. the remaining improvements worth considering
+
+## Short answer
+
+The supported release path is now:
+
+```text
+just release patch|minor|major|set X.Y.Z
+```
+
+That command verifies the repo, bumps version files, creates a release branch,
+pushes it, and opens a release PR.
+
+After that PR is merged into `main`, GitHub Actions:
+
+1. re-verifies format, clippy, and tests
+2. builds release artifacts
+3. packages bundled assets
+4. creates the git tag
+5. generates checksums
+6. creates the GitHub release
+7. verifies the GitHub release metadata
+8. publishes the crate to crates.io
+
+## Supported commands
+
+### `just release-check`
+
+Release verification gate:
+
+```text
+cargo fmt --check
+cargo test
+cargo clippy -- -D warnings
+```
+
+Use this when you want the local release gate without actually cutting a
+release PR.
+
+### `just release <bump>`
+
+The supported release entrypoint.
+
+Examples:
+
+```text
+just release patch
+just release minor
+just release set 2.2.0
+```
+
+This command depends on `release-check`, then runs:
+
+```text
+cargo run -- release <bump>
+```
+
+### `just release-publish <bump>`
+
+Deprecated legacy path.
+
+It is still present only so old habits fail loudly with guidance instead of
+silently doing the wrong thing. It no longer performs a release.
+
+## Current release flow
+
+## 1. Start from a correct local state
+
+`whetstone release` now enforces these preconditions before it edits version
+files:
+
+- working tree must be clean
+- current branch must be `main`
+- local `main` must match `origin/main`
+- `gh` must be installed and authenticated
+- target release branch and tag must not already exist locally or remotely
+
+This is implemented in `src/release.rs`.
+
+## 2. Run the release command
+
+Example:
+
+```text
+just release patch
+```
+
+That performs the local verification gate, then `whetstone release patch`:
+
+1. reads `VERSION`
+2. computes the next version
+3. updates `VERSION`
+4. syncs `Cargo.toml`
+5. creates branch `release/vX.Y.Z`
+6. commits `release: vX.Y.Z`
+7. pushes the branch
+8. opens a PR to `main`
+
+The PR body explicitly says that merging triggers the verified release
+workflow.
+
+## 3. Merge the release PR
+
+Merging the PR is the release boundary.
+
+There is now one intended automation path:
+
+```text
+release PR -> merge -> verified release workflow -> publish
+```
+
+## 4. Release workflow on `main`
+
+`.github/workflows/release.yml` runs only when `VERSION` changes on `main`.
+
+It now has these stages:
+
+### `check-tag`
+
+- reads `VERSION`
+- computes `vX.Y.Z`
+- enters recovery mode if the tag already exists
+
+### `verify`
+
+Runs the shared release gate before any tag or publish step:
+
+- installs `just`
+- runs `just release-check`
+
+This means publish no longer races ahead of verification.
+
+### `build`
+
+Builds binaries for:
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+- `x86_64-apple-darwin`
+- `aarch64-apple-darwin`
+
+### `assets`
+
+Packages `assets/` as `whetstone-assets.tar.gz`.
+
+### `release`
+
+- creates and pushes the tag
+- downloads artifacts
+- generates `SHA256SUMS.txt`
+- creates the GitHub release
+
+### `verify-release`
+
+Checks that the GitHub release:
+
+- exists for the expected tag
+- is not draft
+- is not prerelease
+- contains the expected target archives, assets tarball, and `SHA256SUMS.txt`
+- includes checksum entries for every published `.tar.gz` asset
+
+### `publish-crate`
+
+Only runs after the verification and GitHub release checks succeed.
+
+It publishes the crate with:
+
+```text
+cargo publish --allow-dirty
+```
+
+using `CARGO_REGISTRY_TOKEN` from GitHub secrets.
+
+## Why this is safer than before
+
+The old flow had multiple competing release paths and a release workflow that
+could publish without doing its own verification first.
+
+The current flow reduces that risk by:
+
+- making `just release ...` the only supported path
+- turning `release-publish` into a deprecated failure path
+- enforcing clean-tree and branch preconditions in Rust
+- adding `release-check` locally
+- reusing the shared `just release-check` gate in CI and release workflow
+- generating checksums automatically
+- verifying the GitHub release before publish
+
+## Things to watch during a release
+
+Even with the automation in place, a maintainer should still watch:
+
+1. the release PR
+2. CI on that PR
+3. the release workflow after merge
+4. the GitHub release page
+5. crates.io publish completion
+
+## Contributor checklist
+
+Use this checklist for normal releases:
+
+1. checkout `main`
+2. pull latest
+3. run `just release patch|minor|major|set X.Y.Z`
+4. review the generated release PR
+5. merge the PR
+6. watch the release workflow through publish
+
+If you only want to verify release readiness locally, run:
+
+```text
+just release-check
+```
+
+## Remaining improvements worth considering
+
+The release process is in much better shape now, but these are still worth
+considering later:
+
+### 1. Crates.io post-publish smoke check
+
+A small verification job could poll crates.io for the new version before the
+workflow reports success. I did not add this yet because crates.io propagation
+can be slightly delayed and make the workflow flaky.
+
+### 2. Artifact signing
+
+Checksums are now generated, but cryptographic signing would be stronger.
+
+### 3. Windows release artifacts
+
+The workflow currently builds Linux and macOS artifacts only. That matches the
+previous behavior, but if Windows binaries become important, add them here.
+
+### 4. Release notes curation
+
+The workflow currently uses autogenerated GitHub release notes. If release
+notes need more structure, add a changelog or a release notes template.
+
+## Files involved in releases
+
+- `justfile`
+- `src/release.rs`
+- `.github/workflows/release.yml`
+- `.github/workflows/ci.yml`
+- `VERSION`
+- `Cargo.toml`
+
+## Deprecated behavior
+
+Do not use `just release-publish ...` as a normal release flow.
+
+It is intentionally deprecated so this repo has one supported automated release
+path instead of several half-overlapping ones.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,8 +11,8 @@
 | `whetstone rtk [args...]` | Run RTK |
 | `whetstone version` | Print version |
 | `whetstone update [--full]` | Check for updates |
-| `whetstone release patch\|minor\|major\|set X.Y.Z [--tag]` | Bump VERSION |
-| `whetstone release-publish ...` | Bump, commit, tag, and push |
+| `whetstone release patch\|minor\|major\|set X.Y.Z` | Verify, bump version, and open a release PR |
+| `whetstone release-publish ...` | Deprecated legacy path |
 | `whetstone db <subcommand>` | Session database operations |
 
 ## Headroom Extras
@@ -38,8 +38,8 @@ whetstone update --full            # Force-upgrade Headroom/RTK
 For contributors:
 
 ```bash
-just release patch                 # Bump patch version
-just release-publish minor         # Bump, commit, tag, and push
+just release-check                # Release verification gate
+just release patch                 # Verify, bump version, and open release PR
 ```
 
 ## Headroom Proxy Flags

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,8 +4,7 @@
 
 | File | Owner | Purpose |
 |------|-------|---------|
-| `~/.claude/settings.json` | RTK + whetstone | All hooks (absolute paths to `~/.claude/hooks/`) |
-| `~/.claude/hooks/rtk-rewrite.sh` | RTK | Bash command rewriter |
+| `~/.claude/settings.json` | RTK + whetstone | All hooks, including whetstone's absolute `.../rtk hook claude` command |
 | `~/.claude/RTK.md` | RTK | RTK instructions for Claude Code context |
 | `~/.claude/CLAUDE.md` | Claude Code | Global instructions (references `@RTK.md`) |
 | `~/.headroom/models.json` | Headroom | Custom model context limits and pricing |

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -23,7 +23,7 @@ claude
 - Memory hooks fire on session start/end, commits, pushes
 - Memory skills activate on keyword triggers ("recall", "todo", "verify", etc.)
 
-**Hook configuration** lives in `~/.claude/settings.json` (global). All hooks — RTK and Memory — are installed to `~/.claude/hooks/` with absolute paths. Works in every project, every directory.
+**Hook configuration** lives in `~/.claude/settings.json` (global). RTK is registered there as an absolute `.../rtk hook claude` command, while whetstone's Memory scripts live under `~/.claude/hooks/`. Works in every project, every directory.
 
 **MCP tools** (optional, adds `headroom_compress`, `headroom_retrieve`, `headroom_stats`):
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,17 +31,17 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 ## RTK hook not rewriting commands
 
 ```bash
-# Check hook exists
-ls -la ~/.claude/hooks/rtk-rewrite.sh
-
-# Check settings.json has the hook
+# Check settings.json has the RTK Claude hook
 cat ~/.claude/settings.json | python3 -m json.tool
+# Look for a command ending in: rtk hook claude
 
-# Test rewrite manually
-echo '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | bash ~/.claude/hooks/rtk-rewrite.sh
+# Test the exact command from settings.json
+# Example:
+echo '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | /home/you/.local/bin/rtk hook claude
 
-# Re-initialize
-rtk init -g --hook-only --auto-patch
+# Reinstall whetstone's Claude hook configuration
+# Choose a memory provider other than Skip so hook setup runs.
+whetstone setup
 ```
 
 ## Headroom proxy not compressing

--- a/justfile
+++ b/justfile
@@ -27,8 +27,15 @@ lint:
 fmt:
     cargo fmt
 
+# Check formatting without modifying files
+fmt-check:
+    cargo fmt --check
+
 # Build, test, and lint in one shot
 check: build test lint
+
+# Release verification gate
+release-check: fmt-check test lint
 
 # Run whetstone setup (uses cargo run)
 setup *ARGS:
@@ -39,9 +46,9 @@ uninstall:
     cargo run -- uninstall
 
 # Bump version, push release branch, and open PR: just release patch|minor|major
-release *ARGS: check
+release *ARGS: release-check
     cargo run -- release {{ARGS}}
 
-# Bump, commit, tag, and push release in one command (runs check first)
-release-publish *ARGS: check
+# Deprecated legacy path kept for compatibility
+release-publish *ARGS:
     cargo run -- release-publish {{ARGS}}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,7 +19,8 @@ pub enum Command {
         #[arg(long)]
         full: bool,
 
-        /// Headroom pip extras: "all" (default), "none", or comma-separated like "proxy,code"
+        /// Headroom pip extras: "all" (default), "none", or
+        /// comma-separated like "proxy,code"
         #[arg(long, default_value = "all")]
         headroom_extras: String,
     },
@@ -60,13 +61,13 @@ pub enum Command {
         full: bool,
     },
 
-    /// Bump VERSION file
+    /// Prepare a release PR; GitHub Actions publishes after merge
     Release {
         #[command(subcommand)]
         action: ReleaseAction,
     },
 
-    /// Release, commit, tag, and push
+    /// Deprecated legacy release path
     ReleasePublish {
         #[command(subcommand)]
         action: ReleaseAction,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,11 +1,22 @@
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::memory::MemoryProvider;
 use crate::ui;
+
+const RTK_HOOK_ARGS: [&str; 2] = ["hook", "claude"];
+const LEGACY_RTK_REWRITE_SCRIPT: &str = "rtk-rewrite.sh";
+const MANAGED_HOOK_SCRIPTS: [&str; 6] = [
+    LEGACY_RTK_REWRITE_SCRIPT,
+    "pre-tool-notify.sh",
+    "pre-push.sh",
+    "post-commit.sh",
+    "session-start.sh",
+    "session-end.sh",
+];
 
 pub fn copy_hook_scripts(assets_hooks: &Path, dest_hooks: &Path) -> Result<()> {
     fs::create_dir_all(dest_hooks).with_context(|| format!("creating {}", dest_hooks.display()))?;
@@ -63,7 +74,8 @@ pub fn merge_settings_json(
     };
 
     let hd = hooks_dir.display().to_string();
-    let merged = build_hooks_value(&existing, &hd, provider);
+    let rtk_command = rtk_claude_hook_command();
+    let merged = build_hooks_value(&existing, &hd, provider, &rtk_command);
 
     let json_str = serde_json::to_string_pretty(&merged).context("serializing settings.json")?;
 
@@ -77,7 +89,12 @@ pub fn merge_settings_json(
     Ok(())
 }
 
-fn build_hooks_value(existing: &Value, hd: &str, provider: MemoryProvider) -> Value {
+fn build_hooks_value(
+    existing: &Value,
+    hd: &str,
+    provider: MemoryProvider,
+    rtk_command: &str,
+) -> Value {
     let mut result = existing.clone();
 
     let whetstone_hooks: Vec<(&str, Vec<Value>)> = vec![
@@ -86,17 +103,28 @@ fn build_hooks_value(existing: &Value, hd: &str, provider: MemoryProvider) -> Va
             vec![
                 json!({
                     "matcher": "Bash",
-                    "hooks": [{"type": "command", "command": format!("{hd}/rtk-rewrite.sh")}]
+                    "hooks": [{
+                        "type": "command",
+                        "command": rtk_command,
+                    }]
                 }),
                 json!({
                     "matcher": "Write|Edit|MultiEdit|Bash",
-                    "hooks": [{"type": "command", "command": format!("{hd}/pre-tool-notify.sh"), "timeout": 10000}]
+                    "hooks": [{
+                        "type": "command",
+                        "command": format!("{hd}/pre-tool-notify.sh"),
+                        "timeout": 10000,
+                    }]
                 }),
                 json!({
                     "matcher": "Bash",
-                    "hooks": [{"type": "command",
-                        "command": format!("bash -c 'echo \"$CLAUDE_TOOL_INPUT\" | grep -q \"git push\" && {hd}/pre-push.sh || exit 0'"),
-                        "timeout": 60000}]
+                    "hooks": [{
+                        "type": "command",
+                        "command": format!(
+                            "bash -c 'echo \"$CLAUDE_TOOL_INPUT\" | grep -q \"git push\" && {hd}/pre-push.sh || exit 0'"
+                        ),
+                        "timeout": 60000,
+                    }]
                 }),
             ],
         ),
@@ -104,21 +132,33 @@ fn build_hooks_value(existing: &Value, hd: &str, provider: MemoryProvider) -> Va
             "PostToolUse",
             vec![json!({
                 "matcher": "Bash",
-                "hooks": [{"type": "command",
-                    "command": format!("bash -c 'echo \"$CLAUDE_TOOL_INPUT\" | grep -q \"git commit\" && {hd}/post-commit.sh || exit 0'"),
-                    "timeout": 10000}]
+                "hooks": [{
+                    "type": "command",
+                    "command": format!(
+                        "bash -c 'echo \"$CLAUDE_TOOL_INPUT\" | grep -q \"git commit\" && {hd}/post-commit.sh || exit 0'"
+                    ),
+                    "timeout": 10000,
+                }]
             })],
         ),
         (
             "SessionStart",
             vec![json!({
-                "hooks": [{"type": "command", "command": format!("{hd}/session-start.sh"), "timeout": 10000}]
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("{hd}/session-start.sh"),
+                    "timeout": 10000,
+                }]
             })],
         ),
         (
             "Stop",
             vec![json!({
-                "hooks": [{"type": "command", "command": format!("{hd}/session-end.sh"), "timeout": 10000}]
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("{hd}/session-end.sh"),
+                    "timeout": 10000,
+                }]
             })],
         ),
     ];
@@ -132,7 +172,7 @@ fn build_hooks_value(existing: &Value, hd: &str, provider: MemoryProvider) -> Va
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter(|entry| !entry_references_dir(entry, hd))
+                    .filter(|entry| !entry_is_whetstone_managed(entry, hd, rtk_command))
                     .cloned()
                     .collect()
             })
@@ -157,26 +197,102 @@ fn build_hooks_value(existing: &Value, hd: &str, provider: MemoryProvider) -> Va
         }
         result["mcpServers"]["memory"] = json!({
             "command": "npx",
-            "args": ["-y", "@verygoodplugins/mcp-automem"]
+            "args": ["-y", "@verygoodplugins/mcp-automem"],
         });
     }
 
     result
 }
 
-fn entry_references_dir(entry: &Value, dir: &str) -> bool {
-    let s = entry.to_string();
-    s.contains(dir)
+fn rtk_claude_hook_command() -> String {
+    let binary = resolve_rtk_binary();
+    let program = shell_escape_program(&binary.display().to_string());
+    format!("{program} {} {}", RTK_HOOK_ARGS[0], RTK_HOOK_ARGS[1])
+}
+
+fn resolve_rtk_binary() -> PathBuf {
+    which::which(rtk_binary_name()).unwrap_or_else(|_| {
+        dirs::home_dir()
+            .map(|home| home.join(".local/bin").join(rtk_binary_name()))
+            .unwrap_or_else(|| PathBuf::from(rtk_binary_name()))
+    })
+}
+
+fn rtk_binary_name() -> &'static str {
+    if cfg!(windows) {
+        "rtk.exe"
+    } else {
+        "rtk"
+    }
+}
+
+fn entry_is_whetstone_managed(entry: &Value, dir: &str, rtk_command: &str) -> bool {
+    entry_is_whetstone_rtk_hook(entry, rtk_command) || entry_references_managed_script(entry, dir)
+}
+
+fn entry_is_whetstone_rtk_hook(entry: &Value, _rtk_command: &str) -> bool {
+    let hooks = entry.get("hooks").and_then(Value::as_array);
+
+    entry.get("matcher").and_then(Value::as_str) == Some("Bash")
+        && hooks.is_some_and(|hooks| {
+            hooks.len() == 1 && hook_command(&hooks[0]).is_some_and(is_rtk_claude_hook_command)
+        })
+}
+
+fn entry_references_managed_script(entry: &Value, dir: &str) -> bool {
+    let text = entry.to_string();
+    MANAGED_HOOK_SCRIPTS
+        .iter()
+        .any(|name| text.contains(&format!("{dir}/{name}")))
+}
+
+fn hook_command(hook: &Value) -> Option<&str> {
+    if hook.get("type").and_then(Value::as_str) != Some("command") {
+        return None;
+    }
+
+    hook.get("command").and_then(Value::as_str)
+}
+
+fn is_rtk_claude_hook_command(command: &str) -> bool {
+    rtk_hook_program(command).is_some_and(program_ends_with_rtk)
+}
+
+fn rtk_hook_program(command: &str) -> Option<&str> {
+    let program = command.strip_suffix(" hook claude")?.trim();
+    Some(program.trim_matches('"'))
+}
+
+fn program_ends_with_rtk(program: &str) -> bool {
+    let path = Path::new(program);
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == rtk_binary_name())
+}
+
+fn shell_escape_program(program: &str) -> String {
+    if program.contains([' ', '\t']) {
+        format!("\"{}\"", program.replace('\\', "\\\\").replace('"', "\\\""))
+    } else {
+        program.to_string()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const TEST_RTK_COMMAND: &str = "/home/user/.local/bin/rtk hook claude";
+
     #[test]
     fn merge_into_empty_settings() {
         let existing = json!({});
-        let result = build_hooks_value(&existing, "/home/user/.claude/hooks", MemoryProvider::Skip);
+        let result = build_hooks_value(
+            &existing,
+            "/home/user/.claude/hooks",
+            MemoryProvider::Skip,
+            TEST_RTK_COMMAND,
+        );
 
         let hooks = &result["hooks"];
         assert!(hooks["PreToolUse"].is_array());
@@ -192,7 +308,12 @@ mod tests {
             "apiKey": "sk-test",
             "model": "claude-opus-4-6"
         });
-        let result = build_hooks_value(&existing, "/tmp/hooks", MemoryProvider::Icm);
+        let result = build_hooks_value(
+            &existing,
+            "/tmp/hooks",
+            MemoryProvider::Icm,
+            TEST_RTK_COMMAND,
+        );
 
         assert_eq!(result["apiKey"], "sk-test");
         assert_eq!(result["model"], "claude-opus-4-6");
@@ -200,15 +321,119 @@ mod tests {
     }
 
     #[test]
-    fn hooks_use_absolute_paths() {
-        let result =
-            build_hooks_value(&json!({}), "/home/user/.claude/hooks", MemoryProvider::Skip);
+    fn hooks_use_absolute_rtk_claude_command() {
+        let result = build_hooks_value(
+            &json!({}),
+            "/home/user/.claude/hooks",
+            MemoryProvider::Skip,
+            TEST_RTK_COMMAND,
+        );
 
         let rtk_cmd = result["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
             .as_str()
             .unwrap();
-        assert!(rtk_cmd.starts_with("/home/user/.claude/hooks/"));
-        assert!(rtk_cmd.ends_with("rtk-rewrite.sh"));
+        assert_eq!(rtk_cmd, TEST_RTK_COMMAND);
+    }
+
+    #[test]
+    fn whetstone_script_hooks_use_absolute_paths() {
+        let result = build_hooks_value(
+            &json!({}),
+            "/home/user/.claude/hooks",
+            MemoryProvider::Skip,
+            TEST_RTK_COMMAND,
+        );
+
+        let notify_cmd = result["hooks"]["PreToolUse"][1]["hooks"][0]["command"]
+            .as_str()
+            .unwrap();
+        assert!(notify_cmd.starts_with("/home/user/.claude/hooks/"));
+        assert!(notify_cmd.ends_with("pre-tool-notify.sh"));
+    }
+
+    #[test]
+    fn merge_replaces_existing_rtk_hook_command() {
+        let existing = json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/tmp/old-rtk/bin/rtk hook claude",
+                    }]
+                }]
+            }
+        });
+        let result = build_hooks_value(
+            &existing,
+            "/home/user/.claude/hooks",
+            MemoryProvider::Skip,
+            TEST_RTK_COMMAND,
+        );
+
+        let pre = result["hooks"]["PreToolUse"].as_array().unwrap();
+        let rtk_count = pre
+            .iter()
+            .filter(|entry| entry.to_string().contains(TEST_RTK_COMMAND))
+            .count();
+        assert_eq!(rtk_count, 1);
+    }
+
+    #[test]
+    fn merge_removes_legacy_rtk_rewrite_entry() {
+        let existing = json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/home/user/.claude/hooks/rtk-rewrite.sh",
+                    }]
+                }]
+            }
+        });
+        let result = build_hooks_value(
+            &existing,
+            "/home/user/.claude/hooks",
+            MemoryProvider::Skip,
+            TEST_RTK_COMMAND,
+        );
+
+        let pre = result["hooks"]["PreToolUse"].as_array().unwrap();
+        assert!(pre
+            .iter()
+            .all(|entry| { !entry.to_string().contains(LEGACY_RTK_REWRITE_SCRIPT) }));
+        assert!(pre
+            .iter()
+            .any(|entry| { entry.to_string().contains(TEST_RTK_COMMAND) }));
+    }
+
+    #[test]
+    fn merge_preserves_custom_hook_in_claude_hooks_dir() {
+        let existing = json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/home/user/.claude/hooks/custom.sh",
+                    }]
+                }]
+            }
+        });
+        let result = build_hooks_value(
+            &existing,
+            "/home/user/.claude/hooks",
+            MemoryProvider::Skip,
+            TEST_RTK_COMMAND,
+        );
+
+        let pre = result["hooks"]["PreToolUse"].as_array().unwrap();
+        assert!(pre.iter().any(|entry| {
+            entry
+                .to_string()
+                .contains("/home/user/.claude/hooks/custom.sh")
+        }));
     }
 
     #[test]
@@ -217,18 +442,29 @@ mod tests {
             "hooks": {
                 "PreToolUse": [{
                     "matcher": "Bash",
-                    "hooks": [{"type": "command", "command": "/usr/local/bin/icm hook pre"}]
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/usr/local/bin/icm hook pre"
+                    }]
                 }],
                 "PreCompact": [{
-                    "hooks": [{"type": "command", "command": "/usr/local/bin/icm hook compact"}]
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/usr/local/bin/icm hook compact"
+                    }]
                 }]
             }
         });
-        let result = build_hooks_value(&existing, "/home/user/.claude/hooks", MemoryProvider::Icm);
+        let result = build_hooks_value(
+            &existing,
+            "/home/user/.claude/hooks",
+            MemoryProvider::Icm,
+            TEST_RTK_COMMAND,
+        );
 
         let pre = result["hooks"]["PreToolUse"].as_array().unwrap();
         assert!(pre.iter().any(|e| e.to_string().contains("icm hook pre")));
-        assert!(pre.iter().any(|e| e.to_string().contains("rtk-rewrite")));
+        assert!(pre.iter().any(|e| e.to_string().contains(TEST_RTK_COMMAND)));
 
         assert!(result["hooks"]["PreCompact"].is_array());
     }
@@ -239,6 +475,7 @@ mod tests {
             &json!({}),
             "/home/user/.claude/hooks",
             MemoryProvider::AutoMem,
+            TEST_RTK_COMMAND,
         );
 
         assert!(result["mcpServers"]["memory"].is_object());
@@ -247,8 +484,12 @@ mod tests {
 
     #[test]
     fn skip_provider_no_mcp_servers() {
-        let result =
-            build_hooks_value(&json!({}), "/home/user/.claude/hooks", MemoryProvider::Skip);
+        let result = build_hooks_value(
+            &json!({}),
+            "/home/user/.claude/hooks",
+            MemoryProvider::Skip,
+            TEST_RTK_COMMAND,
+        );
 
         assert!(result.get("mcpServers").is_none());
     }

--- a/src/release.rs
+++ b/src/release.rs
@@ -1,10 +1,13 @@
 use anyhow::{bail, Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::cli::ReleaseAction;
 use crate::ui;
 use crate::version::{self, BumpKind};
+use semver::Version;
+
+type SemverResult = Result<semver::Version>;
 
 fn repo_root() -> Result<PathBuf> {
     let output = Command::new("git")
@@ -27,12 +30,14 @@ fn version_file() -> Result<PathBuf> {
     bail!("VERSION file not found");
 }
 
-fn sync_cargo_toml(root: &std::path::Path, new_ver: &semver::Version) -> Result<()> {
+fn sync_cargo_toml(root: &Path, new_ver: &Version) -> Result<()> {
     let cargo_path = root.join("Cargo.toml");
     if !cargo_path.exists() {
         return Ok(());
     }
-    let content = std::fs::read_to_string(&cargo_path).context("reading Cargo.toml")?;
+
+    let content = std::fs::read_to_string(&cargo_path);
+    let content = content.context("reading Cargo.toml")?;
     let mut in_package = false;
     let mut replaced = false;
     let new_content: String = content
@@ -43,22 +48,31 @@ fn sync_cargo_toml(root: &std::path::Path, new_ver: &semver::Version) -> Result<
             } else if line.starts_with('[') {
                 in_package = false;
             }
-            if in_package && !replaced && line.trim_start().starts_with("version") {
+
+            let is_version_line = line.trim_start().starts_with("version");
+            if in_package && !replaced && is_version_line {
                 if let Some(eq_pos) = line.find('=') {
                     replaced = true;
                     return format!("{}= \"{new_ver}\"", &line[..eq_pos]);
                 }
             }
+
             line.to_string()
         })
         .collect::<Vec<_>>()
         .join("\n");
-    let new_content = if content.ends_with('\n') && !new_content.ends_with('\n') {
+
+    let content_has_newline = content.ends_with('\n');
+    let output_has_newline = new_content.ends_with('\n');
+    let needs_trailing_newline = content_has_newline && !output_has_newline;
+    let new_content = if needs_trailing_newline {
         format!("{new_content}\n")
     } else {
         new_content
     };
-    std::fs::write(&cargo_path, new_content).context("writing Cargo.toml")?;
+
+    let write = std::fs::write(&cargo_path, new_content);
+    write.context("writing Cargo.toml")?;
     Ok(())
 }
 
@@ -71,24 +85,31 @@ fn action_to_bump(action: &ReleaseAction) -> (Option<BumpKind>, Option<&str>) {
     }
 }
 
-fn bump_version(action: &ReleaseAction) -> Result<semver::Version> {
-    let root = repo_root()?;
-    let path = version_file()?;
-    let current = version::read_from_file(&path)?;
+fn next_version(current: &Version, action: &ReleaseAction) -> SemverResult {
     let (bump_kind, explicit) = action_to_bump(action);
 
     let new_ver = if let Some(kind) = bump_kind {
-        version::bump(&current, kind)
+        version::bump(current, kind)
     } else {
         let raw = explicit.context("set requires a version string")?;
-        let sem = version::extract_semver(raw).context("invalid semver in provided version")?;
+        let sem = version::extract_semver(raw);
+        let sem = sem.context("invalid semver in provided version")?;
         semver::Version::parse(&sem)?
     };
 
-    version::write_to_file(&path, &new_ver)?;
-    sync_cargo_toml(&root, &new_ver)?;
-    ui::ok(&format!("VERSION: {current} -> {new_ver}"));
     Ok(new_ver)
+}
+
+fn write_version_files(
+    root: &Path,
+    version_path: &Path,
+    current: &Version,
+    new_ver: &Version,
+) -> Result<()> {
+    version::write_to_file(version_path, new_ver)?;
+    sync_cargo_toml(root, new_ver)?;
+    ui::ok(&format!("VERSION: {current} -> {new_ver}"));
+    Ok(())
 }
 
 fn git_cmd(args: &[&str]) -> Result<()> {
@@ -102,10 +123,120 @@ fn git_cmd(args: &[&str]) -> Result<()> {
     Ok(())
 }
 
+fn git_output(args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .with_context(|| format!("git {}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!("git {} failed: {stderr}", args.join(" "));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn ensure_clean_working_tree() -> Result<()> {
+    let dirty = git_output(&["status", "--porcelain"])?;
+    if !dirty.is_empty() {
+        bail!("working tree is not clean - commit or stash first");
+    }
+    Ok(())
+}
+
+fn current_branch() -> Result<String> {
+    git_output(&["rev-parse", "--abbrev-ref", "HEAD"])
+}
+
+fn ensure_on_main() -> Result<()> {
+    let branch = current_branch()?;
+    if branch != "main" {
+        bail!("release must start from main (current: {branch})");
+    }
+    Ok(())
+}
+
+fn ensure_main_in_sync_with_origin() -> Result<()> {
+    git_cmd(&["fetch", "origin", "main", "--tags"])?;
+
+    let head = git_output(&["rev-parse", "HEAD"])?;
+    let remote = git_output(&["rev-parse", "refs/remotes/origin/main"])?;
+
+    if head != remote {
+        bail!("local main is not up to date with origin/main");
+    }
+    Ok(())
+}
+
+fn ensure_gh_available() -> Result<()> {
+    let status = Command::new("gh")
+        .arg("--version")
+        .status()
+        .context("checking gh availability")?;
+    if !status.success() {
+        bail!("gh CLI is required to open the release PR");
+    }
+
+    let auth = Command::new("gh")
+        .args(["auth", "status"])
+        .status()
+        .context("checking gh authentication")?;
+    if !auth.success() {
+        bail!("gh CLI is not authenticated; run `gh auth login`");
+    }
+    Ok(())
+}
+
+fn ensure_ref_does_not_exist(ref_name: &str) -> Result<()> {
+    let status = Command::new("git")
+        .args(["show-ref", "--verify", "--quiet", ref_name])
+        .status()
+        .with_context(|| format!("checking {ref_name}"))?;
+    if status.success() {
+        bail!("git ref already exists: {ref_name}");
+    }
+    Ok(())
+}
+
+fn ensure_remote_ref_does_not_exist(kind: &str, name: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["ls-remote", "--exit-code", kind, "origin", name])
+        .output()
+        .with_context(|| format!("checking remote {kind} {name}"))?;
+
+    if output.status.success() {
+        bail!("remote git ref already exists: {name}");
+    }
+    Ok(())
+}
+
+fn ensure_release_refs_available(tag: &str, branch: &str) -> Result<()> {
+    ensure_ref_does_not_exist(&format!("refs/tags/{tag}"))?;
+    ensure_ref_does_not_exist(&format!("refs/heads/{branch}"))?;
+    ensure_remote_ref_does_not_exist("--tags", tag)?;
+    ensure_remote_ref_does_not_exist("--heads", branch)?;
+    Ok(())
+}
+
+fn ensure_release_preconditions() -> Result<()> {
+    ensure_clean_working_tree()?;
+    ensure_on_main()?;
+    ensure_main_in_sync_with_origin()?;
+    ensure_gh_available()?;
+    Ok(())
+}
+
 pub fn run(action: &ReleaseAction) -> Result<()> {
-    let new_ver = bump_version(action)?;
+    ensure_release_preconditions()?;
+
+    let root = repo_root()?;
+    let version_path = version_file()?;
+    let current = version::read_from_file(&version_path)?;
+    let new_ver = next_version(&current, action)?;
     let tag = format!("v{new_ver}");
     let branch = format!("release/{tag}");
+
+    ensure_release_refs_available(&tag, &branch)?;
+    write_version_files(&root, &version_path, &current, &new_ver)?;
 
     git_cmd(&["checkout", "-b", &branch])?;
     git_cmd(&["add", "VERSION", "Cargo.toml"])?;
@@ -114,7 +245,10 @@ pub fn run(action: &ReleaseAction) -> Result<()> {
     git_cmd(&["commit", "-m", &msg])?;
     git_cmd(&["push", "-u", "origin", &branch])?;
 
-    let pr_body = format!("Bump version to {new_ver}.\n\nMerging triggers the release workflow.");
+    let pr_body = format!(
+        "Bump version to {new_ver}.\n\n{}",
+        "Merging triggers the verified release workflow.",
+    );
     let pr = Command::new("gh")
         .args([
             "pr",
@@ -140,25 +274,10 @@ pub fn run(action: &ReleaseAction) -> Result<()> {
     Ok(())
 }
 
-pub fn run_publish(action: &ReleaseAction) -> Result<()> {
-    let porcelain = Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .context("running git status")?;
-    let dirty = String::from_utf8_lossy(&porcelain.stdout);
-    if !dirty.trim().is_empty() {
-        bail!("working tree is not clean — commit or stash first");
-    }
-
-    let new_ver = bump_version(action)?;
-    let tag = format!("v{new_ver}");
-
-    git_cmd(&["add", "VERSION", "Cargo.toml"])?;
-    git_cmd(&["commit", "-m", &format!("release: {tag}")])?;
-    git_cmd(&["tag", &tag])?;
-    git_cmd(&["push", "origin", "HEAD"])?;
-    git_cmd(&["push", "origin", &tag])?;
-
-    ui::ok(&format!("published release {tag}"));
-    Ok(())
+pub fn run_publish(_action: &ReleaseAction) -> Result<()> {
+    bail!(concat!(
+        "release-publish is deprecated; use `just release <bump>` ",
+        "and merge the generated PR so GitHub Actions tags, releases, ",
+        "and publishes"
+    ))
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -195,51 +195,15 @@ fn exec(program: &str, args: &[String]) -> ! {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
     }
 
-    #[test]
-    fn build_claude_args_adds_model_and_skips_rtk_when_ready() {
-        let args = build_claude_args(&[], true);
-
-        assert_eq!(
-            args,
-            strings(&["wrap", "claude", "--no-rtk", "--model", DEFAULT_MODEL,])
-        );
-    }
-
-    #[test]
-    fn build_claude_args_preserves_explicit_model() {
-        let args = build_claude_args(&["--model".into(), "claude-sonnet".into()], false);
-
-        assert_eq!(
-            args,
-            strings(&["wrap", "claude", "--model", "claude-sonnet"])
-        );
-    }
-
-    #[test]
-    fn settings_hook_detection_matches_headroom_hook() {
-        let settings = json!({
-            "hooks": {
-                "PreToolUse": [{
-                    "matcher": "Bash",
-                    "hooks": [{
-                        "type": "command",
-                        "command": "rtk hook claude"
-                    }]
-                }]
-            }
-        });
-
-        assert!(settings_has_headroom_rtk_hook(&settings));
-    }
-
-    #[test]
-    fn settings_hook_detection_matches_absolute_rtk_hook_path() {
+    fn create_fake_rtk_binary() -> (PathBuf, PathBuf) {
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -264,6 +228,86 @@ exit 0
             fs::set_permissions(&binary, perms).unwrap();
         }
 
+        (dir, binary)
+    }
+
+    fn cleanup_fake_rtk(dir: &Path, binary: &Path) {
+        let _ = fs::remove_file(binary);
+        let _ = fs::remove_dir(dir);
+    }
+
+    fn with_temp_path(path: &Path, f: impl FnOnce()) {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let old_path = std::env::var_os("PATH");
+        let mut paths = vec![path.to_path_buf()];
+
+        if let Some(existing) = old_path.clone() {
+            paths.extend(std::env::split_paths(&existing));
+        }
+
+        let joined = std::env::join_paths(paths).unwrap();
+        unsafe {
+            std::env::set_var("PATH", &joined);
+        }
+
+        f();
+
+        match old_path {
+            Some(value) => unsafe {
+                std::env::set_var("PATH", value);
+            },
+            None => unsafe {
+                std::env::remove_var("PATH");
+            },
+        }
+    }
+
+    #[test]
+    fn build_claude_args_adds_model_and_skips_rtk_when_ready() {
+        let args = build_claude_args(&[], true);
+
+        assert_eq!(
+            args,
+            strings(&["wrap", "claude", "--no-rtk", "--model", DEFAULT_MODEL,])
+        );
+    }
+
+    #[test]
+    fn build_claude_args_preserves_explicit_model() {
+        let args = build_claude_args(&["--model".into(), "claude-sonnet".into()], false);
+
+        assert_eq!(
+            args,
+            strings(&["wrap", "claude", "--model", "claude-sonnet"])
+        );
+    }
+
+    #[test]
+    fn settings_hook_detection_matches_headroom_hook() {
+        let (dir, binary) = create_fake_rtk_binary();
+        let settings = json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "rtk hook claude"
+                    }]
+                }]
+            }
+        });
+
+        with_temp_path(&dir, || {
+            assert!(settings_has_headroom_rtk_hook(&settings));
+        });
+        cleanup_fake_rtk(&dir, &binary);
+    }
+
+    #[test]
+    fn settings_hook_detection_matches_absolute_rtk_hook_path() {
+        let (dir, binary) = create_fake_rtk_binary();
         let settings = json!({
             "hooks": {
                 "PreToolUse": [{
@@ -277,8 +321,7 @@ exit 0
         });
 
         assert!(settings_has_headroom_rtk_hook(&settings));
-        let _ = fs::remove_file(&binary);
-        let _ = fs::remove_dir(&dir);
+        cleanup_fake_rtk(&dir, &binary);
     }
 
     #[test]
@@ -317,32 +360,9 @@ exit 0
 
     #[test]
     fn path_detection_finds_executable_rtk() {
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("whetstone-rtk-{stamp}"));
-        fs::create_dir_all(&dir).unwrap();
-        let binary = dir.join(rtk_binary_name());
-        fs::write(
-            &binary,
-            "#!/bin/sh
-exit 0
-",
-        )
-        .unwrap();
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut perms = fs::metadata(&binary).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&binary, perms).unwrap();
-        }
+        let (dir, binary) = create_fake_rtk_binary();
 
         assert!(path_has_rtk_binary(dir.clone()));
-        let _ = fs::remove_file(&binary);
-        let _ = fs::remove_dir(&dir);
+        cleanup_fake_rtk(&dir, &binary);
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -47,12 +48,12 @@ fn should_skip_headroom_rtk_setup() -> bool {
     global_headroom_rtk_hook_exists()
 }
 
-fn rtk_exists_on_path() -> bool {
-    let Some(path_var) = env::var_os("PATH") else {
+fn rtk_exists_on_path(path_var: Option<&OsStr>) -> bool {
+    let Some(path_var) = path_var else {
         return false;
     };
 
-    env::split_paths(&path_var).any(path_has_rtk_binary)
+    env::split_paths(path_var).any(path_has_rtk_binary)
 }
 
 fn path_has_rtk_binary(dir: PathBuf) -> bool {
@@ -84,19 +85,31 @@ fn global_headroom_rtk_hook_exists() -> bool {
 }
 
 fn settings_has_headroom_rtk_hook(settings: &Value) -> bool {
+    settings_has_headroom_rtk_hook_for(settings, env::var_os("PATH").as_deref())
+}
+
+fn settings_has_headroom_rtk_hook_for(settings: &Value, path_var: Option<&OsStr>) -> bool {
     settings
         .get("hooks")
         .and_then(|hooks| hooks.get("PreToolUse"))
         .and_then(Value::as_array)
-        .is_some_and(|entries| entries.iter().any(entry_has_headroom_rtk_hook))
+        .is_some_and(|entries| {
+            entries
+                .iter()
+                .any(|entry| entry_has_headroom_rtk_hook(entry, path_var))
+        })
 }
 
-fn entry_has_headroom_rtk_hook(entry: &Value) -> bool {
+fn entry_has_headroom_rtk_hook(entry: &Value, path_var: Option<&OsStr>) -> bool {
     matcher_allows_bash(entry)
         && entry
             .get("hooks")
             .and_then(Value::as_array)
-            .is_some_and(|hooks| hooks.iter().any(command_is_headroom_rtk_hook))
+            .is_some_and(|hooks| {
+                hooks
+                    .iter()
+                    .any(|hook| command_is_headroom_rtk_hook(hook, path_var))
+            })
 }
 
 fn matcher_allows_bash(entry: &Value) -> bool {
@@ -106,15 +119,15 @@ fn matcher_allows_bash(entry: &Value) -> bool {
         .is_some_and(|matcher| matcher.contains("Bash"))
 }
 
-fn command_is_headroom_rtk_hook(hook: &Value) -> bool {
+fn command_is_headroom_rtk_hook(hook: &Value, path_var: Option<&OsStr>) -> bool {
     hook.get("type").and_then(Value::as_str) == Some("command")
         && hook
             .get("command")
             .and_then(Value::as_str)
-            .is_some_and(rtk_hook_command_is_usable)
+            .is_some_and(|command| rtk_hook_command_is_usable(command, path_var))
 }
 
-fn rtk_hook_command_is_usable(command: &str) -> bool {
+fn rtk_hook_command_is_usable(command: &str, path_var: Option<&OsStr>) -> bool {
     let Some(program) = rtk_hook_program(command) else {
         return false;
     };
@@ -124,7 +137,7 @@ fn rtk_hook_command_is_usable(command: &str) -> bool {
     }
 
     if is_bare_rtk_program(program) {
-        return rtk_exists_on_path();
+        return rtk_exists_on_path(path_var);
     }
 
     let path = Path::new(program);
@@ -196,7 +209,6 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::path::{Path, PathBuf};
-    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn strings(values: &[&str]) -> Vec<String> {
@@ -236,34 +248,6 @@ exit 0
         let _ = fs::remove_dir(dir);
     }
 
-    fn with_temp_path(path: &Path, f: impl FnOnce()) {
-        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-        let old_path = std::env::var_os("PATH");
-        let mut paths = vec![path.to_path_buf()];
-
-        if let Some(existing) = old_path.clone() {
-            paths.extend(std::env::split_paths(&existing));
-        }
-
-        let joined = std::env::join_paths(paths).unwrap();
-        unsafe {
-            std::env::set_var("PATH", &joined);
-        }
-
-        f();
-
-        match old_path {
-            Some(value) => unsafe {
-                std::env::set_var("PATH", value);
-            },
-            None => unsafe {
-                std::env::remove_var("PATH");
-            },
-        }
-    }
-
     #[test]
     fn build_claude_args_adds_model_and_skips_rtk_when_ready() {
         let args = build_claude_args(&[], true);
@@ -299,9 +283,10 @@ exit 0
             }
         });
 
-        with_temp_path(&dir, || {
-            assert!(settings_has_headroom_rtk_hook(&settings));
-        });
+        assert!(settings_has_headroom_rtk_hook_for(
+            &settings,
+            Some(dir.as_os_str()),
+        ));
         cleanup_fake_rtk(&dir, &binary);
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -44,7 +44,7 @@ fn build_claude_args(args: &[String], skip_rtk_setup: bool) -> Vec<String> {
 }
 
 fn should_skip_headroom_rtk_setup() -> bool {
-    rtk_exists_on_path() && global_headroom_rtk_hook_exists()
+    global_headroom_rtk_hook_exists()
 }
 
 fn rtk_exists_on_path() -> bool {
@@ -108,7 +108,43 @@ fn matcher_allows_bash(entry: &Value) -> bool {
 
 fn command_is_headroom_rtk_hook(hook: &Value) -> bool {
     hook.get("type").and_then(Value::as_str) == Some("command")
-        && hook.get("command").and_then(Value::as_str) == Some("rtk hook claude")
+        && hook
+            .get("command")
+            .and_then(Value::as_str)
+            .is_some_and(rtk_hook_command_is_usable)
+}
+
+fn rtk_hook_command_is_usable(command: &str) -> bool {
+    let Some(program) = rtk_hook_program(command) else {
+        return false;
+    };
+
+    if !program_ends_with_rtk(program) {
+        return false;
+    }
+
+    if is_bare_rtk_program(program) {
+        return rtk_exists_on_path();
+    }
+
+    let path = Path::new(program);
+    path.is_file() && path_is_executable(path)
+}
+
+fn rtk_hook_program(command: &str) -> Option<&str> {
+    let program = command.strip_suffix(" hook claude")?.trim();
+    Some(program.trim_matches('"'))
+}
+
+fn program_ends_with_rtk(program: &str) -> bool {
+    let path = Path::new(program);
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == rtk_binary_name())
+}
+
+fn is_bare_rtk_program(program: &str) -> bool {
+    program == rtk_binary_name()
 }
 
 #[cfg(unix)]
@@ -203,7 +239,67 @@ mod tests {
     }
 
     #[test]
-    fn settings_hook_detection_rejects_non_headroom_hook() {
+    fn settings_hook_detection_matches_absolute_rtk_hook_path() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("whetstone-rtk-{stamp}"));
+        fs::create_dir_all(&dir).unwrap();
+        let binary = dir.join(rtk_binary_name());
+        fs::write(
+            &binary,
+            "#!/bin/sh
+exit 0
+",
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut perms = fs::metadata(&binary).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&binary, perms).unwrap();
+        }
+
+        let settings = json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": format!("{} hook claude", binary.display())
+                    }]
+                }]
+            }
+        });
+
+        assert!(settings_has_headroom_rtk_hook(&settings));
+        let _ = fs::remove_file(&binary);
+        let _ = fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn settings_hook_detection_rejects_missing_absolute_rtk_hook() {
+        let settings = json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/tmp/missing/rtk hook claude"
+                    }]
+                }]
+            }
+        });
+
+        assert!(!settings_has_headroom_rtk_hook(&settings));
+    }
+
+    #[test]
+    fn settings_hook_detection_rejects_non_rtk_hook() {
         let settings = json!({
             "hooks": {
                 "PreToolUse": [{

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,3 +1,7 @@
+use serde_json::Value;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const DEFAULT_PROXY: &str = "http://127.0.0.1:8787";
@@ -17,14 +21,108 @@ fn has_model_flag(args: &[String]) -> bool {
 pub fn wrap_claude(args: &[String]) -> ! {
     set_proxy_env();
 
+    let skip_rtk_setup = should_skip_headroom_rtk_setup();
+    let cmd_args = build_claude_args(args, skip_rtk_setup);
+
+    exec("headroom", &cmd_args);
+}
+
+fn build_claude_args(args: &[String], skip_rtk_setup: bool) -> Vec<String> {
     let mut cmd_args = vec!["wrap".to_string(), "claude".to_string()];
+
+    if skip_rtk_setup {
+        cmd_args.push("--no-rtk".into());
+    }
+
     if !has_model_flag(args) {
         cmd_args.push("--model".into());
         cmd_args.push(DEFAULT_MODEL.into());
     }
-    cmd_args.extend_from_slice(args);
 
-    exec("headroom", &cmd_args);
+    cmd_args.extend_from_slice(args);
+    cmd_args
+}
+
+fn should_skip_headroom_rtk_setup() -> bool {
+    rtk_exists_on_path() && global_headroom_rtk_hook_exists()
+}
+
+fn rtk_exists_on_path() -> bool {
+    let Some(path_var) = env::var_os("PATH") else {
+        return false;
+    };
+
+    env::split_paths(&path_var).any(path_has_rtk_binary)
+}
+
+fn path_has_rtk_binary(dir: PathBuf) -> bool {
+    let binary = dir.join(rtk_binary_name());
+    binary.is_file() && path_is_executable(&binary)
+}
+
+fn rtk_binary_name() -> &'static str {
+    if cfg!(windows) {
+        "rtk.exe"
+    } else {
+        "rtk"
+    }
+}
+
+fn global_headroom_rtk_hook_exists() -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    let settings_path = home.join(".claude/settings.json");
+    let Ok(contents) = fs::read_to_string(settings_path) else {
+        return false;
+    };
+    let Ok(settings) = serde_json::from_str::<Value>(&contents) else {
+        return false;
+    };
+
+    settings_has_headroom_rtk_hook(&settings)
+}
+
+fn settings_has_headroom_rtk_hook(settings: &Value) -> bool {
+    settings
+        .get("hooks")
+        .and_then(|hooks| hooks.get("PreToolUse"))
+        .and_then(Value::as_array)
+        .is_some_and(|entries| entries.iter().any(entry_has_headroom_rtk_hook))
+}
+
+fn entry_has_headroom_rtk_hook(entry: &Value) -> bool {
+    matcher_allows_bash(entry)
+        && entry
+            .get("hooks")
+            .and_then(Value::as_array)
+            .is_some_and(|hooks| hooks.iter().any(command_is_headroom_rtk_hook))
+}
+
+fn matcher_allows_bash(entry: &Value) -> bool {
+    entry
+        .get("matcher")
+        .and_then(Value::as_str)
+        .is_some_and(|matcher| matcher.contains("Bash"))
+}
+
+fn command_is_headroom_rtk_hook(hook: &Value) -> bool {
+    hook.get("type").and_then(Value::as_str) == Some("command")
+        && hook.get("command").and_then(Value::as_str) == Some("rtk hook claude")
+}
+
+#[cfg(unix)]
+fn path_is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::metadata(path)
+        .map(|meta| meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn path_is_executable(path: &Path) -> bool {
+    path.is_file()
 }
 
 pub fn wrap_proxy(args: &[String]) -> ! {
@@ -55,4 +153,100 @@ fn exec(program: &str, args: &[String]) -> ! {
             std::process::exit(127);
         });
     std::process::exit(status.code().unwrap_or(1));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn build_claude_args_adds_model_and_skips_rtk_when_ready() {
+        let args = build_claude_args(&[], true);
+
+        assert_eq!(
+            args,
+            strings(&["wrap", "claude", "--no-rtk", "--model", DEFAULT_MODEL,])
+        );
+    }
+
+    #[test]
+    fn build_claude_args_preserves_explicit_model() {
+        let args = build_claude_args(&["--model".into(), "claude-sonnet".into()], false);
+
+        assert_eq!(
+            args,
+            strings(&["wrap", "claude", "--model", "claude-sonnet"])
+        );
+    }
+
+    #[test]
+    fn settings_hook_detection_matches_headroom_hook() {
+        let settings = json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "rtk hook claude"
+                    }]
+                }]
+            }
+        });
+
+        assert!(settings_has_headroom_rtk_hook(&settings));
+    }
+
+    #[test]
+    fn settings_hook_detection_rejects_non_headroom_hook() {
+        let settings = json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/tmp/rtk-rewrite.sh"
+                    }]
+                }]
+            }
+        });
+
+        assert!(!settings_has_headroom_rtk_hook(&settings));
+    }
+
+    #[test]
+    fn path_detection_finds_executable_rtk() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("whetstone-rtk-{stamp}"));
+        fs::create_dir_all(&dir).unwrap();
+        let binary = dir.join(rtk_binary_name());
+        fs::write(
+            &binary,
+            "#!/bin/sh
+exit 0
+",
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut perms = fs::metadata(&binary).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&binary, perms).unwrap();
+        }
+
+        assert!(path_has_rtk_binary(dir.clone()));
+        let _ = fs::remove_file(&binary);
+        let _ = fs::remove_dir(&dir);
+    }
 }


### PR DESCRIPTION
## Summary
- skip redundant Headroom RTK registration during `whetstone claude` and replace stale Claude RTK hook entries with an absolute `rtk hook claude` command
- harden releases around a single verified `just release` path, deprecate the direct local publish path, and make the GitHub release workflow safer to rerun
- add `RELEASING.md` and refresh repo docs so contributors follow the new PR-based release process

## Test plan
- [x] `just release-check`
- [ ] Manual smoke test on macOS
- [ ] Manual smoke test on Windows