### PR TITLE
fix(update): conditional --savings-profile and installMethod mismatch fix

### DIFF
--- a/src/claude_code.rs
+++ b/src/claude_code.rs
@@ -94,10 +94,14 @@ pub fn update() -> Result<ui::ComponentStatus> {
 
     let method = install_method();
 
-    match method {
+    let result = match method {
         InstallMethod::NativeBinary => update_from_native(&old_ver),
         InstallMethod::Npm | InstallMethod::Unknown => update_via_npm(&old_ver),
-    }
+    };
+
+    ensure_config_install_method_is_npm();
+
+    result
 }
 
 fn update_from_native(old_ver: &str) -> Result<ui::ComponentStatus> {
@@ -163,6 +167,47 @@ fn cleanup_native_install() {
         ui::info("removing stale native versions directory (~/.local/share/claude/)");
         let _ = fs::remove_dir_all(&versions_dir);
     }
+}
+
+fn ensure_config_install_method_is_npm() {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    fix_install_method_in_config(&home);
+}
+
+fn fix_install_method_in_config(home: &std::path::Path) {
+    let config_path = home.join(".claude.json");
+
+    let content = match fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let mut config: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let obj = match config.as_object_mut() {
+        Some(o) => o,
+        None => return,
+    };
+
+    if obj.get("installMethod").and_then(|v| v.as_str()) == Some("npm") {
+        return;
+    }
+
+    obj.insert(
+        "installMethod".to_string(),
+        serde_json::Value::String("npm".to_string()),
+    );
+
+    ui::info("fixing installMethod in ~/.claude.json (native → npm)");
+    let _ = fs::write(
+        &config_path,
+        serde_json::to_string_pretty(&config).unwrap_or_default(),
+    );
 }
 
 #[cfg(test)]
@@ -264,5 +309,64 @@ mod tests {
             detect_install_method_from_path(path),
             InstallMethod::Unknown,
         );
