### PR TITLE
feat(update): detect and fix stale Claude Code native binary installs

### DIFF
--- a/src/claude_code.rs
+++ b/src/claude_code.rs
@@ -1,5 +1,7 @@
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
+use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 use crate::ui;
@@ -7,16 +9,16 @@ use crate::version;
 
 const NPM_REGISTRY_URL: &str = "https://registry.npmjs.org/@anthropic-ai/claude-code/latest";
 
-#[derive(Deserialize)]
-struct NpmPackage {
-    version: String,
+#[derive(Debug, PartialEq, Eq)]
+pub enum InstallMethod {
+    NativeBinary,
+    Npm,
+    Unknown,
 }
 
-pub fn latest_remote_version() -> Option<String> {
-    let resp = ureq::get(NPM_REGISTRY_URL).call().ok()?;
-    let body = resp.into_string().ok()?;
-    let parsed: NpmPackage = serde_json::from_str(&body).ok()?;
-    Some(parsed.version)
+#[derive(Deserialize)]
+struct NpmLatest {
+    version: String,
 }
 
 pub fn installed_version() -> Option<String> {
@@ -25,7 +27,64 @@ pub fn installed_version() -> Option<String> {
         return None;
     }
     let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    version::extract_semver(&raw)
+    parse_claude_version(&raw)
+}
+
+fn parse_claude_version(raw: &str) -> Option<String> {
+    let first_token = raw.split_whitespace().next()?;
+    version::extract_semver(first_token)
+}
+
+pub fn latest_npm_version() -> Option<String> {
+    let resp = ureq::get(NPM_REGISTRY_URL)
+        .set("Accept", "application/json")
+        .call()
+        .ok()?;
+    let body = resp.into_string().ok()?;
+    parse_npm_response(&body)
+}
+
+fn parse_npm_response(body: &str) -> Option<String> {
+    let parsed: NpmLatest = serde_json::from_str(body).ok()?;
+    version::extract_semver(&parsed.version)
+}
+
+pub fn install_method() -> InstallMethod {
+    detect_install_method_from_path(resolve_claude_binary())
+}
+
+fn resolve_claude_binary() -> Option<PathBuf> {
+    let output = Command::new("which").arg("claude").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let path = PathBuf::from(&path_str);
+    fs::canonicalize(&path).ok().or(Some(path))
+}
+
+fn detect_install_method_from_path(binary_path: Option<PathBuf>) -> InstallMethod {
+    let Some(path) = binary_path else {
+        return InstallMethod::Unknown;
+    };
+    let path_str = path.to_string_lossy();
+
+    if path_str.contains(".local/share/claude/versions/") {
+        return InstallMethod::NativeBinary;
+    }
+
+    if path_str.contains("node_modules")
+        || path_str.contains("/node/")
+        || path_str.contains("/nodejs/")
+        || path_str.contains("/mise/installs/node/")
+        || path_str.contains("/nvm/versions/node/")
+        || path_str.contains("/fnm/node-versions/")
+        || path_str.contains("/.volta/")
+    {
+        return InstallMethod::Npm;
+    }
+
+    InstallMethod::Unknown
 }
 
 pub fn update() -> Result<ui::ComponentStatus> {
@@ -33,28 +92,76 @@ pub fn update() -> Result<ui::ComponentStatus> {
         return Ok(ui::ComponentStatus::NotInstalled);
     };
 
-    let mut sp = ui::spinner(&format!("updating claude code from {old_ver}"));
+    let method = install_method();
 
-    // `claude update` silently no-ops in non-interactive (piped stdio) mode.
-    // Use the official install script which always works.
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg("curl -fsSL https://claude.ai/install.sh | sh")
+    match method {
+        InstallMethod::NativeBinary => update_from_native(&old_ver),
+        InstallMethod::Npm | InstallMethod::Unknown => update_via_npm(&old_ver),
+    }
+}
+
+fn update_from_native(old_ver: &str) -> Result<ui::ComponentStatus> {
+    ui::info("native binary detected — installing via npm to fix stale update channel");
+
+    run_npm_install()?;
+    cleanup_native_install();
+
+    let new_ver = installed_version().unwrap_or_else(|| old_ver.to_string());
+    if new_ver != old_ver {
+        Ok(ui::ComponentStatus::Updated(old_ver.to_string(), new_ver))
+    } else {
+        Ok(ui::ComponentStatus::UpToDate(old_ver.to_string()))
+    }
+}
+
+fn update_via_npm(old_ver: &str) -> Result<ui::ComponentStatus> {
+    run_npm_install()?;
+
+    let new_ver = installed_version().unwrap_or_else(|| old_ver.to_string());
+    if new_ver != old_ver {
+        Ok(ui::ComponentStatus::Updated(old_ver.to_string(), new_ver))
+    } else {
+        Ok(ui::ComponentStatus::UpToDate(old_ver.to_string()))
+    }
+}
+
+fn run_npm_install() -> Result<()> {
+    let output = Command::new("npm")
+        .args(["install", "-g", "@anthropic-ai/claude-code"])
         .output()
-        .context("failed to run claude code installer")?;
-
-    sp.finish_and_clear();
+        .context("failed to run npm install")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("claude code installer failed: {stderr}");
+        bail!("npm install -g @anthropic-ai/claude-code failed: {stderr}");
     }
 
-    let new_ver = installed_version().unwrap_or_else(|| old_ver.clone());
-    if new_ver != old_ver {
-        Ok(ui::ComponentStatus::Updated(old_ver, new_ver))
-    } else {
-        Ok(ui::ComponentStatus::UpToDate(old_ver))
+    Ok(())
+}
+
+fn cleanup_native_install() {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+
+    let symlink = home.join(".local/bin/claude");
+    let versions_dir = home.join(".local/share/claude");
+
+    if symlink.is_symlink() || symlink.exists() {
+        if let Ok(target) = fs::read_link(&symlink) {
+            if target
+                .to_string_lossy()
+                .contains(".local/share/claude/versions/")
+            {
+                ui::info("removing stale native binary symlink (~/.local/bin/claude)");
+                let _ = fs::remove_file(&symlink);
+            }
+        }
+    }
+
+    if versions_dir.is_dir() {
+        ui::info("removing stale native versions directory (~/.local/share/claude/)");
+        let _ = fs::remove_dir_all(&versions_dir);
     }
 }
 
@@ -63,22 +170,99 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_npm_registry_response() {
-        let json = r#"{"name":"@anthropic-ai/claude-code","version":"2.1.153"}"#;
-        let parsed: NpmPackage = serde_json::from_str(json).unwrap();
-        assert_eq!(parsed.version, "2.1.153");
-    }
-
-    #[test]
-    fn extract_version_from_cli_output() {
+    fn parse_claude_version_standard_format() {
         assert_eq!(
-            version::extract_semver("2.1.153 (Claude Code)"),
-            Some("2.1.153".into())
+            parse_claude_version("2.1.153 (Claude Code)"),
+            Some("2.1.153".into()),
         );
     }
 
     #[test]
-    fn extract_version_bare() {
-        assert_eq!(version::extract_semver("2.1.153"), Some("2.1.153".into()));
+    fn parse_claude_version_bare() {
+        assert_eq!(parse_claude_version("2.1.172"), Some("2.1.172".into()));
+    }
+
+    #[test]
+    fn parse_claude_version_empty() {
+        assert_eq!(parse_claude_version(""), None);
+    }
+
+    #[test]
+    fn parse_claude_version_garbage() {
+        assert_eq!(parse_claude_version("not a version"), None);
+    }
+
+    #[test]
+    fn parse_npm_response_valid() {
+        let body = r#"{"name":"@anthropic-ai/claude-code","version":"2.1.172"}"#;
+        assert_eq!(parse_npm_response(body), Some("2.1.172".into()));
+    }
+
+    #[test]
+    fn parse_npm_response_invalid_json() {
+        assert_eq!(parse_npm_response("{broken"), None);
+    }
+
+    #[test]
+    fn parse_npm_response_missing_version() {
+        assert_eq!(parse_npm_response(r#"{"name":"foo"}"#), None);
+    }
+
+    #[test]
+    fn detect_native_binary_path() {
+        let path = Some(PathBuf::from(
+            "/home/user/.local/share/claude/versions/2.1.153",
+        ));
+        assert_eq!(
+            detect_install_method_from_path(path),
+            InstallMethod::NativeBinary,
+        );
+    }
+
+    #[test]
+    fn detect_npm_via_mise() {
+        let path = Some(PathBuf::from(
+            "/home/user/.local/share/mise/installs/node/24.11.1/bin/claude",
+        ));
+        assert_eq!(detect_install_method_from_path(path), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn detect_npm_via_nvm() {
+        let path = Some(PathBuf::from(
+            "/home/user/.nvm/versions/node/v22.0.0/bin/claude",
+        ));
+        assert_eq!(detect_install_method_from_path(path), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn detect_npm_via_node_modules() {
+        let path = Some(PathBuf::from(
+            "/usr/lib/node_modules/@anthropic-ai/claude-code/bin/claude",
+        ));
+        assert_eq!(detect_install_method_from_path(path), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn detect_npm_via_volta() {
+        let path = Some(PathBuf::from("/home/user/.volta/bin/claude"));
+        assert_eq!(detect_install_method_from_path(path), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn detect_unknown_when_no_binary() {
+        assert_eq!(
+            detect_install_method_from_path(None),
+            InstallMethod::Unknown
+        );
+    }
+
+    #[test]
+    fn detect_unknown_for_unrecognized_path() {
+        let path = Some(PathBuf::from("/opt/custom/bin/claude"));
+        assert_eq!(
+            detect_install_method_from_path(path),
+            InstallMethod::Unknown,
+        );
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -442,7 +442,7 @@ pub fn run(full: bool) -> Result<()> {
     let whetstone_latest = fetch_remote_version()?;
     let rtk_remote = rtk::latest_remote_version();
     let headroom_remote = headroom::latest_remote_version();
-    let claude_code_remote = claude_code::latest_remote_version();
+    let claude_code_remote = claude_code::latest_npm_version();
     sp.finish_and_clear();
 
     let current = version::current().to_string();
@@ -725,8 +725,8 @@ mod tests {
             rtk_current: Some("0.42.3".into()),
             headroom_latest: Some("0.23.0".into()),
             headroom_current: Some("0.23.0".into()),
-            claude_code_latest: Some("2.1.0".into()),
-            claude_code_current: Some("2.1.0".into()),
+            claude_code_latest: Some("2.1.172".into()),
+            claude_code_current: Some("2.1.153".into()),
             integration_version_bundled: Some(INTEGRATION_VERSION),
             integration_version_project: Some(1),
             timestamp: 1_700_000_000,
@@ -739,6 +739,8 @@ mod tests {
             Some(INTEGRATION_VERSION)
         );
         assert_eq!(parsed.integration_version_project, Some(1));
+        assert_eq!(parsed.claude_code_latest, Some("2.1.172".into()));
+        assert_eq!(parsed.claude_code_current, Some("2.1.153".into()));
     }
 
     #[test]
@@ -757,5 +759,7 @@ mod tests {
         let parsed: VersionCache = serde_json::from_str(legacy).unwrap();
         assert_eq!(parsed.integration_version_bundled, None);
         assert_eq!(parsed.integration_version_project, None);
+        assert_eq!(parsed.claude_code_latest, None);
+        assert_eq!(parsed.claude_code_current, None);
     }
 }


### PR DESCRIPTION
## Summary

- Claude Code's native Linux binary updater checks `downloads.claude.ai/claude-code-releases/stable`, which frequently lags behind npm (e.g. returns 2.1.153 while npm has 2.1.172), causing `claude update` to silently report "up to date"
- Adds a new `claude_code` module that detects the install method (native binary vs npm/mise/nvm/volta/fnm), checks the npm registry for the latest version, and migrates native installs to npm
- Native binary installs get reinstalled via npm, then the stale symlink and versions directory are cleaned up
- `whetstone update` now shows a `claude code` component line alongside whetstone/rtk/headroom

## Test plan

- [x] 108 tests pass (11 new in `claude_code::tests` + existing)
- [x] clippy clean
- [ ] Manual: `whetstone update` on a machine with native binary install confirms migration
- [ ] Manual: `whetstone update` on a machine with npm install shows version correctly