### PR TITLE
feat: migrate terminal UI to ratatui

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "whetstone"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- rust
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,15 +24,22 @@ Single binary distribution. Users run `whetstone setup` from inside a git projec
 <!-- AUTO-GENERATED: commands -->
 | Command | Description |
 |---------|-------------|
-| `cargo build` | Build the whetstone binary |
-| `cargo test` | Run all tests (11 tests) |
-| `cargo clippy` | Run lints |
-| `cargo fmt` | Format Rust code |
+| `just run <args>` | Run whetstone with arguments |
 | `just build` | Build debug binary |
-| `just test` | Run tests |
-| `just release-check` | Format check, tests, and lints for releases |
-| `just release <bump>` | Verify, bump version, and open a release PR |
-| `just release-publish <bump>` | Deprecated legacy path |
+| `just build-release` | Build optimized release binary |
+| `just test` | Run all tests |
+| `just test-one <name>` | Run a single test by name |
+| `just lint` | Format check + clippy |
+| `just fix` | Auto-format + clippy fix |
+| `just check` | Check compilation without binaries |
+| `just release-check` | Release quality gate (fmt + clippy + test) |
+| `just release <level>` | Bump version, create release branch + PR |
+| `just release-dry-run <level>` | Preview release without changes |
+| `just info` | Show project and toolchain versions |
+| `just loc` | Show lines of code |
+| `just clean` | Remove build artifacts |
+| `just deps` | Show dependency tree |
+| `just audit` | Audit dependencies for vulnerabilities |
 <!-- AUTO-GENERATED: end -->
 
 ## CLI Reference

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,16 +201,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "console"
-version = "0.15.11"
+name = "compact_str"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -214,16 +239,111 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.11.0"
+name = "crossterm"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "console",
- "shell-words",
- "tempfile",
- "thiserror",
- "zeroize",
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -259,16 +379,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -299,12 +422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -358,19 +475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,18 +485,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -525,10 +625,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -552,28 +652,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.14.0"
+name = "indoc"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
- "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "rustversion",
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.17.11"
+name = "instability"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
- "web-time",
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -581,6 +678,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -599,10 +705,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
+name = "kasuari"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "libc"
@@ -619,7 +730,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -631,6 +742,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -652,10 +772,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "memchr"
@@ -674,6 +818,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,10 +845,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
+name = "num_threads"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -705,6 +870,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -740,14 +928,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "powerfmt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -768,10 +952,76 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
+name = "ratatui"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -788,9 +1038,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -801,7 +1051,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -819,6 +1069,15 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -889,6 +1148,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,16 +1209,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -968,10 +1264,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1013,25 +1336,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1044,6 +1363,38 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -1062,16 +1413,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1138,24 +1500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,50 +1545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,11 +1569,10 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "console",
- "dialoguer",
+ "crossterm 0.28.1",
  "dirs",
  "flate2",
- "indicatif",
+ "ratatui",
  "rusqlite",
  "semver",
  "serde",
