### PR TITLE
feat: settings TUI with global/project layering

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,9 @@ pub enum Command {
     /// Interactive dashboard
     Dashboard,
 
+    /// Modify project settings interactively
+    Settings,
+
     /// Inspect ~/.claude/settings.json and report problems (Phase 1 task 1.2)
     Doctor,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ use crate::memory::MemoryProvider;
 
 /// Bump this whenever the manifest schema gains/changes a required field.
 /// `whetstone update` uses it to decide when to rewrite the manifest in place.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Bump this whenever whetstone's *integration contract* changes — e.g. the
 /// expected hook layout shifts because we now delegate to a tool's init that
@@ -62,6 +62,72 @@ pub struct ToolVersions {
     pub headroom: Option<String>,
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub headroom_telemetry: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_model: Option<String>,
+}
+
+const GLOBAL_DIR: &str = ".whetstone";
+const GLOBAL_SETTINGS_FILENAME: &str = "settings.json";
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GlobalSettings {
+    #[serde(default)]
+    pub headroom_telemetry: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_model: Option<String>,
+}
+
+impl GlobalSettings {
+    pub fn path() -> Option<PathBuf> {
+        dirs::home_dir().map(|h| h.join(GLOBAL_DIR).join(GLOBAL_SETTINGS_FILENAME))
+    }
+
+    pub fn load() -> Result<Self> {
+        let Some(path) = Self::path() else {
+            return Ok(Self::default());
+        };
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let raw =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = Self::path().context("could not determine home directory")?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let pretty = serde_json::to_string_pretty(self).context("serializing global settings")?;
+        fs::write(&path, pretty).with_context(|| format!("writing {}", path.display()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSettings {
+    pub headroom_telemetry: bool,
+    pub api_model: Option<String>,
+}
+
+impl ResolvedSettings {
+    pub fn resolve(global: &GlobalSettings, project: &ProjectSettings) -> Self {
+        Self {
+            headroom_telemetry: project
+                .headroom_telemetry
+                .unwrap_or(global.headroom_telemetry),
+            api_model: project
+                .api_model
+                .clone()
+                .or_else(|| global.api_model.clone()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WhetstoneManifest {
     pub schema: u32,
@@ -70,6 +136,8 @@ pub struct WhetstoneManifest {
     pub provider: ProviderTag,
     #[serde(default)]
     pub tool_versions: ToolVersions,
+    #[serde(default)]
+    pub settings: ProjectSettings,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migration_id: Option<String>,
     pub created_at: DateTime<Utc>,
@@ -86,6 +154,7 @@ impl WhetstoneManifest {
             integration_version: INTEGRATION_VERSION,
             provider: provider.into(),
             tool_versions,
+            settings: ProjectSettings::default(),
             migration_id: None,
             created_at: now,
             updated_at: now,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod migrate;
 mod preflight;
 mod release;
 mod rtk;
+mod settings;
 mod setup;
 mod shell;
 mod stats;
@@ -172,6 +173,11 @@ fn main() {
             }
             Command::Dashboard => {
                 if let Err(e) = dashboard::run() {
+                    ui::fail(&format!("{e:#}"));
+                }
+            }
+            Command::Settings => {
+                if let Err(e) = settings::run() {
                     ui::fail(&format!("{e:#}"));
                 }
             }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -134,6 +134,9 @@ impl SettingsState {
     }
 
     fn current_model_display(&self, id: SettingId) -> Option<&str> {
+        if id != SettingId::ApiModel {
+            return None;
+        }
         match self.scope(id) {
             Scope::Off => None,
             Scope::Global => self.global.api_model.as_deref(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,597 @@
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    DefaultTerminal, Frame,
+};
+use std::time::Duration;
+
+use crate::config::{GlobalSettings, ProjectSettings, WhetstoneManifest};
+use crate::memory::MemoryProvider;
+use crate::ui;
+
+const KNOWN_MODELS: &[&str] = &[
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-fable-5",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Scope {
+    Off,
+    Global,
+    Project,
+}
+
+impl Scope {
+    fn cycle(self) -> Self {
+        match self {
+            Self::Off => Self::Global,
+            Self::Global => Self::Project,
+            Self::Project => Self::Off,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SettingId {
+    HeadroomTelemetry,
+    ApiModel,
+}
+
+const SETTINGS: &[SettingId] = &[SettingId::HeadroomTelemetry, SettingId::ApiModel];
+
+struct SettingsState {
+    global: GlobalSettings,
+    project: ProjectSettings,
+    original_global: GlobalSettings,
+    original_project: ProjectSettings,
+    selected: usize,
+}
+
+impl SettingsState {
+    fn scope(&self, id: SettingId) -> Scope {
+        match id {
+            SettingId::HeadroomTelemetry => match self.project.headroom_telemetry {
+                Some(true) => Scope::Project,
+                Some(false) => Scope::Off,
+                None if self.global.headroom_telemetry => Scope::Global,
+                None => Scope::Off,
+            },
+            SettingId::ApiModel => {
+                if self.project.api_model.is_some() {
+                    Scope::Project
+                } else if self.global.api_model.is_some() {
+                    Scope::Global
+                } else {
+                    Scope::Off
+                }
+            }
+        }
+    }
+
+    fn cycle_scope(&mut self, id: SettingId) {
+        let next = self.scope(id).cycle();
+        match id {
+            SettingId::HeadroomTelemetry => match next {
+                Scope::Off => {
+                    self.global.headroom_telemetry = false;
+                    self.project.headroom_telemetry = None;
+                }
+                Scope::Global => {
+                    self.global.headroom_telemetry = true;
+                    self.project.headroom_telemetry = None;
+                }
+                Scope::Project => {
+                    self.project.headroom_telemetry = Some(true);
+                }
+            },
+            SettingId::ApiModel => match next {
+                Scope::Off => {
+                    self.global.api_model = None;
+                    self.project.api_model = None;
+                }
+                Scope::Global => {
+                    if self.global.api_model.is_none() {
+                        self.global.api_model = Some(KNOWN_MODELS[0].to_string());
+                    }
+                    self.project.api_model = None;
+                }
+                Scope::Project => {
+                    let base = self
+                        .global
+                        .api_model
+                        .clone()
+                        .unwrap_or_else(|| KNOWN_MODELS[0].to_string());
+                    self.project.api_model = Some(base);
+                }
+            },
+        }
+    }
+
+    fn cycle_model_value(&mut self) {
+        let id = SETTINGS[self.selected];
+        if id != SettingId::ApiModel {
+            return;
+        }
+        let scope = self.scope(id);
+        let target = match scope {
+            Scope::Global => &mut self.global.api_model,
+            Scope::Project => &mut self.project.api_model,
+            Scope::Off => return,
+        };
+        let current = target.as_deref().unwrap_or(KNOWN_MODELS[0]);
+        let idx = KNOWN_MODELS
+            .iter()
+            .position(|m| *m == current)
+            .map(|i| (i + 1) % KNOWN_MODELS.len())
+            .unwrap_or(0);
+        *target = Some(KNOWN_MODELS[idx].to_string());
+    }
+
+    fn current_model_display(&self, id: SettingId) -> Option<&str> {
+        match self.scope(id) {
+            Scope::Off => None,
+            Scope::Global => self.global.api_model.as_deref(),
+            Scope::Project => self.project.api_model.as_deref(),
+        }
+    }
+
+    fn dirty(&self) -> bool {
+        self.global != self.original_global || self.project != self.original_project
+    }
+}
+
+pub fn run() -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let manifest_path = WhetstoneManifest::path_for(&cwd);
+
+    let (manifest, had_manifest) = match WhetstoneManifest::load(&manifest_path)? {
+        Some(m) => (Some(m), true),
+        None => (None, false),
+    };
+
+    let global = GlobalSettings::load()?;
+    let project = manifest
+        .as_ref()
+        .map(|m| m.settings.clone())
+        .unwrap_or_default();
+
+    let mut terminal = ratatui::init();
+    let result = run_loop(&mut terminal, global.clone(), project.clone());
+    ratatui::restore();
+
+    match result {
+        Ok(Some(saved)) => {
+            let global_changed = saved.global != global;
+            let project_changed = saved.project != project;
+
+            if global_changed {
+                saved.global.save()?;
+            }
+            if project_changed {
+                save_project_settings(&manifest_path, manifest, had_manifest, saved.project)?;
+            }
+
+            if global_changed || project_changed {
+                ui::ok("settings saved");
+            } else {
+                ui::info("no changes");
+            }
+        }
+        Ok(None) => {
+            ui::info("no changes");
+        }
+        Err(e) => return Err(e),
+    }
+
+    Ok(())
+}
+
+fn save_project_settings(
+    manifest_path: &std::path::Path,
+    existing: Option<WhetstoneManifest>,
+    had_manifest: bool,
+    project: ProjectSettings,
+) -> Result<()> {
+    let mut manifest = if had_manifest {
+        existing.unwrap()
+    } else {
+        WhetstoneManifest::new(MemoryProvider::Skip, crate::config::ToolVersions::default())
+    };
+    manifest.settings = project;
+    manifest.updated_at = chrono::Utc::now();
+
+    if let Some(parent) = manifest_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    manifest.save(manifest_path)
+}
+
+struct SavedState {
+    global: GlobalSettings,
+    project: ProjectSettings,
+}
+
+fn run_loop(
+    terminal: &mut DefaultTerminal,
+    global: GlobalSettings,
+    project: ProjectSettings,
+) -> Result<Option<SavedState>> {
+    let mut state = SettingsState {
+        original_global: global.clone(),
+        original_project: project.clone(),
+        global,
+        project,
+        selected: 0,
+    };
+
+    loop {
+        terminal.draw(|frame| draw(frame, &state))?;
+
+        if event::poll(Duration::from_millis(250))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => {
+                        if state.dirty() {
+                            return Ok(Some(SavedState {
+                                global: state.global,
+                                project: state.project,
+                            }));
+                        }
+                        return Ok(None);
+                    }
+                    KeyCode::Char(' ') => {
+                        state.cycle_scope(SETTINGS[state.selected]);
+                    }
+                    KeyCode::Tab | KeyCode::Enter => {
+                        state.cycle_model_value();
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        state.selected = state.selected.saturating_sub(1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') if state.selected + 1 < SETTINGS.len() => {
+                        state.selected += 1;
+                    }
+                    KeyCode::Char('s') => {
+                        return Ok(Some(SavedState {
+                            global: state.global,
+                            project: state.project,
+                        }));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn draw(frame: &mut Frame, state: &SettingsState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(6),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+    draw_header(frame, chunks[0], state.dirty());
+    draw_entries(frame, chunks[1], state);
+    draw_footer(frame, chunks[2]);
+}
+
+fn draw_header(frame: &mut Frame, area: Rect, dirty: bool) {
+    let title = if dirty {
+        " Settings (modified) "
+    } else {
+        " Settings "
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let paragraph = Paragraph::new(Line::from(Span::styled(
+        " whetstone configuration",
+        Style::default().add_modifier(Modifier::DIM),
+    )))
+    .block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn scope_spans(scope: Scope) -> Vec<Span<'static>> {
+    let dim = Style::default().fg(Color::DarkGray);
+    let active = Style::default()
+        .fg(Color::Green)
+        .add_modifier(Modifier::BOLD);
+
+    match scope {
+        Scope::Off => vec![
+            Span::styled("off", active),
+            Span::styled(" | ", dim),
+            Span::styled("g", dim),
+            Span::styled(" | ", dim),
+            Span::styled("p", dim),
+        ],
+        Scope::Global => vec![
+            Span::styled("off", dim),
+            Span::styled(" | ", dim),
+            Span::styled("g", active),
+            Span::styled(" | ", dim),
+            Span::styled("p", dim),
+        ],
+        Scope::Project => vec![
+            Span::styled("off", dim),
+            Span::styled(" | ", dim),
+            Span::styled("g", dim),
+            Span::styled(" | ", dim),
+            Span::styled("p", active),
+        ],
+    }
+}
+
+fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
+    let mut lines: Vec<Line<'_>> = vec![Line::from("")];
+
+    for (i, &id) in SETTINGS.iter().enumerate() {
+        let is_selected = i == state.selected;
+        let cursor = if is_selected { " › " } else { "   " };
+        let label_style = if is_selected {
+            Style::default().add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+
+        let (label, desc) = match id {
+            SettingId::HeadroomTelemetry => (
+                "Headroom Telemetry",
+                "Send anonymous usage data to Headroom",
+            ),
+            SettingId::ApiModel => ("API Model", "Model used for Claude Code sessions"),
+        };
+
+        let scope = state.scope(id);
+
+        let mut row = vec![Span::styled(
+            cursor,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )];
+        row.extend(scope_spans(scope));
+        row.push(Span::raw("  "));
+        row.push(Span::styled(label.to_string(), label_style));
+
+        if let Some(model) = state.current_model_display(id) {
+            row.push(Span::styled(
+                format!("  {model}"),
+                Style::default().fg(Color::Yellow),
+            ));
+        }
+
+        lines.push(Line::from(row));
+
+        let desc_line = if id == SettingId::ApiModel && scope != Scope::Off {
+            format!("{desc}  (tab to cycle model)")
+        } else {
+            desc.to_string()
+        };
+
+        lines.push(Line::from(vec![
+            Span::raw("                  "),
+            Span::styled(desc_line, Style::default().add_modifier(Modifier::DIM)),
+        ]));
+
+        lines.push(Line::from(""));
+    }
+
+    let block = Block::default().borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect) {
+    let help = Line::from(vec![
+        Span::styled(
+            " space",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(":scope "),
+        Span::styled(
+            "tab",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(":value "),
+        Span::styled(
+            "s",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(":save "),
+        Span::styled(
+            "q",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(":quit "),
+        Span::styled(
+            "↑↓",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(":navigate"),
+    ]);
+
+    let block = Block::default().borders(Borders::ALL);
+    let paragraph = Paragraph::new(help).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_state() -> SettingsState {
+        SettingsState {
+            global: GlobalSettings::default(),
+            project: ProjectSettings::default(),
+            original_global: GlobalSettings::default(),
+            original_project: ProjectSettings::default(),
+            selected: 0,
+        }
+    }
+
+    #[test]
+    fn scope_cycle_order() {
+        assert_eq!(Scope::Off.cycle(), Scope::Global);
+        assert_eq!(Scope::Global.cycle(), Scope::Project);
+        assert_eq!(Scope::Project.cycle(), Scope::Off);
+    }
+
+    #[test]
+    fn telemetry_scope_from_project_override() {
+        let mut s = default_state();
+        s.project.headroom_telemetry = Some(true);
+        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Project);
+
+        s.project.headroom_telemetry = Some(false);
+        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Off);
+    }
+
+    #[test]
+    fn telemetry_scope_from_global() {
+        let mut s = default_state();
+        s.global.headroom_telemetry = true;
+        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Global);
+    }
+
+    #[test]
+    fn telemetry_cycle_through_all_scopes() {
+        let mut s = default_state();
+        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Off);
+
+        s.cycle_scope(SettingId::HeadroomTelemetry);
+        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Global);
+        assert!(s.global.headroom_telemetry);
+
+        s.cycle_scope(SettingId::HeadroomTelemetry);
+        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Project);
+        assert_eq!(s.project.headroom_telemetry, Some(true));
+
+        s.cycle_scope(SettingId::HeadroomTelemetry);
+        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Off);
+    }
+
+    #[test]
+    fn model_scope_detection() {
+        let mut s = default_state();
+        assert_eq!(s.scope(SettingId::ApiModel), Scope::Off);
+
+        s.global.api_model = Some("claude-opus-4-6".into());
+        assert_eq!(s.scope(SettingId::ApiModel), Scope::Global);
+
+        s.project.api_model = Some("claude-sonnet-4-6".into());
+        assert_eq!(s.scope(SettingId::ApiModel), Scope::Project);
+    }
+
+    #[test]
+    fn model_cycle_through_scopes() {
+        let mut s = default_state();
+
+        s.cycle_scope(SettingId::ApiModel);
+        assert_eq!(s.scope(SettingId::ApiModel), Scope::Global);
+        assert_eq!(s.global.api_model.as_deref(), Some(KNOWN_MODELS[0]));
+
+        s.cycle_scope(SettingId::ApiModel);
+        assert_eq!(s.scope(SettingId::ApiModel), Scope::Project);
+        assert_eq!(s.project.api_model.as_deref(), Some(KNOWN_MODELS[0]));
+
+        s.cycle_scope(SettingId::ApiModel);
+        assert_eq!(s.scope(SettingId::ApiModel), Scope::Off);
+        assert!(s.global.api_model.is_none());
+        assert!(s.project.api_model.is_none());
+    }
+
+    #[test]
+    fn model_value_cycling() {
+        let mut s = default_state();
+        s.selected = 1;
+        s.global.api_model = Some(KNOWN_MODELS[0].to_string());
+
+        s.cycle_model_value();
+        assert_eq!(s.global.api_model.as_deref(), Some(KNOWN_MODELS[1]));
+
+        s.cycle_model_value();
+        assert_eq!(s.global.api_model.as_deref(), Some(KNOWN_MODELS[2]));
+    }
+
+    #[test]
+    fn model_value_cycling_wraps() {
+        let mut s = default_state();
+        s.selected = 1;
+        s.global.api_model = Some(KNOWN_MODELS[KNOWN_MODELS.len() - 1].to_string());
+
+        s.cycle_model_value();
+        assert_eq!(s.global.api_model.as_deref(), Some(KNOWN_MODELS[0]));
+    }
+
+    #[test]
+    fn model_value_cycle_noop_when_off() {
+        let mut s = default_state();
+        s.selected = 1;
+        s.cycle_model_value();
+        assert!(s.global.api_model.is_none());
+        assert!(s.project.api_model.is_none());
+    }
+
+    #[test]
+    fn model_value_cycle_noop_for_non_model_setting() {
+        let mut s = default_state();
+        s.selected = 0;
+        s.cycle_model_value();
+        assert!(s.global.api_model.is_none());
+    }
+
+    #[test]
+    fn dirty_detection() {
+        let mut s = default_state();
+        assert!(!s.dirty());
+        s.cycle_scope(SettingId::HeadroomTelemetry);
+        assert!(s.dirty());
+    }
+
+    #[test]
+    fn project_model_inherits_global_on_promote() {
+        let mut s = default_state();
+
+        s.cycle_scope(SettingId::ApiModel);
+        assert_eq!(s.scope(SettingId::ApiModel), Scope::Global);
+
+        s.global.api_model = Some("claude-sonnet-4-6".into());
+
+        s.cycle_scope(SettingId::ApiModel);
+        assert_eq!(s.scope(SettingId::ApiModel), Scope::Project);
+        assert_eq!(s.project.api_model.as_deref(), Some("claude-sonnet-4-6"));
+    }
+}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -23,9 +23,22 @@ pub fn wrap_claude(args: &[String]) -> ! {
     let proxy_ready = ensure_proxy_ready();
 
     let skip_rtk_setup = should_skip_headroom_rtk_setup();
-    let cmd_args = build_claude_args(args, skip_rtk_setup, proxy_ready);
+    let resolved = resolved_settings();
+    let model = resolved.api_model.as_deref().unwrap_or(DEFAULT_MODEL);
+    let cmd_args = build_claude_args(args, skip_rtk_setup, proxy_ready, model);
 
     exec("headroom", &cmd_args);
+}
+
+fn resolved_settings() -> crate::config::ResolvedSettings {
+    let global = crate::config::GlobalSettings::load().unwrap_or_default();
+    let cwd = env::current_dir().ok();
+    let project = cwd
+        .map(|d| crate::config::WhetstoneManifest::path_for(&d))
+        .and_then(|p| crate::config::WhetstoneManifest::load(&p).ok().flatten())
+        .map(|m| m.settings)
+        .unwrap_or_default();
+    crate::config::ResolvedSettings::resolve(&global, &project)
 }
 
 /// Phase 6.3: claude's first API call must hit a live proxy. The SessionStart
@@ -70,23 +83,36 @@ fn probe_proxy() -> bool {
 
 fn spawn_proxy_detached() -> std::io::Result<()> {
     use std::process::Stdio;
-    let args = build_proxy_args(headroom_proxy_supports_savings_profile());
-    Command::new("headroom")
-        .args(&args)
+    let telemetry_disabled = !headroom_telemetry_enabled();
+    let args = build_proxy_args(
+        headroom_proxy_supports_savings_profile(),
+        telemetry_disabled,
+    );
+    let mut cmd = Command::new("headroom");
+    cmd.args(&args)
         .env("HEADROOM_SAVINGS_PROFILE", required_savings_profile())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .map(|_| ())
+        .stderr(Stdio::null());
+    if telemetry_disabled {
+        cmd.env("HEADROOM_TELEMETRY", "off");
+    }
+    cmd.spawn().map(|_| ())
 }
 
-fn build_proxy_args(savings_profile: bool) -> Vec<&'static str> {
+fn build_proxy_args(savings_profile: bool, no_telemetry: bool) -> Vec<&'static str> {
     let mut args = vec!["proxy", "--port", "8787"];
     if savings_profile {
         args.push("--savings-profile");
     }
+    if no_telemetry {
+        args.push("--no-telemetry");
+    }
     args
+}
+
+fn headroom_telemetry_enabled() -> bool {
+    resolved_settings().headroom_telemetry
 }
 
 // The savings profile `headroom wrap claude` requires (headroom
@@ -135,15 +161,14 @@ fn proxy_help_mentions_flag(help_text: &str, flag: &str) -> bool {
 // alone.
 const DEFAULT_MODEL: &str = "claude-opus-4-6";
 
-fn build_claude_args(args: &[String], skip_rtk_setup: bool, proxy_ready: bool) -> Vec<String> {
+fn build_claude_args(
+    args: &[String],
+    skip_rtk_setup: bool,
+    proxy_ready: bool,
+    model: &str,
+) -> Vec<String> {
     let mut cmd_args = vec!["wrap".to_string(), "claude".to_string()];
 
-    // whetstone owns the proxy lifecycle (`ensure_proxy_ready`). When a proxy
-    // is already up, tell `headroom wrap` to skip its own proxy management with
-    // `--no-proxy`. Otherwise wrap compares the running proxy's savings profile
-    // and, on a mismatch, hot-restarts it — binding the port before the old
-    // proxy releases it and crashing with [Errno 98]. If we could not bring a
-    // proxy up, omit the flag so wrap can still try to start one as a fallback.
     if proxy_ready {
         cmd_args.push("--no-proxy".into());
     }
@@ -157,7 +182,7 @@ fn build_claude_args(args: &[String], skip_rtk_setup: bool, proxy_ready: bool) -
         .any(|a| a == "--model" || a.starts_with("--model="));
     if !user_set_model {
         cmd_args.push("--model".into());
-        cmd_args.push(DEFAULT_MODEL.into());
+        cmd_args.push(model.into());
     }
 
     cmd_args.extend_from_slice(args);
@@ -370,7 +395,7 @@ exit 0
 
     #[test]
     fn build_claude_args_injects_default_model_when_absent() {
-        let args = build_claude_args(&[], true, false);
+        let args = build_claude_args(&[], true, false, DEFAULT_MODEL);
 
         assert_eq!(
             args,
@@ -380,9 +405,13 @@ exit 0
 
     #[test]
     fn build_claude_args_preserves_explicit_model() {
-        let args = build_claude_args(&["--model".into(), "claude-sonnet".into()], false, false);
+        let args = build_claude_args(
+            &["--model".into(), "claude-sonnet".into()],
+            false,
+            false,
+            DEFAULT_MODEL,
+        );
 
-        // Explicit user --model wins; we do NOT add our default on top.
         assert_eq!(
             args,
             strings(&["wrap", "claude", "--model", "claude-sonnet"])
@@ -392,7 +421,12 @@ exit 0
 
     #[test]
     fn build_claude_args_preserves_explicit_model_equals_form() {
-        let args = build_claude_args(&["--model=claude-sonnet".into()], false, false);
+        let args = build_claude_args(
+            &["--model=claude-sonnet".into()],
+            false,
+            false,
+            DEFAULT_MODEL,
+        );
 
         assert_eq!(args, strings(&["wrap", "claude", "--model=claude-sonnet"]));
     }
@@ -403,9 +437,9 @@ exit 0
             &["--dangerously-skip-permissions".into(), "--print".into()],
             false,
             false,
+            DEFAULT_MODEL,
         );
 
-        // Default --model goes ahead of pass-through args.
         assert_eq!(
             args,
             strings(&[
@@ -416,6 +450,16 @@ exit 0
                 "--dangerously-skip-permissions",
                 "--print",
             ])
+        );
+    }
+
+    #[test]
+    fn build_claude_args_uses_configured_model() {
+        let args = build_claude_args(&[], false, false, "claude-sonnet-4-6");
+
+        assert_eq!(
+            args,
+            strings(&["wrap", "claude", "--model", "claude-sonnet-4-6"])
         );
     }
 
@@ -504,14 +548,35 @@ exit 0
 
     #[test]
     fn build_proxy_args_without_savings_profile() {
-        let args = build_proxy_args(false);
+        let args = build_proxy_args(false, false);
         assert_eq!(args, vec!["proxy", "--port", "8787"]);
     }
 
     #[test]
     fn build_proxy_args_with_savings_profile() {
-        let args = build_proxy_args(true);
+        let args = build_proxy_args(true, false);
         assert_eq!(args, vec!["proxy", "--port", "8787", "--savings-profile"]);
+    }
+
+    #[test]
+    fn build_proxy_args_with_no_telemetry() {
+        let args = build_proxy_args(false, true);
+        assert_eq!(args, vec!["proxy", "--port", "8787", "--no-telemetry"]);
+    }
+
+    #[test]
+    fn build_proxy_args_with_savings_profile_and_no_telemetry() {
+        let args = build_proxy_args(true, true);
+        assert_eq!(
+            args,
+            vec![
+                "proxy",
+                "--port",
+                "8787",
+                "--savings-profile",
+                "--no-telemetry"
+            ]
+        );
     }
 
     #[test]
@@ -599,22 +664,21 @@ exit 0
 
     #[test]
     fn build_claude_args_skips_no_rtk_when_not_requested() {
-        let args = build_claude_args(&[], false, false);
+        let args = build_claude_args(&[], false, false, DEFAULT_MODEL);
         assert!(!args.contains(&"--no-rtk".to_string()));
         assert!(args.contains(&"--model".to_string()));
     }
 
     #[test]
     fn build_claude_args_adds_no_proxy_when_proxy_ready() {
-        let args = build_claude_args(&[], false, true);
+        let args = build_claude_args(&[], false, true, DEFAULT_MODEL);
         assert!(args.contains(&"--no-proxy".to_string()));
-        // wrap subcommand stays first; --no-proxy is an option after it.
         assert_eq!(&args[0..2], &["wrap".to_string(), "claude".to_string()]);
     }
 
     #[test]
     fn build_claude_args_omits_no_proxy_when_proxy_not_ready() {
-        let args = build_claude_args(&[], false, false);
+        let args = build_claude_args(&[], false, false, DEFAULT_MODEL);
         assert!(!args.contains(&"--no-proxy".to_string()));
     }
 


### PR DESCRIPTION
## Summary
- Adds `whetstone settings` interactive TUI with ratatui for managing settings at global (`~/.whetstone/settings.json`) or project (`.claude/whetstone.json`) scope
- Each setting shows an `off | g | p` scope selector — space cycles scope, tab cycles value for multi-value settings
- Two settings: **Headroom Telemetry** (bool) and **API Model** (string, cycles known models)
- Global settings layer at `~/.whetstone/settings.json` with `GlobalSettings` load/save and `ResolvedSettings` merge (project wins over global)
- `ProjectSettings` fields are now `Option<T>` — absent means inherit from global, backward-compatible via `#[serde(default)]`
- Works without a project manifest; creates `.claude/whetstone.json` on save if a project-scoped setting is chosen
- Wrapper uses resolved `api_model` instead of hardcoded default

## Test plan
- [x] `cargo build` — compiles clean
- [x] `cargo test` — 160 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [ ] Run `whetstone settings` in a project with existing manifest — verify settings load and save
- [ ] Run `whetstone settings` in a directory without manifest — verify it opens, and setting something to `p` creates the manifest
- [ ] Set API Model to `p:claude-sonnet-4-6`, then run `whetstone` — verify `--model claude-sonnet-4-6` is passed
- [ ] Set Headroom Telemetry to `g`, verify `~/.whetstone/settings.json` is created with `headroom_telemetry: true`