### PR TITLE
fix: send a user agent to the crates.io version probe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,12 @@ jobs:
           VERSION: ${{ needs.check-tag.outputs.version }}
         run: |
           URL="https://crates.io/api/v1/crates/whetstone-cli/${VERSION}"
-          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" "$URL")
+          STATUS=$(curl -sS \
+            -H "Accept: application/json" \
+            -A "whetstone-release-check" \
+            -o /dev/null \
+            -w "%{http_code}" \
+            "$URL")
           if [ "$STATUS" = "200" ]; then
             echo "needed=false" >> "$GITHUB_OUTPUT"
             echo "Version ${VERSION} is already published"


### PR DESCRIPTION
## Summary
- add an explicit user agent to the crates.io version check in the release workflow
- fix the GitHub Actions-only 403 that aborted publish after the v2.2.1 release had already been created
- keep the existing publish gate behavior so 200 still means already published and 404 still means publish is needed

## Test plan
- [x] inspect failed release run logs for the 403 root cause
- [x] verify the updated probe still returns 404 locally for an unpublished version
- [x] pre-commit checks during commit