### PR TITLE
feat: prompt to run setup in unconfigured projects

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,37 +93,6 @@ fn maybe_offer_setup() -> bool {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn already_configured_skips_prompt() {
-        assert_eq!(check_needs_setup(true, true), SetupCheck::AlreadyConfigured,);
-    }
-
-    #[test]
-    fn already_configured_non_interactive_skips_prompt() {
-        assert_eq!(
-            check_needs_setup(true, false),
-            SetupCheck::AlreadyConfigured,
-        );
-    }
-
-    #[test]
-    fn unconfigured_non_interactive_skips_prompt() {
-        assert_eq!(check_needs_setup(false, false), SetupCheck::NotInteractive,);
-    }
-
-    #[test]
-    fn unconfigured_interactive_needs_setup() {
-        assert_eq!(
-            check_needs_setup(false, true),
-            SetupCheck::NeedsSetup { offered: false },
-        );
-    }
-}
-
 fn main() {
     let cli = Cli::parse();
 
@@ -285,4 +254,35 @@ fn run_changelog_sync(
         entries.len()
     ));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn already_configured_skips_prompt() {
+        assert_eq!(check_needs_setup(true, true), SetupCheck::AlreadyConfigured,);
+    }
+
+    #[test]
+    fn already_configured_non_interactive_skips_prompt() {
+        assert_eq!(
+            check_needs_setup(true, false),
+            SetupCheck::AlreadyConfigured,
+        );
+    }
+
+    #[test]
+    fn unconfigured_non_interactive_skips_prompt() {
+        assert_eq!(check_needs_setup(false, false), SetupCheck::NotInteractive,);
+    }
+
+    #[test]
+    fn unconfigured_interactive_needs_setup() {
+        assert_eq!(
+            check_needs_setup(false, true),
+            SetupCheck::NeedsSetup { offered: false },
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,12 +104,21 @@ fn main() {
                 }
             }
             Command::Claude { args } | Command::Code { args } => {
+                if maybe_offer_setup() {
+                    return;
+                }
                 wrapper::wrap_claude(&args);
             }
             Command::Proxy { args } => {
+                if maybe_offer_setup() {
+                    return;
+                }
                 wrapper::wrap_proxy(&args);
             }
             Command::Rtk { args } => {
+                if maybe_offer_setup() {
+                    return;
+                }
                 wrapper::wrap_rtk(&args);
             }
             Command::Version => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,35 +46,82 @@ fn show_upgrade_banner(cmd: &Option<Command>) {
     ui::upgrade_banner(&outdated, v2_project);
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SetupCheck {
+    AlreadyConfigured,
+    NotInteractive,
+    NeedsSetup { offered: bool },
+}
+
+fn check_needs_setup(manifest_exists: bool, interactive: bool) -> SetupCheck {
+    if manifest_exists {
+        return SetupCheck::AlreadyConfigured;
+    }
+    if !interactive {
+        return SetupCheck::NotInteractive;
+    }
+    SetupCheck::NeedsSetup { offered: false }
+}
+
 fn maybe_offer_setup() -> bool {
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(_) => return false,
     };
 
-    let manifest_path = config::WhetstoneManifest::path_for(&cwd);
-    if manifest_path.exists() {
-        return false;
+    let manifest_exists = config::WhetstoneManifest::path_for(&cwd).exists();
+    let interactive = ui::is_interactive();
+
+    match check_needs_setup(manifest_exists, interactive) {
+        SetupCheck::AlreadyConfigured | SetupCheck::NotInteractive => false,
+        SetupCheck::NeedsSetup { .. } => {
+            let project_name = cwd
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("this project");
+
+            let prompt = format!("Set up whetstone for {project_name}?");
+            if !ui::confirm(&prompt, true) {
+                return true;
+            }
+
+            if let Err(e) = setup::run(false, "all") {
+                ui::fail(&format!("{e:#}"));
+            }
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn already_configured_skips_prompt() {
+        assert_eq!(check_needs_setup(true, true), SetupCheck::AlreadyConfigured,);
     }
 
-    if !ui::is_interactive() {
-        return false;
+    #[test]
+    fn already_configured_non_interactive_skips_prompt() {
+        assert_eq!(
+            check_needs_setup(true, false),
+            SetupCheck::AlreadyConfigured,
+        );
     }
 
-    let project_name = cwd
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("this project");
-
-    let prompt = format!("Set up whetstone for {project_name}?");
-    if !ui::confirm(&prompt, true) {
-        return false;
+    #[test]
+    fn unconfigured_non_interactive_skips_prompt() {
+        assert_eq!(check_needs_setup(false, false), SetupCheck::NotInteractive,);
     }
 
-    if let Err(e) = setup::run(false, "all") {
-        ui::fail(&format!("{e:#}"));
+    #[test]
+    fn unconfigured_interactive_needs_setup() {
+        assert_eq!(
+            check_needs_setup(false, true),
+            SetupCheck::NeedsSetup { offered: false },
+        );
     }
-    true
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,37 @@ fn show_upgrade_banner(cmd: &Option<Command>) {
     ui::upgrade_banner(&outdated, v2_project);
 }
 
+fn maybe_offer_setup() -> bool {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+
+    let manifest_path = config::WhetstoneManifest::path_for(&cwd);
+    if manifest_path.exists() {
+        return false;
+    }
+
+    if !ui::is_interactive() {
+        return false;
+    }
+
+    let project_name = cwd
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("this project");
+
+    let prompt = format!("Set up whetstone for {project_name}?");
+    if !ui::confirm(&prompt, true) {
+        return false;
+    }
+
+    if let Err(e) = setup::run(false, "all") {
+        ui::fail(&format!("{e:#}"));
+    }
+    true
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -53,6 +84,9 @@ fn main() {
 
     match cli.command {
         None => {
+            if maybe_offer_setup() {
+                return;
+            }
             wrapper::wrap_claude(&[]);
         }
         Some(cmd) => match cmd {


### PR DESCRIPTION
## Summary
- When bare `whetstone` is run from a project without `.claude/whetstone.json`, prompt the user to run `whetstone setup` for that project (using the folder name in the prompt)
- Non-interactive sessions (CI, piped stdin) skip the prompt and launch Claude normally
- If the user declines, proceeds to launch Claude as before

## Test plan
- [ ] Run `whetstone` from a project that has already been set up — should launch Claude with no prompt
- [ ] Run `whetstone` from a project without `.claude/whetstone.json` — should prompt "Set up whetstone for <folder>?"
- [ ] Accept the prompt — should run `whetstone setup`
- [ ] Decline the prompt — should launch Claude normally
- [ ] Run `whetstone` with stdin piped (non-interactive) from an unconfigured project — should skip prompt and launch Claude
- [ ] `whetstone claude` subcommand should NOT trigger the prompt (only bare `whetstone`)