### PR TITLE
fix: re-sync headroom MCP on update; prefer newest Sonnet as default model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Single binary distribution. Users run `whetstone setup` from inside a git projec
 
 <!-- AUTO-GENERATED: cli -->
 ```
-whetstone                              # Default: headroom wrap claude --model claude-opus-4-6
+whetstone                              # Default: headroom wrap claude (auto-selects newest available Sonnet; falls back to claude-opus-4-6)
 whetstone setup [--full] [--headroom-extras EXTRAS]
 whetstone uninstall
 whetstone claude [args...]

--- a/src/headroom.rs
+++ b/src/headroom.rs
@@ -235,6 +235,51 @@ pub fn learn() -> Result<bool> {
     );
 }
 
+/// Whether a serde_json value has a `mcpServers.headroom` entry.
+fn json_has_headroom_mcp(v: &serde_json::Value) -> bool {
+    v.get("mcpServers")
+        .and_then(|servers| servers.get("headroom"))
+        .is_some()
+}
+
+/// Whether the Headroom MCP server is registered in Claude Code's config
+/// (`~/.claude.json`). We only re-sync registrations the user already opted
+/// into — never force-add MCP for users who kept it off.
+fn mcp_registered() -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    let Ok(content) = fs::read_to_string(home.join(".claude.json")) else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(&content)
+        .map(|json| json_has_headroom_mcp(&json))
+        .unwrap_or(false)
+}
+
+/// After a headroom upgrade the registered MCP command (bare `headroom` vs. the
+/// absolute uv path) and `--proxy-url` can drift out of sync, which makes the
+/// `headroom_retrieve` tool warn on every session start. Re-run `mcp install`
+/// (scoped to Claude Code) to rewrite the entry — but only when it already
+/// exists. Best-effort; returns `Ok(false)` when nothing was registered.
+pub fn resync_mcp_if_registered() -> Result<bool> {
+    if !mcp_registered() {
+        return Ok(false);
+    }
+
+    let output = Command::new("headroom")
+        .args(["mcp", "install", "--agent", "claude", "--force"])
+        .output()
+        .context("failed to run `headroom mcp install`")?;
+
+    if output.status.success() {
+        Ok(true)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("headroom mcp install failed: {}", stderr.trim());
+    }
+}
+
 fn run_uv_install(spec: &str, upgrade: bool) -> Result<()> {
     let mut args = vec!["tool", "install"];
     if upgrade {
@@ -259,6 +304,28 @@ fn run_uv_install(spec: &str, upgrade: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn detects_registered_headroom_mcp() {
+        let json = serde_json::json!({
+            "mcpServers": { "headroom": { "command": "headroom", "args": ["mcp", "serve"] } }
+        });
+        assert!(json_has_headroom_mcp(&json));
+    }
+
+    #[test]
+    fn ignores_config_without_headroom_mcp() {
+        let json = serde_json::json!({
+            "mcpServers": { "icm": { "command": "icm" } }
+        });
+        assert!(!json_has_headroom_mcp(&json));
+    }
+
+    #[test]
+    fn ignores_config_without_mcp_servers() {
+        let json = serde_json::json!({ "projects": {} });
+        assert!(!json_has_headroom_mcp(&json));
+    }
 
     #[test]
     fn extras_all() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,6 +19,7 @@ use crate::ui;
 const FALLBACK_MODELS: &[&str] = &[
     "claude-opus-4-8",
     "claude-opus-4-6",
+    "claude-sonnet-5",
     "claude-sonnet-4-6",
     "claude-haiku-4-5-20251001",
     "claude-fable-5",
@@ -156,17 +157,45 @@ fn fetch_models_from_api() -> Option<Vec<String>> {
     Some(models)
 }
 
-fn load_available_models() -> Vec<String> {
+/// Available models from the 12h cache or the live API, or `None` when neither
+/// is reachable. Distinct from [`load_available_models`], which substitutes the
+/// static `FALLBACK_MODELS` — callers that need to know whether availability
+/// was *actually* determined (vs. guessed) use this instead.
+fn live_available_models() -> Option<Vec<String>> {
     if let Some(cached) = read_models_cache() {
-        return cached;
+        return Some(cached);
     }
 
     if let Some(fetched) = fetch_models_from_api() {
         write_models_cache(&fetched);
-        return fetched;
+        return Some(fetched);
     }
 
-    FALLBACK_MODELS.iter().map(|s| s.to_string()).collect()
+    None
+}
+
+fn load_available_models() -> Vec<String> {
+    live_available_models()
+        .unwrap_or_else(|| FALLBACK_MODELS.iter().map(|s| s.to_string()).collect())
+}
+
+/// Newest Sonnet in `models`, by lexical id (matching the descending sort the
+/// picker uses: `claude-sonnet-5` > `claude-sonnet-4-6`). `None` when the list
+/// has no Sonnet. Independent of input ordering so it's safe to unit-test.
+fn newest_sonnet(models: &[String]) -> Option<String> {
+    models
+        .iter()
+        .filter(|id| id.contains("-sonnet-"))
+        .max_by(|a, b| a.as_str().cmp(b.as_str()))
+        .cloned()
+}
+
+/// The model whetstone uses when the user hasn't pinned one: the newest
+/// available Sonnet per the live/cached models list. Returns `None` when
+/// availability can't be determined (offline / no `ANTHROPIC_API_KEY`) so the
+/// caller falls back to its own pinned default rather than guessing.
+pub fn preferred_default_model() -> Option<String> {
+    newest_sonnet(&live_available_models()?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -623,6 +652,35 @@ mod tests {
             selected: 0,
             models: test_models(),
         }
+    }
+
+    #[test]
+    fn newest_sonnet_picks_highest_version() {
+        let models = vec![
+            "claude-opus-4-8".to_string(),
+            "claude-sonnet-4-6".to_string(),
+            "claude-sonnet-5".to_string(),
+            "claude-haiku-4-5".to_string(),
+        ];
+        assert_eq!(newest_sonnet(&models).as_deref(), Some("claude-sonnet-5"));
+    }
+
+    #[test]
+    fn newest_sonnet_ignores_input_order() {
+        let models = vec![
+            "claude-sonnet-5".to_string(),
+            "claude-sonnet-4-6".to_string(),
+        ];
+        assert_eq!(newest_sonnet(&models).as_deref(), Some("claude-sonnet-5"));
+    }
+
+    #[test]
+    fn newest_sonnet_none_when_absent() {
+        let models = vec![
+            "claude-opus-4-8".to_string(),
+            "claude-haiku-4-5".to_string(),
+        ];
+        assert_eq!(newest_sonnet(&models), None);
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -497,6 +497,17 @@ pub fn run(full: bool) -> Result<()> {
     }
     ui::component_line("headroom", &headroom_status);
 
+    // A headroom upgrade can shift its binary path, leaving the registered MCP
+    // command stale and making `headroom_retrieve` warn every session start.
+    // Re-sync the registration (only if the user already had it installed).
+    if matches!(&headroom_status, ui::ComponentStatus::Updated(_, _)) {
+        match headroom::resync_mcp_if_registered() {
+            Ok(true) => ui::ok("re-synced headroom MCP registration"),
+            Ok(false) => {}
+            Err(e) => ui::warn(&format!("headroom MCP re-sync skipped: {e:#}")),
+        }
+    }
+
     let claude_code_status = match dependency_decision(
         claude_code_current.as_deref(),
         claude_code_remote.as_deref(),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -24,8 +24,8 @@ pub fn wrap_claude(args: &[String]) -> ! {
 
     let skip_rtk_setup = should_skip_headroom_rtk_setup();
     let resolved = resolved_settings();
-    let model = resolved.api_model.as_deref().unwrap_or(DEFAULT_MODEL);
-    let cmd_args = build_claude_args(args, skip_rtk_setup, proxy_ready, model);
+    let model = resolve_model(resolved.api_model.clone());
+    let cmd_args = build_claude_args(args, skip_rtk_setup, proxy_ready, &model);
 
     exec("headroom", &cmd_args);
 }
@@ -156,10 +156,21 @@ fn proxy_help_mentions_flag(help_text: &str, flag: &str) -> bool {
     help_text.contains(flag)
 }
 
-// Default model — whetstone pins claude-opus-4-6 until it is fully deprecated.
-// If the user (or a wrapping CLI layer) already passes `--model`, we leave it
-// alone.
+// Pinned fallback model — used only when the user hasn't selected one AND we
+// can't reach the models API to detect a newer Sonnet (offline / no
+// ANTHROPIC_API_KEY). If the user (or a wrapping CLI layer) already passes
+// `--model`, we leave it alone.
 const DEFAULT_MODEL: &str = "claude-opus-4-6";
+
+// Resolve the model to launch with, in priority order:
+//   1. an explicit selection stored in whetstone settings (`api_model`)
+//   2. the newest available Sonnet, per the 12h-cached models API
+//   3. the pinned `DEFAULT_MODEL` fallback
+fn resolve_model(explicit: Option<String>) -> String {
+    explicit
+        .or_else(crate::settings::preferred_default_model)
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string())
+}
 
 fn build_claude_args(
     args: &[String],
@@ -360,6 +371,14 @@ mod tests {
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn resolve_model_prefers_explicit_selection() {
+        assert_eq!(
+            resolve_model(Some("claude-sonnet-5".to_string())),
+            "claude-sonnet-5"
+        );
     }
 
     fn create_fake_rtk_binary() -> (PathBuf, PathBuf) {


### PR DESCRIPTION
## Summary

Two related fixes surfaced after a `whetstone update`.

### 1. MCP `retrieve` mismatch warning
A headroom upgrade can shift its binary path, leaving the registered `mcpServers.headroom` entry stale — bare `command: "headroom"` (or an old path) and no `--proxy-url` — so headroom's `retrieve` tool warns on every session start (`existing config differs`).

`whetstone update` now re-runs `headroom mcp install --agent claude --force` after a headroom upgrade, **only when the MCP was already registered** in `~/.claude.json` (never force-adds it for users who opted out).

- `headroom::resync_mcp_if_registered()` + `mcp_registered()` / `json_has_headroom_mcp()` helpers (`src/headroom.rs`)
- Wired into the headroom branch of `update::run()` (`src/update.rs`)

### 2. Default model prefers newest Sonnet
When no model is explicitly pinned, whetstone resolves the newest available Sonnet from the 12h-cached models API. It falls back to the pinned `claude-opus-4-6` when availability can't be determined (offline / no `ANTHROPIC_API_KEY`). Explicit selections (`api_model`) still win.

- `settings::preferred_default_model()` / `newest_sonnet()` / `live_available_models()` (`src/settings.rs`)
- `wrapper::resolve_model()` — explicit → newest Sonnet → pinned fallback (`src/wrapper.rs`)
- Added `claude-sonnet-5` to the offline fallback list so the picker lists it without an API key

## Test plan
- [x] `cargo test` — 172 passing (added `newest_sonnet`, `resolve_model`, and `json_has_headroom_mcp` cases)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: `whetstone update` on a machine with the headroom MCP registered re-syncs the entry without warning