+    }
+
+    #[test]
+    fn fix_install_method_rewrites_native_to_npm() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join(".claude.json");
+        fs::write(&config, r#"{"installMethod":"native","numStartups":10}"#).unwrap();
+
+        fix_install_method_in_config(dir.path());
+
+        let result: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&config).unwrap()).unwrap();
+        assert_eq!(result["installMethod"], "npm");
+        assert_eq!(result["numStartups"], 10);
+    }
+
+    #[test]
+    fn fix_install_method_noop_when_already_npm() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join(".claude.json");
+        let original = r#"{"installMethod":"npm","numStartups":5}"#;
+        fs::write(&config, original).unwrap();
+
+        fix_install_method_in_config(dir.path());
+
+        let after = fs::read_to_string(&config).unwrap();
+        assert_eq!(after, original, "file should not be rewritten");
+    }
+
+    #[test]
+    fn fix_install_method_adds_field_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join(".claude.json");
+        fs::write(&config, r#"{"numStartups":1}"#).unwrap();
+
+        fix_install_method_in_config(dir.path());
+
+        let result: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&config).unwrap()).unwrap();
+        assert_eq!(result["installMethod"], "npm");
+    }
+
+    #[test]
+    fn fix_install_method_noop_when_no_config_file() {
+        let dir = tempfile::tempdir().unwrap();
+        fix_install_method_in_config(dir.path());
+        assert!(!dir.path().join(".claude.json").exists());
+    }
+
+    #[test]
+    fn fix_install_method_noop_for_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join(".claude.json");
+        let garbage = "not json {{{";
+        fs::write(&config, garbage).unwrap();
+
+        fix_install_method_in_config(dir.path());
+
+        assert_eq!(fs::read_to_string(&config).unwrap(), garbage);
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -67,13 +67,42 @@ fn probe_proxy() -> bool {
 
 fn spawn_proxy_detached() -> std::io::Result<()> {
     use std::process::Stdio;
+    let args = build_proxy_args(headroom_proxy_supports_savings_profile());
     Command::new("headroom")
-        .args(["proxy", "--port", "8787", "--savings-profile"])
+        .args(&args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
         .map(|_| ())
+}
+
+fn build_proxy_args(savings_profile: bool) -> Vec<&'static str> {
+    let mut args = vec!["proxy", "--port", "8787"];
+    if savings_profile {
+        args.push("--savings-profile");
+    }
+    args
+}
+
+fn headroom_proxy_supports_savings_profile() -> bool {
+    let output = Command::new("headroom")
+        .args(["proxy", "--help"])
+        .output()
+        .ok();
+
+    let Some(output) = output else {
+        return false;
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    proxy_help_mentions_flag(&stdout, "--savings-profile")
+        || proxy_help_mentions_flag(&stderr, "--savings-profile")
+}
+
+fn proxy_help_mentions_flag(help_text: &str, flag: &str) -> bool {
+    help_text.contains(flag)
 }
 
 // Default model — whetstone pins claude-opus-4-6 until it is fully deprecated.
@@ -435,5 +464,122 @@ exit 0
 
         assert!(path_has_rtk_binary(dir.clone()));
         cleanup_fake_rtk(&dir, &binary);
+    }
+
+    #[test]
+    fn build_proxy_args_without_savings_profile() {
+        let args = build_proxy_args(false);
+        assert_eq!(args, vec!["proxy", "--port", "8787"]);
+    }
+
+    #[test]
+    fn build_proxy_args_with_savings_profile() {
+        let args = build_proxy_args(true);
+        assert_eq!(args, vec!["proxy", "--port", "8787", "--savings-profile"]);
+    }
+
+    #[test]
+    fn proxy_help_mentions_flag_finds_present_flag() {
+        let help = "  --port INTEGER  Port to listen on\n  --savings-profile  Enable savings\n";
+        assert!(proxy_help_mentions_flag(help, "--savings-profile"));
+    }
+
+    #[test]
+    fn proxy_help_mentions_flag_rejects_absent_flag() {
+        let help = "  --port INTEGER  Port to listen on\n  --verbose  Verbose output\n";
+        assert!(!proxy_help_mentions_flag(help, "--savings-profile"));
+    }
+
+    #[test]
+    fn proxy_help_mentions_flag_empty_text() {
+        assert!(!proxy_help_mentions_flag("", "--savings-profile"));
+    }
+
+    #[test]
+    fn rtk_hook_program_extracts_bare_name() {
+        assert_eq!(rtk_hook_program("rtk hook claude"), Some("rtk"));
+    }
+
+    #[test]
+    fn rtk_hook_program_extracts_absolute_path() {
+        assert_eq!(
+            rtk_hook_program("/usr/local/bin/rtk hook claude"),
+            Some("/usr/local/bin/rtk")
+        );
+    }
+
+    #[test]
+    fn rtk_hook_program_strips_quotes() {
+        assert_eq!(rtk_hook_program("\"rtk\" hook claude"), Some("rtk"));
+    }
+
+    #[test]
+    fn rtk_hook_program_rejects_non_hook_command() {
+        assert_eq!(rtk_hook_program("rtk gain"), None);
+        assert_eq!(rtk_hook_program("echo hello"), None);
+    }
+
+    #[test]
+    fn program_ends_with_rtk_matches_bare_and_pathed() {
+        assert!(program_ends_with_rtk("rtk"));
+        assert!(program_ends_with_rtk("/usr/local/bin/rtk"));
+        assert!(program_ends_with_rtk("/home/user/.local/bin/rtk"));
+    }
+
+    #[test]
+    fn program_ends_with_rtk_rejects_non_rtk() {
+        assert!(!program_ends_with_rtk("not-rtk"));
+        assert!(!program_ends_with_rtk("/usr/bin/rtkx"));
+        assert!(!program_ends_with_rtk("rtk-rewrite.sh"));
+    }
+
+    #[test]
+    fn is_bare_rtk_program_only_matches_bare() {
+        assert!(is_bare_rtk_program("rtk"));
+        assert!(!is_bare_rtk_program("/usr/bin/rtk"));
+        assert!(!is_bare_rtk_program("./rtk"));
+    }
+
+    #[test]
+    fn build_claude_args_skips_no_rtk_when_not_requested() {
+        let args = build_claude_args(&[], false);
+        assert!(!args.contains(&"--no-rtk".to_string()));
+        assert!(args.contains(&"--model".to_string()));
+    }
+
+    #[test]
+    fn rtk_exists_on_path_returns_false_for_none() {
+        assert!(!rtk_exists_on_path(None));
+    }
+
+    #[test]
+    fn rtk_exists_on_path_returns_false_for_empty_path() {
+        assert!(!rtk_exists_on_path(Some(std::ffi::OsStr::new(""))));
+    }
+
+    #[test]
+    fn rtk_exists_on_path_finds_in_path_var() {
+        let (dir, binary) = create_fake_rtk_binary();
+        let path_str = dir.to_str().unwrap();
+        assert!(rtk_exists_on_path(Some(std::ffi::OsStr::new(path_str))));
+        cleanup_fake_rtk(&dir, &binary);
+    }
+
+    #[test]
+    fn settings_hook_detection_handles_empty_settings() {
+        let settings = json!({});
+        assert!(!settings_has_headroom_rtk_hook(&settings));
+    }
+
+    #[test]
+    fn settings_hook_detection_handles_empty_hooks() {
+        let settings = json!({ "hooks": {} });
+        assert!(!settings_has_headroom_rtk_hook(&settings));
+    }
+
+    #[test]
+    fn settings_hook_detection_handles_empty_pre_tool_use() {
+        let settings = json!({ "hooks": { "PreToolUse": [] } });
+        assert!(!settings_has_headroom_rtk_hook(&settings));
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -68,7 +68,7 @@ fn probe_proxy() -> bool {
 fn spawn_proxy_detached() -> std::io::Result<()> {
     use std::process::Stdio;
     Command::new("headroom")
-        .args(["proxy", "--port", "8787"])
+        .args(["proxy", "--port", "8787", "--savings-profile"])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())


### PR DESCRIPTION
## Summary
- Make `--savings-profile` flag conditional on headroom actually supporting it — probes `headroom proxy --help` before spawning the detached proxy, preventing silent startup failures on older headroom versions
- After every `whetstone update`, ensure `~/.claude.json` `installMethod` is set to `"npm"` — a stale `"native"` value causes Claude Code to report "claude command missing or broken" even when the npm binary works fine
- Adds 24 new tests covering proxy arg building, help text probing, rtk hook program parsing, installMethod config fixup edge cases, and previously untested wrapper utilities (112 → 136 total)

## Test plan
- [x] `cargo test` — 136 tests pass
- [x] `cargo clippy` — clean
- [x] Verify on a machine with older headroom (<0.26) that proxy starts without `--savings-profile`
- [x] Verify on a machine with `~/.claude.json` `installMethod: "native"` that `whetstone update` corrects it to `"npm"`