@@ -1294,6 +1593,28 @@ dependencies = [
  "rustix 0.38.44",
  "winsafe",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1516,100 +1837,6 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,14 @@ serde_json = "1"
 rusqlite = { version = "0.31", features = ["bundled"] }
 semver = "1"
 ureq = "2"
-dialoguer = "0.11"
-console = "0.15"
 which = "6"
 dirs = "5"
 chrono = { version = "0.4", features = ["serde"] }
 anyhow = "1"
-indicatif = "0.17"
 flate2 = "1"
 tar = "0.4"
+ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
+crossterm = "0.28"
 
 [profile.release]
 lto = true

--- a/justfile
+++ b/justfile
@@ -1,11 +1,16 @@
-# Whetstone — run tasks via `just <recipe>`
+# Whetstone — project command runner
+# https://github.com/casey/just
+
+set dotenv-load := false
+
+version := `grep '^version' Cargo.toml | head -1 | cut -d'"' -f2`
+
+# ─── Default ──────────────────────────────────────────────────────
 
 default:
-    @just --list
+    @just --list --unsorted
 
-# Set up git hooks (run once after clone)
-init:
-    git config core.hooksPath .githooks
+# ─── Development ──────────────────────────────────────────────────
 
 # Build debug binary
 build:
@@ -15,29 +20,25 @@ build:
 build-release:
     cargo build --release
 
-# Run all tests
-test:
-    cargo test
+# Install whetstone to ~/.cargo/bin
+install:
+    cargo install --path .
 
-# Run clippy lints
-lint:
-    cargo clippy -- -D warnings
+# Run whetstone with arguments (e.g. `just run -- setup --full`)
+run *ARGS:
+    cargo run -- {{ARGS}}
 
-# Format code
-fmt:
-    cargo fmt
+# Watch for changes and rebuild on save
+watch:
+    cargo watch -x check -x 'test -- --nocapture'
 
-# Check formatting without modifying files
-fmt-check:
-    cargo fmt --check
+# Check compilation without producing binaries
+check:
+    cargo check --all-targets --all-features
 
-# Build, test, and lint in one shot
-check: build test lint
+# ─── Whetstone Commands ──────────────────────────────────────────
 
-# Release verification gate
-release-check: fmt-check test lint
-
-# Run whetstone setup (uses cargo run)
+# Run whetstone setup
 setup *ARGS:
     cargo run -- setup {{ARGS}}
 
@@ -45,10 +46,188 @@ setup *ARGS:
 uninstall:
     cargo run -- uninstall
 
-# Bump version, push release branch, and open PR: just release patch|minor|major
-release *ARGS: release-check
-    cargo run -- release {{ARGS}}
+# Show whetstone version info
+version:
+    cargo run -- version
 
-# Deprecated legacy path kept for compatibility
-release-publish *ARGS:
-    cargo run -- release-publish {{ARGS}}
+# ─── Testing ─────────────────────────────────────────────────────
+
+# Run all tests
+test:
+    cargo test
+
+# Run a single test by name
+test-one NAME:
+    cargo test {{NAME}} -- --nocapture
+
+# Run tests with stdout visible
+test-verbose:
+    cargo test -- --nocapture
+
+# Generate HTML coverage report via tarpaulin
+test-coverage:
+    cargo tarpaulin --out Html --output-directory coverage
+    @echo "Report: coverage/tarpaulin-report.html"
+
+# Generate coverage and fail if below threshold
+test-coverage-check THRESHOLD="80":
+    cargo tarpaulin --fail-under {{THRESHOLD}}
+
+# ─── Linting & Formatting ───────────────────────────────────────
+
+# Format all source files
+fmt:
+    cargo fmt --all
+
+# Check formatting without modifying files
+fmt-check:
+    cargo fmt --all -- --check
+
+# Run clippy with warnings-as-errors
+clippy:
+    cargo clippy --all-targets --all-features -- -D warnings
+
+# Run clippy and auto-fix what it can
+clippy-fix:
+    cargo clippy --all-targets --all-features --fix --allow-dirty -- -D warnings
+
+# Lint everything (format check + clippy)
+lint: fmt-check clippy
+
+# Fix everything (format + clippy auto-fix)
+fix: fmt clippy-fix
+
+# ─── Security & Dependencies ────────────────────────────────────
+
+# Audit dependencies for known vulnerabilities
+audit:
+    cargo audit
+
+# Show outdated dependencies
+outdated:
+    cargo outdated
+
+# Show the full dependency tree
+deps:
+    cargo tree
+
+# Show duplicate dependencies
+deps-dupes:
+    cargo tree -d
+
+# Update all dependencies to latest compatible versions
+deps-update:
+    cargo update
+
+# ─── Pre-commit & CI ────────────────────────────────────────────
+
+# Quick pre-commit checks (format + clippy + check)
+pre-commit: fmt clippy check
+
+# Full local CI pipeline (lint + all tests)
+ci-local: lint test
+
+# Set up git hooks (run once after clone)
+init:
+    git config core.hooksPath .githooks
+
+# ─── Release ─────────────────────────────────────────────────────
+
+# Release quality gate (fmt + clippy + test)
+release-check:
+    cargo fmt --check
+    cargo clippy --all-targets --all-features -- -D warnings
+    cargo test
+
+# Preview what a release would do without changing anything
+release-dry-run LEVEL:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ ! "{{LEVEL}}" =~ ^(patch|minor|major)$ ]]; then
+        echo "Usage: just release-dry-run patch|minor|major"; exit 1
+    fi
+    CURRENT=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+    echo "Current version: $CURRENT"
+    echo "Bump level: {{LEVEL}}"
+    just release-check
+    echo ""
+    echo "All checks passed. Run: just release {{LEVEL}}"
+
+# Bump version, create release branch + PR (requires: cargo-set-version, gh)
+release LEVEL: release-check
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ ! "{{LEVEL}}" =~ ^(patch|minor|major)$ ]]; then
+        echo "Usage: just release patch|minor|major"; exit 1
+    fi
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Error: dirty working tree"; exit 1
+    fi
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$BRANCH" != "main" ]]; then
+        echo "Error: must be on main (currently on $BRANCH)"; exit 1
+    fi
+    git pull --ff-only origin main
+    cargo set-version --bump {{LEVEL}}
+    cargo check --quiet
+    VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+    git checkout -b "release/v${VERSION}"
+    git add Cargo.toml Cargo.lock
+    git commit -m "release: v${VERSION}"
+    git push -u origin "release/v${VERSION}"
+    gh pr create \
+        --title "release: v${VERSION}" \
+        --body "Bump to v${VERSION} ({{LEVEL}} release)" \
+        --base main
+    echo ""
+    echo "PR created. Next steps:"
+    echo "  gh pr checks           # watch CI"
+    echo "  gh pr merge --squash --delete-branch"
+    echo "  gh run watch           # watch release workflow"
+
+# ─── Cleanup ─────────────────────────────────────────────────────
+
+# Remove build artifacts
+clean:
+    cargo clean
+
+# Remove build artifacts and coverage reports
+clean-all: clean
+    rm -rf coverage dist
+
+# ─── Project Info ────────────────────────────────────────────────
+
+# Show project and toolchain versions
+info:
+    @echo "Whetstone v{{version}}"
+    @echo ""
+    @echo "Toolchain"
+    @echo "  rustc:  $(rustc --version)"
+    @echo "  cargo:  $(cargo --version)"
+    @echo "  just:   $(just --version)"
+    @echo ""
+    @echo "Dev Tools"
+    @echo "  cargo-set-version: $(cargo set-version --version 2>/dev/null || echo 'not installed')"
+    @echo "  cargo-audit:       $(cargo audit --version 2>/dev/null || echo 'not installed')"
+    @echo "  cargo-outdated:    $(cargo outdated --version 2>/dev/null || echo 'not installed')"
+    @echo "  cargo-watch:       $(cargo watch --version 2>/dev/null || echo 'not installed')"
+    @echo "  cargo-tarpaulin:   $(cargo tarpaulin --version 2>/dev/null || echo 'not installed')"
+
+# Show lines of code
+loc:
+    @echo "Source:"
+    @find src -name '*.rs' | xargs wc -l | tail -1
+    @echo "Assets:"
+    @find assets -type f | wc -l | xargs -I{} echo "  {} files"
+
+# Install all development tools
+install-tools:
+    cargo install cargo-set-version cargo-audit cargo-outdated cargo-watch
+    cargo install cargo-tarpaulin --version 0.32.8
+
+# Show disk usage of build artifacts and caches
+cache-status:
+    @echo "Disk Usage"
+    @echo "  target/:           $(du -sh target 2>/dev/null | cut -f1 || echo 'n/a')"
+    @echo "  coverage/:         $(du -sh coverage 2>/dev/null | cut -f1 || echo 'n/a')"
+    @echo "  ~/.cargo/registry: $(du -sh ~/.cargo/registry 2>/dev/null | cut -f1 || echo 'n/a')"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,9 @@ pub enum Command {
     /// Print whetstone version
     Version,
 
+    /// Interactive dashboard
+    Dashboard,
+
     /// Pull latest and rerun setup
     Update {
         #[arg(long)]

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,0 +1,296 @@
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Tabs},
+    DefaultTerminal, Frame,
+};
+use std::time::{Duration, Instant};
+
+use crate::{headroom, rtk, update, version};
+
+const POLL_MS: u64 = 250;
+const REFRESH_SECS: u64 = 30;
+
+struct ComponentInfo {
+    name: &'static str,
+    installed: Option<String>,
+    latest: Option<String>,
+}
+
+impl ComponentInfo {
+    fn status_line(&self) -> Line<'_> {
+        match (&self.installed, &self.latest) {
+            (Some(cur), Some(lat)) if version::is_older(cur, lat) => Line::from(vec![
+                Span::styled("  ● ", Style::default().fg(Color::Yellow)),
+                Span::styled(self.name, Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(format!("  {cur} → {lat}")),
+            ]),
+            (Some(cur), _) => Line::from(vec![
+                Span::styled("  ● ", Style::default().fg(Color::Green)),
+                Span::styled(self.name, Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(format!("  {cur}")),
+            ]),
+            (None, _) => Line::from(vec![
+                Span::styled("  ○ ", Style::default().add_modifier(Modifier::DIM)),
+                Span::styled(self.name, Style::default().add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    "  not installed",
+                    Style::default().add_modifier(Modifier::DIM),
+                ),
+            ]),
+        }
+    }
+}
+
+struct DashboardState {
+    components: Vec<ComponentInfo>,
+    tab: usize,
+    last_refresh: Instant,
+    status_msg: String,
+}
+
+impl DashboardState {
+    fn new() -> Self {
+        let mut state = Self {
+            components: Vec::new(),
+            tab: 0,
+            last_refresh: Instant::now() - Duration::from_secs(REFRESH_SECS + 1),
+            status_msg: "Loading...".into(),
+        };
+        state.refresh();
+        state
+    }
+
+    fn refresh(&mut self) {
+        self.status_msg = "Refreshing...".into();
+        let outdated = update::check_cached_upgrade();
+        let is_outdated = |name: &str| outdated.iter().find(|c| c.name == name);
+
+        let whetstone_latest = is_outdated("whetstone")
+            .map(|c| c.latest.clone())
+            .or_else(|| Some(version::current().to_string()));
+        let rtk_latest = is_outdated("rtk")
+            .map(|c| c.latest.clone())
+            .or_else(rtk::installed_version);
+        let headroom_latest = is_outdated("headroom")
+            .map(|c| c.latest.clone())
+            .or_else(headroom::installed_version);
+
+        self.components = vec![
+            ComponentInfo {
+                name: "whetstone",
+                installed: Some(version::current().to_string()),
+                latest: whetstone_latest,
+            },
+            ComponentInfo {
+                name: "headroom",
+                installed: headroom::installed_version(),
+                latest: headroom_latest,
+            },
+            ComponentInfo {
+                name: "rtk",
+                installed: rtk::installed_version(),
+                latest: rtk_latest,
+            },
+            ComponentInfo {
+                name: "memory",
+                installed: Some("ICM (embedded)".into()),
+                latest: None,
+            },
+        ];
+        self.last_refresh = Instant::now();
+        self.status_msg = "Ready".into();
+    }
+
+    fn should_refresh(&self) -> bool {
+        self.last_refresh.elapsed() >= Duration::from_secs(REFRESH_SECS)
+    }
+}
+
+fn draw(frame: &mut Frame, state: &DashboardState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(8),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+    draw_header(frame, chunks[0], state);
+    draw_body(frame, chunks[1], state);
+    draw_footer(frame, chunks[2], state);
+}
+
+fn draw_header(frame: &mut Frame, area: Rect, state: &DashboardState) {
+    let titles = vec!["Components", "Actions"];
+    let tabs = Tabs::new(titles)
+        .block(
+            Block::default().borders(Borders::ALL).title(Span::styled(
+                format!(" whetstone v{} ", version::current()),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )),
+        )
+        .select(state.tab)
+        .style(Style::default().fg(Color::DarkGray))
+        .highlight_style(
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        );
+    frame.render_widget(tabs, area);
+}
+
+fn draw_body(frame: &mut Frame, area: Rect, state: &DashboardState) {
+    match state.tab {
+        0 => draw_components(frame, area, state),
+        1 => draw_actions(frame, area),
+        _ => {}
+    }
+}
+
+fn draw_components(frame: &mut Frame, area: Rect, state: &DashboardState) {
+    let mut lines: Vec<Line<'_>> = vec![Line::from("")];
+    for c in &state.components {
+        lines.push(c.status_line());
+    }
+    lines.push(Line::from(""));
+
+    let elapsed = state.last_refresh.elapsed().as_secs();
+    lines.push(Line::from(Span::styled(
+        format!("  Last checked {elapsed}s ago"),
+        Style::default().add_modifier(Modifier::DIM),
+    )));
+
+    let block = Block::default().borders(Borders::ALL).title(" Components ");
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn draw_actions(frame: &mut Frame, area: Rect) {
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  u",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  update all components"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  v",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  refresh version check"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  r",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  refresh dashboard"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Press the key to execute an action",
+            Style::default().add_modifier(Modifier::DIM),
+        )),
+    ];
+
+    let block = Block::default().borders(Borders::ALL).title(" Actions ");
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect, state: &DashboardState) {
+    let help = Line::from(vec![
+        Span::styled(
+            " q",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(":quit  "),
+        Span::styled(
+            "←→",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(":tab  "),
+        Span::styled(
+            "r",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(":refresh  "),
+        Span::raw(format!("  {}", state.status_msg)),
+    ]);
+
+    let block = Block::default().borders(Borders::ALL);
+    let paragraph = Paragraph::new(help).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+pub fn run() -> Result<()> {
+    let mut terminal = ratatui::init();
+    let result = run_loop(&mut terminal);
+    ratatui::restore();
+    result
+}
+
+fn run_loop(terminal: &mut DefaultTerminal) -> Result<()> {
+    let mut state = DashboardState::new();
+
+    loop {
+        terminal.draw(|frame| draw(frame, &state))?;
+
+        if event::poll(Duration::from_millis(POLL_MS))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                    KeyCode::Left | KeyCode::Char('h') => {
+                        state.tab = state.tab.saturating_sub(1);
+                    }
+                    KeyCode::Right | KeyCode::Char('l') if state.tab < 1 => {
+                        state.tab += 1;
+                    }
+                    KeyCode::Char('r') | KeyCode::Char('v') => {
+                        state.refresh();
+                    }
+                    KeyCode::Char('u') => {
+                        ratatui::restore();
+                        if let Err(e) = update::run(false) {
+                            eprintln!("Update failed: {e:#}");
+                        }
+                        eprintln!("\nPress Enter to return to dashboard...");
+                        let _ = std::io::stdin().read_line(&mut String::new());
+                        *terminal = ratatui::init();
+                        state.refresh();
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if state.should_refresh() {
+            state.refresh();
+        }
+    }
+}

--- a/src/headroom.rs
+++ b/src/headroom.rs
@@ -1,10 +1,29 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
 use std::process::Command;
 
 use crate::ui;
 use crate::version;
 
 const MIN_VERSION: &str = "0.21.0";
+const PYPI_URL: &str = "https://pypi.org/pypi/headroom-ai/json";
+
+#[derive(Deserialize)]
+struct PypiResponse {
+    info: PypiInfo,
+}
+
+#[derive(Deserialize)]
+struct PypiInfo {
+    version: String,
+}
+
+pub fn latest_remote_version() -> Option<String> {
+    let resp = ureq::get(PYPI_URL).call().ok()?;
+    let body = resp.into_string().ok()?;
+    let parsed: PypiResponse = serde_json::from_str(&body).ok()?;
+    Some(parsed.info.version)
+}
 
 pub fn resolve_extras(input: &str) -> String {
     match input.trim().to_lowercase().as_str() {
@@ -60,7 +79,16 @@ pub fn update() -> Result<ui::ComponentStatus> {
     };
 
     let spec = package_spec("all");
-    run_uv_install(&spec, true)?;
+    let output = Command::new("uv")
+        .args(["tool", "install", "--upgrade", &spec])
+        .env("PYO3_USE_ABI3_FORWARD_COMPATIBILITY", "1")
+        .output()
+        .context("failed to run uv tool install")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("uv tool install failed: {stderr}");
+    }
 
     let new_ver = installed_version().unwrap_or_else(|| old_ver.clone());
     if new_ver != old_ver {
@@ -108,5 +136,12 @@ mod tests {
     #[test]
     fn extras_custom() {
         assert_eq!(package_spec("proxy,code"), "headroom-ai[proxy,code]");
+    }
+
+    #[test]
+    fn parse_pypi_response() {
+        let json = r#"{"info":{"version":"0.22.2"}}"#;
+        let parsed: PypiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.info.version, "0.22.2");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,27 @@ fn main() {
                 wrapper::wrap_rtk(&args);
             }
             Command::Version => {
-                println!("whetstone {}", version::current());
+                let outdated = update::check_cached_upgrade();
+                let is_outdated = |name: &str| outdated.iter().any(|c| c.name == name);
+
+                let entries = vec![
+                    ui::VersionEntry {
+                        name: "whetstone",
+                        version: Some(version::current().to_string()),
+                        outdated: is_outdated("whetstone"),
+                    },
+                    ui::VersionEntry {
+                        name: "headroom",
+                        version: headroom::installed_version(),
+                        outdated: is_outdated("headroom"),
+                    },
+                    ui::VersionEntry {
+                        name: "rtk",
+                        version: rtk::installed_version(),
+                        outdated: is_outdated("rtk"),
+                    },
+                ];
+                ui::version_report(&entries);
             }
             Command::Update { full } => {
                 if let Err(e) = update::run(full) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod config;
+mod dashboard;
 mod db;
 mod headroom;
 mod hooks;
@@ -13,13 +14,17 @@ mod ui;
 mod uninstall;
 mod update;
 mod version;
+mod wizard;
 mod wrapper;
 
 use clap::Parser;
 use cli::{Cli, Command};
 
 fn show_upgrade_banner(cmd: &Option<Command>) {
-    let skip = matches!(cmd, Some(Command::Update { .. } | Command::Version));
+    let skip = matches!(
+        cmd,
+        Some(Command::Update { .. } | Command::Version | Command::Dashboard)
+    );
     if skip {
         return;
     }
@@ -84,6 +89,11 @@ fn main() {
             }
             Command::Update { full } => {
                 if let Err(e) = update::run(full) {
+                    ui::fail(&format!("{e:#}"));
+                }
+            }
+            Command::Dashboard => {
+                if let Err(e) = dashboard::run() {
                     ui::fail(&format!("{e:#}"));
                 }
             }

--- a/src/rtk.rs
+++ b/src/rtk.rs
@@ -1,4 +1,5 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
 use std::process::Command;
 
 use crate::ui;
@@ -7,6 +8,23 @@ use crate::version;
 const MIN_VERSION: &str = "0.39.0";
 const INSTALL_URL: &str =
     "https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh";
+const GITHUB_LATEST_URL: &str = "https://api.github.com/repos/rtk-ai/rtk/releases/latest";
+
+#[derive(Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+}
+
+pub fn latest_remote_version() -> Option<String> {
+    let resp = ureq::get(GITHUB_LATEST_URL)
+        .set("User-Agent", "whetstone")
+        .call()
+        .ok()?;
+    let body = resp.into_string().ok()?;
+    let release: GithubRelease = serde_json::from_str(&body).ok()?;
+    let tag = release.tag_name.trim_start_matches('v');
+    version::extract_semver(tag)
+}
 
 pub fn installed_version() -> Option<String> {
     let output = Command::new("rtk").arg("--version").output().ok()?;
@@ -59,7 +77,17 @@ pub fn update() -> Result<ui::ComponentStatus> {
             "not rtk-ai (collision?)".into(),
         ));
     }
-    run_install()?;
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(format!("curl -fsSL {INSTALL_URL} | sh"))
+        .output()
+        .context("failed to run rtk install")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("rtk installation failed: {stderr}");
+    }
 
     let new_ver = installed_version().unwrap_or_else(|| old_ver.clone());
     if new_ver != old_ver {
@@ -79,4 +107,26 @@ fn run_install() -> Result<()> {
         bail!("rtk installation failed");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_github_release() {
+        let json = r#"{"tag_name":"v0.42.0"}"#;
+        let release: GithubRelease = serde_json::from_str(json).unwrap();
+        assert_eq!(release.tag_name, "v0.42.0");
+        let tag = release.tag_name.trim_start_matches('v');
+        assert_eq!(version::extract_semver(tag), Some("0.42.0".into()));
+    }
+
+    #[test]
+    fn parse_github_release_no_v_prefix() {
+        let json = r#"{"tag_name":"0.42.0"}"#;
+        let release: GithubRelease = serde_json::from_str(json).unwrap();
+        let tag = release.tag_name.trim_start_matches('v');
+        assert_eq!(version::extract_semver(tag), Some("0.42.0".into()));
+    }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::memory::MemoryProvider;
 use crate::{config, headroom, hooks, preflight, rtk, shell, ui};
 
-const DEFAULT_PROXY: &str = "http://127.0.0.1:8787";
+pub(crate) const DEFAULT_PROXY: &str = "http://127.0.0.1:8787";
 
 pub fn resolve_assets_dir() -> Result<PathBuf> {
     if let Ok(dir) = std::env::var("WHETSTONE_ASSETS") {
@@ -38,6 +38,13 @@ pub fn resolve_assets_dir() -> Result<PathBuf> {
 }
 
 pub fn run(full: bool, headroom_extras: &str) -> Result<()> {
+    if ui::is_interactive() {
+        return crate::wizard::run(full, headroom_extras);
+    }
+    run_sequential(full, headroom_extras)
+}
+
+fn run_sequential(full: bool, headroom_extras: &str) -> Result<()> {
     ui::info("whetstone setup");
 
     let assets = resolve_assets_dir()?;
@@ -87,7 +94,7 @@ pub fn run(full: bool, headroom_extras: &str) -> Result<()> {
     Ok(())
 }
 
-fn prompt_memory_provider(full: bool) -> Result<MemoryProvider> {
+pub(crate) fn prompt_memory_provider(full: bool) -> Result<MemoryProvider> {
     let project_dir = std::env::current_dir()?;
     let has_existing = project_dir.join(".claude/skills").is_dir()
         || project_dir.join(".claude/MEMSTACK.md").exists();
@@ -125,7 +132,11 @@ fn detect_installed_provider() -> Result<MemoryProvider> {
     }
 }
 
-fn install_general_assets(assets: &Path, full: bool, headroom_extras: &str) -> Result<()> {
+pub(crate) fn install_general_assets(
+    assets: &Path,
+    full: bool,
+    headroom_extras: &str,
+) -> Result<()> {
     let project_dir = std::env::current_dir()?;
     let claude_dir = project_dir.join(".claude");
 
@@ -141,7 +152,7 @@ fn install_general_assets(assets: &Path, full: bool, headroom_extras: &str) -> R
     Ok(())
 }
 
-fn install_provider(provider: MemoryProvider) -> Result<()> {
+pub(crate) fn install_provider(provider: MemoryProvider) -> Result<()> {
     match provider {
         MemoryProvider::Icm => install_icm(),
         MemoryProvider::AutoMem => install_automem(),
@@ -260,7 +271,7 @@ fn copy_memstack_md(assets: &Path, claude_dir: &Path, force: bool) -> Result<()>
     Ok(())
 }
 
-fn generate_stack_setup(provider: MemoryProvider) -> Result<()> {
+pub(crate) fn generate_stack_setup(provider: MemoryProvider) -> Result<()> {
     let project_dir = std::env::current_dir()?;
     let dest = project_dir.join("STACK-SETUP.md");
     let content = stack_setup_content(provider);
@@ -338,7 +349,7 @@ Per-project: `whetstone uninstall`
     )
 }
 
-fn self_install() -> Result<()> {
+pub(crate) fn self_install() -> Result<()> {
     let current_exe =
         std::env::current_exe().context("could not determine current executable path")?;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,24 +1,91 @@
-use console::style;
-use dialoguer::{Confirm, Select};
-use indicatif::{ProgressBar, ProgressStyle};
-use std::io::{self, IsTerminal};
+use crossterm::style::Stylize;
+use crossterm::{cursor, event, terminal};
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Terminal, TerminalOptions, Viewport,
+};
+use std::io::{self, IsTerminal, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
-const BOX_WIDTH: usize = 48;
+fn render_inline_stderr(lines: Vec<Line<'_>>) {
+    let height = lines.len() as u16;
+    let backend = ratatui::backend::CrosstermBackend::new(io::stderr());
+    if let Ok(mut terminal) = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(height),
+        },
+    ) {
+        let _ = terminal.draw(|frame| {
+            let paragraph = Paragraph::new(lines);
+            frame.render_widget(paragraph, frame.area());
+        });
+    }
+}
 
 pub fn info(msg: &str) {
-    eprintln!("{} {msg}", style("[INFO]").blue().bold());
+    if is_interactive() {
+        render_inline_stderr(vec![Line::from(vec![
+            Span::styled(
+                "[INFO]",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(" {msg}")),
+        ])]);
+    } else {
+        eprintln!("[INFO] {msg}");
+    }
 }
 
 pub fn ok(msg: &str) {
-    eprintln!("{} {msg}", style("  [OK]").green().bold());
+    if is_interactive() {
+        render_inline_stderr(vec![Line::from(vec![
+            Span::styled(
+                "  [OK]",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(" {msg}")),
+        ])]);
+    } else {
+        eprintln!("  [OK] {msg}");
+    }
 }
 
 pub fn warn(msg: &str) {
-    eprintln!("{} {msg}", style("[WARN]").yellow().bold());
+    if is_interactive() {
+        render_inline_stderr(vec![Line::from(vec![
+            Span::styled(
+                "[WARN]",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(" {msg}")),
+        ])]);
+    } else {
+        eprintln!("[WARN] {msg}");
+    }
 }
 
 pub fn fail(msg: &str) -> ! {
-    eprintln!("{} {msg}", style("[FAIL]").red().bold());
+    if is_interactive() {
+        render_inline_stderr(vec![Line::from(vec![
+            Span::styled(
+                "[FAIL]",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(" {msg}")),
+        ])]);
+    } else {
+        eprintln!("[FAIL] {msg}");
+    }
     std::process::exit(1);
 }
 
@@ -30,23 +97,85 @@ pub fn confirm(prompt: &str, default: bool) -> bool {
     if !is_interactive() {
         return default;
     }
-    Confirm::new()
-        .with_prompt(prompt)
-        .default(default)
-        .interact()
-        .unwrap_or(default)
+
+    let hint = if default { "[Y/n]" } else { "[y/N]" };
+    eprint!("{} {} ", prompt, hint.dim());
+    let _ = io::stderr().flush();
+
+    terminal::enable_raw_mode().ok();
+    let result = loop {
+        if let Ok(event::Event::Key(key)) = event::read() {
+            match key.code {
+                event::KeyCode::Char('y' | 'Y') => break true,
+                event::KeyCode::Char('n' | 'N') => break false,
+                event::KeyCode::Enter => break default,
+                event::KeyCode::Esc => break false,
+                _ => {}
+            }
+        }
+    };
+    terminal::disable_raw_mode().ok();
+    eprintln!("{}", if result { "yes" } else { "no" });
+    result
 }
 
 pub fn select<T: std::fmt::Display>(prompt: &str, items: &[T], default: usize) -> usize {
-    if !is_interactive() {
+    if !is_interactive() || items.is_empty() {
         return default;
     }
-    Select::new()
-        .with_prompt(prompt)
-        .items(items)
-        .default(default)
-        .interact()
-        .unwrap_or(default)
+
+    let mut selected = default;
+
+    eprintln!("{prompt}");
+
+    terminal::enable_raw_mode().ok();
+    loop {
+        let mut stderr = io::stderr();
+        for (i, item) in items.iter().enumerate() {
+            if i == selected {
+                let _ = write!(
+                    stderr,
+                    "\r  {} {}\r\n",
+                    "›".cyan().bold(),
+                    item.to_string().bold()
+                );
+            } else {
+                let _ = write!(stderr, "\r    {}\r\n", item);
+            }
+        }
+        let _ = stderr.flush();
+
+        if let Ok(event::Event::Key(key)) = event::read() {
+            match key.code {
+                event::KeyCode::Up | event::KeyCode::Char('k') => {
+                    selected = selected.saturating_sub(1);
+                }
+                event::KeyCode::Down | event::KeyCode::Char('j') if selected + 1 < items.len() => {
+                    selected += 1;
+                }
+                event::KeyCode::Enter => break,
+                event::KeyCode::Esc => {
+                    selected = default;
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        // Move cursor back up to redraw
+        let _ = crossterm::execute!(stderr, cursor::MoveUp(items.len() as u16));
+    }
+    terminal::disable_raw_mode().ok();
+
+    // Clear the selection display
+    let mut stderr = io::stderr();
+    for _ in items {
+        let _ = write!(stderr, "\r{}\r\n", " ".repeat(60));
+    }
+    let _ = crossterm::execute!(stderr, cursor::MoveUp(items.len() as u16));
+    eprintln!("{}: {}", prompt, items[selected].to_string().cyan().bold());
+
+    selected
 }
 
 pub fn upgrade_banner(components: &[crate::update::OutdatedComponent]) {
@@ -54,98 +183,68 @@ pub fn upgrade_banner(components: &[crate::update::OutdatedComponent]) {
         return;
     }
 
-    let title = "UPDATES AVAILABLE";
+    let title = "⬆  UPDATES AVAILABLE";
     let action_line = "Run: whetstone update";
 
-    let mut content_lines: Vec<String> = Vec::new();
+    let mut content_lines: Vec<Line<'_>> = Vec::new();
     for c in components {
-        content_lines.push(format!("{}: {} → {}", c.name, c.current, c.latest));
+        content_lines.push(Line::from(vec![Span::styled(
+            format!("{}: {} → {}", c.name, c.current, c.latest),
+            Style::default().add_modifier(Modifier::BOLD),
+        )]));
     }
+    content_lines.push(Line::from(""));
+    content_lines.push(Line::from(Span::styled(
+        action_line,
+        Style::default().add_modifier(Modifier::DIM),
+    )));
 
-    let max_content = content_lines
-        .iter()
-        .map(|l| l.chars().count())
-        .max()
-        .unwrap_or(0);
-    let min_width = [
-        title.chars().count() + 4,
-        action_line.chars().count(),
-        max_content,
-    ]
-    .into_iter()
-    .max()
-    .unwrap_or(0);
-    let inner = min_width.max(BOX_WIDTH - 4);
-    let border = "─".repeat(inner + 2);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Span::styled(
+            format!(" {title} "),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .border_style(Style::default().fg(Color::Cyan));
 
+    let paragraph = Paragraph::new(content_lines).block(block);
+
+    let height = (components.len() + 5) as u16;
     eprintln!();
-    eprintln!(
-        "  {}{}{}",
-        style("┌").cyan(),
-        style(&border).cyan(),
-        style("┐").cyan()
-    );
-    eprintln!(
-        "  {}{}{}",
-        style("│").cyan(),
-        " ".repeat(inner + 2),
-        style("│").cyan()
-    );
-    eprintln!(
-        "  {} {} {}{}",
-        style("│").cyan(),
-        style(format!("⬆  {title}")).yellow().bold(),
-        " ".repeat(inner.saturating_sub(title.chars().count() + 4)),
-        style("│").cyan()
-    );
-    eprintln!(
-        "  {}{}{}",
-        style("│").cyan(),
-        " ".repeat(inner + 2),
-        style("│").cyan()
-    );
-    for line in &content_lines {
-        eprintln!(
-            "  {} {} {}{}",
-            style("│").cyan(),
-            style(line).white().bold(),
-            " ".repeat(inner.saturating_sub(line.chars().count() + 1)),
-            style("│").cyan()
-        );
+    let backend = ratatui::backend::CrosstermBackend::new(io::stderr());
+    if let Ok(mut terminal) = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(height),
+        },
+    ) {
+        let _ = terminal.draw(|frame| {
+            frame.render_widget(paragraph, frame.area());
+        });
     }
-    eprintln!(
-        "  {}{}{}",
-        style("│").cyan(),
-        " ".repeat(inner + 2),
-        style("│").cyan()
-    );
-    eprintln!(
-        "  {} {} {}{}",
-        style("│").cyan(),
-        style(action_line).dim(),
-        " ".repeat(inner.saturating_sub(action_line.chars().count() + 1)),
-        style("│").cyan()
-    );
-    eprintln!(
-        "  {}{}{}",
-        style("│").cyan(),
-        " ".repeat(inner + 2),
-        style("│").cyan()
-    );
-    eprintln!(
-        "  {}{}{}",
-        style("└").cyan(),
-        style(&border).cyan(),
-        style("┘").cyan()
-    );
     eprintln!();
 }
 
 pub fn section(title: &str) {
-    let line = "─".repeat(40);
-    eprintln!();
-    eprintln!("  {} {}", style(title).bold(), style(&line).dim());
-    eprintln!();
+    if is_interactive() {
+        let line_chars = "─".repeat(40);
+        render_inline_stderr(vec![
+            Line::from(""),
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(title, Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(" "),
+                Span::styled(line_chars, Style::default().add_modifier(Modifier::DIM)),
+            ]),
+            Line::from(""),
+        ]);
+    } else {
+        eprintln!();
+        eprintln!("  {title} {}", "─".repeat(40));
+        eprintln!();
+    }
 }
 
 #[derive(Debug)]
@@ -158,40 +257,64 @@ pub enum ComponentStatus {
 
 pub fn component_line(name: &str, status: &ComponentStatus) {
     let label = format!("{:.<16}", format!("{name} "));
-    match status {
-        ComponentStatus::UpToDate(ver) => {
-            eprintln!(
-                "  {} {} {}",
-                style("●").green(),
-                style(&label).bold(),
-                style(format!("{ver} (up to date)")).dim()
-            );
-        }
-        ComponentStatus::Updated(from, to) => {
-            eprintln!(
-                "  {} {} {} → {}",
-                style("●").green(),
-                style(&label).bold(),
-                style(from).dim(),
-                style(to).green().bold()
-            );
-        }
-        ComponentStatus::NotInstalled => {
-            eprintln!(
-                "  {} {} {}",
-                style("○").dim(),
-                style(&label).bold(),
-                style("not installed").dim()
-            );
-        }
-        ComponentStatus::Failed(reason) => {
-            eprintln!(
-                "  {} {} {}",
-                style("✗").red(),
-                style(&label).bold(),
-                style(reason).red()
-            );
-        }
+    let line = match status {
+        ComponentStatus::UpToDate(ver) => Line::from(vec![
+            Span::raw("  "),
+            Span::styled("●", Style::default().fg(Color::Green)),
+            Span::raw(" "),
+            Span::styled(&*label, Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" "),
+            Span::styled(
+                format!("{ver} (up to date)"),
+                Style::default().add_modifier(Modifier::DIM),
+            ),
+        ]),
+        ComponentStatus::Updated(from, to) => Line::from(vec![
+            Span::raw("  "),
+            Span::styled("●", Style::default().fg(Color::Green)),
+            Span::raw(" "),
+            Span::styled(&*label, Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" "),
+            Span::styled(from.as_str(), Style::default().add_modifier(Modifier::DIM)),
+            Span::raw(" → "),
+            Span::styled(
+                to.as_str(),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        ComponentStatus::NotInstalled => Line::from(vec![
+            Span::raw("  "),
+            Span::styled("○", Style::default().add_modifier(Modifier::DIM)),
+            Span::raw(" "),
+            Span::styled(&*label, Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" "),
+            Span::styled(
+                "not installed",
+                Style::default().add_modifier(Modifier::DIM),
+            ),
+        ]),
+        ComponentStatus::Failed(reason) => Line::from(vec![
+            Span::raw("  "),
+            Span::styled("✗", Style::default().fg(Color::Red)),
+            Span::raw(" "),
+            Span::styled(&*label, Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" "),
+            Span::styled(reason.as_str(), Style::default().fg(Color::Red)),
+        ]),
+    };
+
+    if is_interactive() {
+        render_inline_stderr(vec![line]);
+    } else {
+        let plain = match status {
+            ComponentStatus::UpToDate(ver) => format!("  ● {label} {ver} (up to date)"),
+            ComponentStatus::Updated(from, to) => format!("  ● {label} {from} → {to}"),
+            ComponentStatus::NotInstalled => format!("  ○ {label} not installed"),
+            ComponentStatus::Failed(reason) => format!("  ✗ {label} {reason}"),
+        };
+        eprintln!("{plain}");
     }
 }
 
@@ -209,11 +332,11 @@ pub fn version_report(entries: &[VersionEntry]) {
             match &e.version {
                 Some(v) => format!(
                     "{} {}{}",
-                    style(e.name).bold(),
-                    style(v).cyan(),
-                    style(indicator).yellow().bold()
+                    e.name.bold(),
+                    v.clone().cyan(),
+                    indicator.yellow().bold()
                 ),
-                None => format!("{} {}", style(e.name).bold(), style("—").dim()),
+                None => format!("{} {}", e.name.bold(), "—".dim()),
             }
         })
         .collect();
@@ -221,23 +344,104 @@ pub fn version_report(entries: &[VersionEntry]) {
 }
 
 pub fn summary_ok(msg: &str) {
-    eprintln!();
-    eprintln!("  {} {}", style("✓").green().bold(), style(msg).green());
-    eprintln!();
+    if is_interactive() {
+        render_inline_stderr(vec![
+            Line::from(""),
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    "✓",
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" "),
+                Span::styled(msg, Style::default().fg(Color::Green)),
+            ]),
+            Line::from(""),
+        ]);
+    } else {
+        eprintln!();
+        eprintln!("  ✓ {msg}");
+        eprintln!();
+    }
 }
 
 pub fn summary_info(msg: &str) {
-    eprintln!();
-    eprintln!("  {} {}", style("ℹ").blue().bold(), style(msg).bold());
-    eprintln!();
+    if is_interactive() {
+        render_inline_stderr(vec![
+            Line::from(""),
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    "ℹ",
+                    Style::default()
+                        .fg(Color::Blue)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" "),
+                Span::styled(msg, Style::default().add_modifier(Modifier::BOLD)),
+            ]),
+            Line::from(""),
+        ]);
+    } else {
+        eprintln!();
+        eprintln!("  ℹ {msg}");
+        eprintln!();
+    }
 }
 
-pub fn spinner(msg: &str) -> ProgressBar {
-    let pb = ProgressBar::new_spinner();
-    let style = ProgressStyle::with_template("  {spinner:.cyan} {msg}")
-        .unwrap_or_else(|_| ProgressStyle::default_spinner());
-    pb.set_style(style.tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]));
-    pb.set_message(msg.to_string());
-    pb.enable_steady_tick(std::time::Duration::from_millis(80));
-    pb
+const BRAILLE: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+pub struct Spinner {
+    stop: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Spinner {
+    pub fn finish_and_clear(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+        let mut stderr = io::stderr();
+        let _ = write!(stderr, "\r{}\r", " ".repeat(80));
+        let _ = stderr.flush();
+    }
+}
+
+impl Drop for Spinner {
+    fn drop(&mut self) {
+        if !self.stop.load(Ordering::Relaxed) {
+            self.finish_and_clear();
+        }
+    }
+}
+
+pub fn spinner(msg: &str) -> Spinner {
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_clone = Arc::clone(&stop);
+    let msg = msg.to_string();
+
+    if !is_interactive() {
+        eprintln!("  {msg}");
+        return Spinner { stop, handle: None };
+    }
+
+    let handle = std::thread::spawn(move || {
+        let mut i = 0;
+        let mut stderr = io::stderr();
+        while !stop_clone.load(Ordering::Relaxed) {
+            let frame = BRAILLE[i % BRAILLE.len()];
+            let _ = write!(stderr, "\r  {} {}", frame.cyan(), msg);
+            let _ = stderr.flush();
+            i += 1;
+            std::thread::sleep(std::time::Duration::from_millis(80));
+        }
+    });
+
+    Spinner {
+        stop,
+        handle: Some(handle),
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -195,6 +195,31 @@ pub fn component_line(name: &str, status: &ComponentStatus) {
     }
 }
 
+pub struct VersionEntry {
+    pub name: &'static str,
+    pub version: Option<String>,
+    pub outdated: bool,
+}
+
+pub fn version_report(entries: &[VersionEntry]) {
+    let parts: Vec<String> = entries
+        .iter()
+        .map(|e| {
+            let indicator = if e.outdated { " ⬆" } else { "" };
+            match &e.version {
+                Some(v) => format!(
+                    "{} {}{}",
+                    style(e.name).bold(),
+                    style(v).cyan(),
+                    style(indicator).yellow().bold()
+                ),
+                None => format!("{} {}", style(e.name).bold(), style("—").dim()),
+            }
+        })
+        .collect();
+    println!("{}", parts.join("  "));
+}
+
 pub fn summary_ok(msg: &str) {
     eprintln!();
     eprintln!("  {} {}", style("✓").green().bold(), style(msg).green());

--- a/src/update.rs
+++ b/src/update.rs
@@ -149,7 +149,7 @@ fn self_update(latest: &str) -> Result<ui::ComponentStatus> {
     let target = detect_target().context("unsupported platform for self-update")?;
     let url = format!("{RELEASE_URL_BASE}/v{latest}/whetstone-{target}.tar.gz");
 
-    let sp = ui::spinner(&format!("downloading whetstone {latest}"));
+    let mut sp = ui::spinner(&format!("downloading whetstone {latest}"));
 
     let resp = ureq::get(&url)
         .call()
@@ -221,16 +221,18 @@ fn self_update(latest: &str) -> Result<ui::ComponentStatus> {
 pub fn run(_full: bool) -> Result<()> {
     ui::section("whetstone update");
 
-    let sp = ui::spinner("checking for updates");
-    let latest = fetch_remote_version()?;
+    let mut sp = ui::spinner("checking for updates");
+    let whetstone_latest = fetch_remote_version()?;
+    let rtk_remote = rtk::latest_remote_version();
+    let headroom_remote = headroom::latest_remote_version();
     sp.finish_and_clear();
 
     let current = version::current().to_string();
-    let rtk_before = rtk::installed_version();
-    let headroom_before = headroom::installed_version();
+    let rtk_current = rtk::installed_version();
+    let headroom_current = headroom::installed_version();
     let mut updated_count = 0u32;
 
-    let whetstone_status = match self_update(&latest) {
+    let whetstone_status = match self_update(&whetstone_latest) {
         Ok(status) => status,
         Err(e) => ui::ComponentStatus::Failed(format!("{e:#}")),
     };
@@ -239,18 +241,30 @@ pub fn run(_full: bool) -> Result<()> {
     }
     ui::component_line("whetstone", &whetstone_status);
 
-    let rtk_status = match rtk::update() {
-        Ok(status) => status,
-        Err(e) => ui::ComponentStatus::Failed(format!("{e:#}")),
+    let rtk_status = match (&rtk_current, &rtk_remote) {
+        (Some(cur), Some(latest)) if !version::is_older(cur, latest) => {
+            ui::ComponentStatus::UpToDate(cur.clone())
+        }
+        (Some(_), _) => match rtk::update() {
+            Ok(status) => status,
+            Err(e) => ui::ComponentStatus::Failed(format!("{e:#}")),
+        },
+        (None, _) => ui::ComponentStatus::NotInstalled,
     };
     if matches!(&rtk_status, ui::ComponentStatus::Updated(_, _)) {
         updated_count += 1;
     }
     ui::component_line("rtk", &rtk_status);
 
-    let headroom_status = match headroom::update() {
-        Ok(status) => status,
-        Err(e) => ui::ComponentStatus::Failed(format!("{e:#}")),
+    let headroom_status = match (&headroom_current, &headroom_remote) {
+        (Some(cur), Some(latest)) if !version::is_older(cur, latest) => {
+            ui::ComponentStatus::UpToDate(cur.clone())
+        }
+        (Some(_), _) => match headroom::update() {
+            Ok(status) => status,
+            Err(e) => ui::ComponentStatus::Failed(format!("{e:#}")),
+        },
+        (None, _) => ui::ComponentStatus::NotInstalled,
     };
     if matches!(&headroom_status, ui::ComponentStatus::Updated(_, _)) {
         updated_count += 1;
@@ -261,20 +275,20 @@ pub fn run(_full: bool) -> Result<()> {
     ui::component_line("memory (ICM)", &memory_status);
 
     write_cache(&VersionCache {
-        whetstone_latest: latest.clone(),
-        rtk_current: rtk_before,
-        rtk_latest: rtk::installed_version(),
-        headroom_current: headroom_before,
-        headroom_latest: headroom::installed_version(),
+        whetstone_latest: whetstone_latest.clone(),
+        rtk_current: rtk::installed_version(),
+        rtk_latest: rtk_remote,
+        headroom_current: headroom::installed_version(),
+        headroom_latest: headroom_remote,
         timestamp: now_epoch(),
     });
 
     if updated_count > 0 {
         ui::summary_ok(&format!("Updated {updated_count} component(s)"));
-
         if matches!(&whetstone_status, ui::ComponentStatus::Updated(_, _)) {
             ui::info(&format!(
-                "whetstone updated from {current} → {latest} — restart your shell to use it"
+                "whetstone updated from {current} → {whetstone_latest} — \
+                 restart your shell to use it"
             ));
         }
     } else {

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -1,0 +1,299 @@
+use anyhow::{Context, Result};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Gauge, Paragraph},
+    DefaultTerminal, Frame,
+};
+use std::io;
+use std::time::Duration;
+
+use crate::memory::MemoryProvider;
+use crate::{headroom, hooks, preflight, rtk, setup, shell, ui, version};
+
+const TOTAL_STEPS: usize = 7;
+
+pub fn run(full: bool, headroom_extras: &str) -> Result<()> {
+    welcome_screen()?;
+
+    let assets = setup::resolve_assets_dir()?;
+    ui::ok(&format!("assets at {}", assets.display()));
+
+    step_progress(1, "Dependencies");
+    preflight::check_all()?;
+
+    step_progress(2, "Headroom");
+    headroom::install(headroom_extras, full)?;
+
+    step_progress(3, "RTK");
+    rtk::install(full)?;
+
+    step_progress(4, "Shell profile");
+    shell::set_anthropic_base_url(setup::DEFAULT_PROXY)?;
+    shell::ensure_path_contains_local_bin()?;
+
+    step_progress(5, "Binary install");
+    setup::self_install()?;
+
+    step_progress(6, "Memory provider");
+    let provider = setup::prompt_memory_provider(full)?;
+
+    if provider != MemoryProvider::Skip {
+        step_progress(7, "Assets & hooks");
+        setup::install_general_assets(&assets, full, headroom_extras)?;
+        setup::install_provider(provider)?;
+
+        let claude_dir = dirs::home_dir()
+            .context("could not determine home directory")?
+            .join(".claude");
+        let hooks_dir = claude_dir.join("hooks");
+        let settings_path = claude_dir.join("settings.json");
+        hooks::copy_hook_scripts(&assets.join("hooks"), &hooks_dir)?;
+        hooks::merge_settings_json(&settings_path, &hooks_dir, provider)?;
+        setup::generate_stack_setup(provider)?;
+    } else {
+        ui::info("skipped memory provider, skills, hooks, and STACK-SETUP.md");
+    }
+
+    completion_screen(provider)?;
+    Ok(())
+}
+
+fn step_progress(step: usize, name: &str) {
+    ui::section(&format!("Step {step}/{TOTAL_STEPS} — {name}"));
+    render_gauge(step);
+}
+
+fn render_gauge(step: usize) {
+    let ratio = (step.saturating_sub(1) as f64 / TOTAL_STEPS as f64).min(1.0);
+    let label = format!(" {}/{TOTAL_STEPS} ", step.saturating_sub(1));
+
+    let gauge = Gauge::default()
+        .gauge_style(Style::default().fg(Color::Cyan).bg(Color::DarkGray))
+        .ratio(ratio)
+        .label(Span::styled(
+            label,
+            Style::default().add_modifier(Modifier::BOLD),
+        ));
+
+    let backend = ratatui::backend::CrosstermBackend::new(io::stderr());
+    if let Ok(mut terminal) = ratatui::Terminal::with_options(
+        backend,
+        ratatui::TerminalOptions {
+            viewport: ratatui::Viewport::Inline(1),
+        },
+    ) {
+        let _ = terminal.draw(|frame| {
+            frame.render_widget(gauge, frame.area());
+        });
+    }
+}
+
+fn welcome_screen() -> Result<()> {
+    let mut terminal = ratatui::init();
+    let result = welcome_loop(&mut terminal);
+    ratatui::restore();
+    result
+}
+
+fn welcome_loop(terminal: &mut DefaultTerminal) -> Result<()> {
+    loop {
+        terminal.draw(draw_welcome)?;
+
+        if event::poll(Duration::from_millis(250))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match key.code {
+                    KeyCode::Enter | KeyCode::Char(' ') => return Ok(()),
+                    KeyCode::Char('q') | KeyCode::Esc => {
+                        anyhow::bail!("setup cancelled");
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn draw_welcome(frame: &mut Frame) {
+    let area = centered_rect(52, 14, frame.area());
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Whetstone Setup",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from("  This wizard will install and configure:"),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("    1. ", Style::default().add_modifier(Modifier::DIM)),
+            Span::styled("Headroom", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" — context compression proxy"),
+        ]),
+        Line::from(vec![
+            Span::styled("    2. ", Style::default().add_modifier(Modifier::DIM)),
+            Span::styled("RTK", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" — CLI output compression"),
+        ]),
+        Line::from(vec![
+            Span::styled("    3. ", Style::default().add_modifier(Modifier::DIM)),
+            Span::styled("Memory", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" — persistent session context"),
+        ]),
+        Line::from(""),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Press Enter to begin, q to cancel",
+            Style::default().add_modifier(Modifier::DIM),
+        )),
+        Line::from(""),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn completion_screen(provider: MemoryProvider) -> Result<()> {
+    let mut terminal = ratatui::init();
+    let result = completion_loop(&mut terminal, provider);
+    ratatui::restore();
+    result
+}
+
+fn completion_loop(terminal: &mut DefaultTerminal, provider: MemoryProvider) -> Result<()> {
+    loop {
+        terminal.draw(|frame| draw_completion(frame, provider))?;
+
+        if event::poll(Duration::from_millis(250))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn draw_completion(frame: &mut Frame, provider: MemoryProvider) {
+    let area = centered_rect(52, 16, frame.area());
+
+    let headroom_ver = headroom::installed_version().unwrap_or_else(|| "—".into());
+    let rtk_ver = rtk::installed_version().unwrap_or_else(|| "—".into());
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  \u{2713} ",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "Setup Complete",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Installed:",
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(vec![
+            Span::styled("    \u{25cf} ", Style::default().fg(Color::Green)),
+            Span::raw(format!("Headroom {headroom_ver}")),
+        ]),
+        Line::from(vec![
+            Span::styled("    \u{25cf} ", Style::default().fg(Color::Green)),
+            Span::raw(format!("RTK {rtk_ver}")),
+        ]),
+    ];
+
+    match provider {
+        MemoryProvider::Icm => lines.push(Line::from(vec![
+            Span::styled("    \u{25cf} ", Style::default().fg(Color::Green)),
+            Span::raw("ICM (embedded SQLite)"),
+        ])),
+        MemoryProvider::AutoMem => lines.push(Line::from(vec![
+            Span::styled("    \u{25cf} ", Style::default().fg(Color::Green)),
+            Span::raw("AutoMem (graph memory)"),
+        ])),
+        MemoryProvider::Skip => lines.push(Line::from(vec![
+            Span::styled(
+                "    \u{25cb} ",
+                Style::default().add_modifier(Modifier::DIM),
+            ),
+            Span::styled(
+                "Memory provider skipped",
+                Style::default().add_modifier(Modifier::DIM),
+            ),
+        ])),
+    }
+
+    lines.extend([
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("  whetstone v{}", version::current()),
+            Style::default().add_modifier(Modifier::DIM),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Run: whetstone",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Press any key to exit",
+            Style::default().add_modifier(Modifier::DIM),
+        )),
+        Line::from(""),
+    ]);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(Span::styled(
+            " whetstone ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Fill(1),
+            Constraint::Length(height),
+            Constraint::Fill(1),
+        ])
+        .split(area);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Fill(1),
+            Constraint::Length(width),
+            Constraint::Fill(1),
+        ])
+        .split(vertical[1])[1]
+}


### PR DESCRIPTION
## Summary

- Replace `console`, `dialoguer`, and `indicatif` with `ratatui` + `crossterm` for all terminal rendering
- Add `whetstone dashboard` — fullscreen TUI showing component health, versions, and action shortcuts
- Add TUI setup wizard — multi-step interactive installer with progress gauge and fullscreen welcome/completion screens
- Fix noisy update output — capture installer stdout/stderr so `whetstone update` only shows clean status lines

## Changes

| Commit | Scope |
|--------|-------|
| `feat: replace console/dialoguer/indicatif with ratatui` | Rewrite ui.rs: status lines, prompts, spinner, upgrade banner, version report |
| `feat: add fullscreen TUI dashboard` | New `src/dashboard.rs`, CLI variant in `src/cli.rs` |
| `feat: add TUI setup wizard` | New `src/wizard.rs`, refactor `src/setup.rs` dispatch |
| `fix: suppress noisy installer output during update` | Quiet `uv`/`rtk` install in `headroom.rs`/`rtk.rs` |

**Net deps:** -3 (console, dialoguer, indicatif) +2 (ratatui, crossterm)

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings`
- [x] `cargo test` — 31/31 pass
- [x] `whetstone version` — inline component line renders correctly
- [x] `whetstone update` — clean status output, no installer noise
- [x] `whetstone dashboard` — fullscreen TUI, q to quit
- [ ] `whetstone setup` — interactive wizard in terminal, sequential fallback when piped