### PR TITLE
fix: give release verification explicit repo context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,10 +174,15 @@ jobs:
       - name: Inspect release metadata
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.check-tag.outputs.tag }}
         run: |
-          gh release view "$TAG"             --json tagName,isDraft,isPrerelease,assets > release.json
-          gh release download "$TAG" --pattern "SHA256SUMS.txt" --dir .
+          gh release view "$TAG" \
+            --json tagName,isDraft,isPrerelease,assets \
+            > release.json
+          gh release download "$TAG" \
+            --pattern "SHA256SUMS.txt" \
+            --dir .
           python3 - <<'PY2'
           import json
           import os


### PR DESCRIPTION
## Summary
- pass explicit repository context to the `verify-release` job so `gh release` commands do not depend on a local `.git` checkout
- fix the release workflow failure that created the GitHub release for `v2.2.0` but skipped crates.io publish before verification completed
- keep the change minimal by scoping it to the existing post-release verification step

## Test plan
- [x] `just release-check`
- [x] reproduce the original `gh release` failure outside a git repo
- [x] confirm the fixed `gh release view` and `gh release download` commands succeed outside git context