### PR TITLE
feat: scope uninstall into project/global commands

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "rust-analyzer.server.path": "/home/zrk/.cursor/extensions/rust-lang.rust-analyzer-0.3.2921-linux-x64/server/rust-analyzer",
   "rust-analyzer.server.extraEnv": {
     "PATH": "/home/zrk/.local/share/mise/shims:/home/zrk/.cargo/bin:/usr/bin:/bin",
     "RUSTUP_HOME": "/home/zrk/.rustup",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to whetstone will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Anthropic API URL setting in `whetstone settings` — a custom upstream Anthropic API URL for the Headroom proxy, exported as `ANTHROPIC_TARGET_API_URL` before launch (project- or global-scoped; an externally-set env var takes precedence)
+
+### Changed
+
+- Split `whetstone uninstall` into `whetstone project uninstall` (removes per-project files) and `whetstone global uninstall` (removes the whetstone binary, RTK, and Headroom). The top-level `uninstall` command is deprecated: it now removes nothing and prints guidance toward the two scoped commands.
+
 ## [3.7.0] - 2026-07-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,12 @@ Whetstone is a Rust CLI that installs and configures three token optimization to
 
 - **Headroom** — HTTP proxy between Claude Code and the Anthropic API (50-90% context compression)
 - **RTK** — Hook that rewrites CLI commands to compress output before entering context (60-90% savings)
-- **Memory** — Persistent memory via ICM (embedded SQLite) or AutoMem (graph memory), with bundled skills and session hooks
+- **Memory** — Persistent project memory via ICM (embedded SQLite). ICM owns its own skills, hooks, and CLI, installed by `icm init --mode standard`.
 
-Single binary distribution. Users run `whetstone setup` from inside a git project. Global tools (Headroom, RTK) install once; skills, rules, and memory provider are configured per-project.
+Single binary distribution. Users run `whetstone setup` from inside a git project. Global tools (Headroom, RTK) install once; the memory provider and version-pinned manifest are configured per-project.
 
-**Bundled assets** in this repo:
-- `assets/skills/` — 20 skill directories (copied to project's `.claude/skills/`)
-- `assets/hooks/` — 5 hook `.sh` scripts (copied to `~/.claude/hooks/`)
-- `assets/rules/` — 8 rule `.md` files (copied to project's `.claude/rules/`)
-- `assets/commands/` — 2 command `.md` files (copied to project's `.claude/commands/`)
+**Bundled assets** in this repo (v3 ships only slash commands and the DB schema — skills, rules, and hook scripts are no longer vendored):
+- `assets/commands/` — slash command `.md` files (copied to project's `.claude/commands/`)
 - `assets/db/schema.sql` — SQLite schema for session database
 
 ## Commands
@@ -48,15 +45,22 @@ Single binary distribution. Users run `whetstone setup` from inside a git projec
 ```
 whetstone                              # Default: headroom wrap claude (auto-selects newest available Sonnet; falls back to claude-opus-4-6)
 whetstone setup [--full] [--headroom-extras EXTRAS]
-whetstone uninstall
+whetstone project uninstall            # Remove whetstone files from this project
+whetstone global uninstall             # Remove global binaries, RTK, Headroom
 whetstone claude [args...]
 whetstone code [args...]               # Alias for claude
 whetstone proxy [args...]
 whetstone rtk [args...]
 whetstone version
+whetstone dashboard                    # TUI: installed tool versions vs pinned floors
+whetstone settings                     # Interactive layered settings (global/project)
+whetstone doctor                       # Inspect ~/.claude/settings.json + manifest, report drift
+whetstone migrate [--dry-run] [-y] [--rollback ID]   # v2 → v3 migration (reversible)
+whetstone stats                        # Token savings across RTK + Headroom
 whetstone update [--full]
 whetstone release patch|minor|major|set X.Y.Z
 whetstone release-publish patch|minor|major|set X.Y.Z # Deprecated
+whetstone changelog-sync [--input F] [--output F] [--limit N]  # regen site/src/changelog.js
 whetstone db init|add-session|add-insight|search|get-sessions|...
 ```
 <!-- AUTO-GENERATED: end -->
@@ -65,37 +69,34 @@ whetstone db init|add-session|add-insight|search|get-sessions|...
 
 `--memory` is a global flag (e.g. `whetstone --memory`, `whetstone --memory claude`). It enables Headroom persistent cross-session memory by passing `--memory` to the proxy whetstone spawns. If a proxy is already running *without* memory, whetstone prompts: restart it with memory (replaces the global proxy), start a memory proxy for this session only, or cancel. It can also be set persistently per-project or globally via `whetstone settings` (Headroom Memory).
 
+`whetstone settings` also exposes **Anthropic API URL** — a custom upstream Anthropic API URL for the Headroom proxy. When set (per-project or globally), whetstone exports it as `ANTHROPIC_TARGET_API_URL` before launching Headroom, so the whetstone-spawned proxy targets that upstream (mirrors Headroom's `proxy --anthropic-api-url` flag). An externally-set `ANTHROPIC_TARGET_API_URL` env var takes precedence over the stored setting.
+
+On launch, whetstone (`src/model_update.rs`) checks the 12h-cached Anthropic models list for a model newer than the one this project runs — or a brand-new model family — and shows a full-screen modal offering to pin it as the project default (`api_model`), use it for one session, or dismiss it permanently (recorded in the manifest's top-level `dismissed_models`). The prompt is skipped when non-interactive, offline, not a v3 project, or when `--model` was passed explicitly.
+
 ## Architecture
 
 ```
 User → Claude Code
          ├── Bash calls → [RTK Hook] → rtk <cmd> → compressed output
          ├── Context    → [Headroom Proxy :8787] → Anthropic API
-         └── Memory     → [ICM or AutoMem] → persistent context
+         └── Memory     → [ICM, embedded SQLite] → persistent context
 ```
 
-**Setup flow** (`whetstone setup`, orchestrated by `src/setup.rs`):
-1. Preflight: verify Python 3.10+, git, curl, uv; confirm inside git repo
+**Setup flow** (`whetstone setup`, orchestrated by `src/setup.rs`). Setup first self-updates and offers v2→v3 migration; if the terminal is interactive it runs `src/wizard.rs`, otherwise the headless sequence below:
+1. Resolve assets; preflight-check dependencies (python, git, curl, uv)
 2. Install Headroom via `uv tool install "headroom-ai[EXTRAS]"` (extras configurable)
 3. Install RTK from GitHub (detects name collision with Rust Type Kit)
-4. Configure RTK hook globally + set `ANTHROPIC_BASE_URL` in shell profile
+4. Shell profile: set `ANTHROPIC_BASE_URL` + ensure `~/.local/bin` on PATH
 5. Self-install binary to `~/.local/bin/whetstone`
-6. Prompt for memory provider (ICM, AutoMem, or Skip)
-7. Copy skills, rules, commands, MEMSTACK.md; create config.local.json
-8. Install and configure chosen memory provider
-9. Copy hook scripts to `~/.claude/hooks/`; merge into `~/.claude/settings.json` (backed up with timestamp)
-10. Generate `STACK-SETUP.md`
+6. Prompt for memory provider (ICM or Skip)
+7. If a provider was chosen, `complete_setup`: copy slash commands, install the provider binary, run tool integrations (`src/integrations.rs`), run `doctor`, write the `.claude/whetstone.json` manifest, generate `STACK-SETUP.md`
 
-**Hook system** — registered in `~/.claude/settings.json`:
+**Hook system** — v3 no longer hand-writes `~/.claude/settings.json`. Whetstone delegates to each tool's own installer (`src/integrations.rs`), which writes its own hook entries; `whetstone doctor` reports drift.
 
-| Event | What Fires | Source |
-|-------|-----------|--------|
-| PreToolUse (Bash) | RTK rewrites command | RTK |
-| PreToolUse (Write/Edit/Bash) | TTS notification | whetstone |
-| PreToolUse (Bash, git push) | Build check + secrets scan | whetstone |
-| PostToolUse (git commit) | Debug artifact scan | whetstone |
-| SessionStart | Headroom auto-start + indexing | whetstone |
-| Stop | Session reporting | whetstone |
+| What Fires | Installed by |
+|-----------|--------------|
+| PreToolUse (Bash) — RTK rewrites the command | `rtk init --auto-patch` |
+| ICM slash commands, CLAUDE.md block, session hooks | `icm init --mode standard` |
 
 ## Source Layout
 
@@ -104,15 +105,23 @@ User → Claude Code
 src/
 ├── main.rs          # Entry: parse CLI, dispatch subcommands
 ├── cli.rs           # clap derive structs for all subcommands
-├── setup.rs         # whetstone setup orchestrator (8 steps)
+├── setup.rs         # whetstone setup orchestrator (headless path)
+├── wizard.rs        # Interactive setup wizard
 ├── uninstall.rs     # Interactive component removal
-├── wrapper.rs       # claude/proxy/rtk exec wrappers
-├── update.rs        # 12h-cached remote version check
+├── wrapper.rs       # claude/proxy/rtk exec wrappers; proxy + model resolution
+├── claude_code.rs   # Claude Code launch/detection helpers
+├── integrations.rs  # Delegates to `rtk init` / `icm init` (tool-managed hooks)
+├── migrate.rs       # v2 → v3 migration + reversible rollback
+├── doctor.rs        # Inspect settings.json + manifest, report drift
+├── dashboard.rs     # TUI: installed tool versions vs pinned floors
+├── settings.rs      # Interactive layered global/project settings TUI
+├── stats.rs         # Token-savings summary (RTK + Headroom)
+├── update.rs        # 12h-cached remote version check + self-update
 ├── release.rs       # Release preflight, version bump, and PR creation
+├── changelog.rs     # CHANGELOG.md parsing / site changelog sync
 ├── db.rs            # SQLite ops for session/memory database
-├── memory.rs        # MemoryProvider enum (ICM, AutoMem, Skip)
-├── hooks.rs         # Hook script copy + settings.json merge
-├── config.rs        # Typed structs for config.local.json
+├── memory.rs        # MemoryProvider enum (ICM, Skip)
+├── config.rs        # ProjectSettings/GlobalSettings + .claude/whetstone.json manifest
 ├── shell.rs         # Shell profile detection, env var injection
 ├── preflight.rs     # Dependency checks (python, git, curl, uv)
 ├── headroom.rs      # Headroom install/upgrade (extras configurable)
@@ -127,9 +136,9 @@ src/
 - **Single Rust binary**: replaces ~1200 lines Bash + ~460 lines Python
 - **Idempotent**: setup skips already-installed components; safe to rerun
 - **Absolute paths in hooks**: avoids PATH/shell-state issues
-- **Global tools, per-project config**: RTK/Headroom installed globally; memory provider and config are per-project
-- **Backup before modify**: `settings.json` backed up with timestamp before any merge
-- **No jq dependency**: serde_json replaces jq for settings.json manipulation
+- **Global tools, per-project config**: RTK/Headroom installed globally; memory provider and version-pinned manifest are per-project
+- **Tool-managed hooks**: v3 delegates `~/.claude/settings.json` hook entries to `rtk init` / `icm init`; whetstone never hand-merges them (`doctor` reports drift, `migrate` archives before touching state)
+- **Layered settings**: `GlobalSettings` (`~/.whetstone/settings.json`) and per-project `ProjectSettings` (in `.claude/whetstone.json`) resolve with project-over-global precedence
 - **rusqlite bundled**: statically links SQLite, no system dependency
 - **Asset resolution**: `WHETSTONE_ASSETS` env → `<binary_dir>/../assets/` → `~/.whetstone/assets/`
 
@@ -147,14 +156,13 @@ src/
 
 ### Repository Layout — Bundled Assets
 *~4,000 tokens/session saved*
-- `assets/skills/` contains ONLY skill files (flat, no subdirectories from external repos)
-- `assets/hooks/`, `assets/rules/`, `assets/commands/` contain runtime files
-- These directories are **static/vendored** — do NOT clone or pull external repos into them at install time; files are shipped with whetstone and should only change on a new whetstone release
+- v3 vendors **only** `assets/commands/` (slash commands) and `assets/db/schema.sql`. Skills, rules, and hook scripts are no longer bundled — ICM owns those via `icm init --mode standard`
+- These directories are **static/vendored** — do NOT clone or pull external repos into them at install time; files are shipped with whetstone and change only on a new whetstone release
 
 ### Install Constraints
 *~3,000 tokens/session saved*
-- `src/setup.rs` copies skills flat into `.claude/skills/` via `copy_dir_recursive` (no nested repo structure)
-- Never use `git clone` or `git submodule` for skills during install; copy bundled files only
+- `src/setup.rs` copies slash commands into `.claude/commands/` via `copy_dir_recursive`; provider assets come from the provider's own `init`
+- Never use `git clone` or `git submodule` during install; copy bundled files only
 - Verify with `cargo clippy` and `cargo test` after any edits
 
 ### Available Commands

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Full procedure, archive contents, and rollback semantics: [docs/migration.md](do
 - **Hooks are tool-managed.** Whetstone no longer hand-merges `~/.claude/settings.json`. `rtk init --auto-patch` and `icm init` write their own hook entries. `whetstone doctor` reports drift.
 - **Migration is mandatory.** Existing v2 installs must run `whetstone migrate` before any v3 command will configure them.
 - **`config.local.json` replaced by `.claude/whetstone.json`** (schema version, integration version, provider, tool versions, timestamps).
-- **Hardcoded `--model` injection removed.** `whetstone claude` no longer forces a model; Claude Code's own settings choose it.
+- **Default model is settings-driven.** `whetstone claude` injects `--model` using, in order: an explicit `api_model` from `whetstone settings`, else the newest available Sonnet (12h-cached models API), else `claude-opus-4-6`. (v3.0.0 dropped the old hardcoded model; #68 restored a settings-driven default.)
 
 Full release notes in [CHANGELOG.md](CHANGELOG.md).
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,13 +4,15 @@
 |---------|-------------|
 | `whetstone` | Start Claude Code through Headroom (waits for proxy, then `headroom wrap claude`) |
 | `whetstone setup [--full] [--headroom-extras EXTRAS]` | Install/configure all components (auto-detects v2 and hands off to `migrate`) |
-| `whetstone uninstall` | Interactive removal of components |
+| `whetstone project uninstall` | Interactive removal of whetstone files from the current project |
+| `whetstone global uninstall` | Interactive removal of global components (binaries, RTK, Headroom) |
 | `whetstone claude [args...]` | Run Claude Code through Headroom |
 | `whetstone code [args...]` | Alias for `claude` |
 | `whetstone proxy [args...]` | Run `headroom proxy` |
 | `whetstone rtk [args...]` | Run RTK |
 | `whetstone doctor` | Inspect installed tool versions, `~/.claude/settings.json` hooks, and the per-project manifest |
 | `whetstone dashboard` | TUI dashboard for installed tool versions vs. pinned floors |
+| `whetstone settings` | Interactively edit whetstone settings, layered global/project (Headroom telemetry, Headroom memory, default API model, Anthropic API URL) |
 | `whetstone migrate [--dry-run] [-y] [--rollback ID]` | Migrate a v2 install to v3 (or roll back) — see [Migration Guide](migration.md) |
 | `whetstone version` | Print version |
 | `whetstone stats` | Token-savings summary from RTK + Headroom stats endpoints |
@@ -18,6 +20,11 @@
 | `whetstone release patch\|minor\|major\|set X.Y.Z` | Verify, bump version, and open a release PR |
 | `whetstone release-publish ...` | **Deprecated** — use `whetstone release` |
 | `whetstone db <subcommand>` | Session database operations (init / add-session / add-insight / search / get-sessions / get-insights / stats) |
+| `whetstone changelog-sync [--input F] [--output F] [--limit N]` | Regenerate `site/src/changelog.js` from `CHANGELOG.md` (maintainer tooling) |
+
+The global `--memory` flag (e.g. `whetstone --memory` or `whetstone --memory claude`)
+enables Headroom persistent cross-session memory for that run. Persist it per-project
+or globally via `whetstone settings` (Headroom Memory).
 
 ## Headroom Extras
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,7 @@
 | File | Owner | Purpose |
 |------|-------|---------|
 | `~/.claude/settings.json` | RTK + whetstone | All hooks, including whetstone's absolute `.../rtk hook claude` command |
+| `~/.whetstone/settings.json` | whetstone | Global whetstone settings (Headroom telemetry/memory, default model, Anthropic API URL) |
 | `~/.claude/RTK.md` | RTK | RTK instructions for Claude Code context |
 | `~/.claude/CLAUDE.md` | Claude Code | Global instructions (references `@RTK.md`) |
 | `~/.headroom/models.json` | Headroom | Custom model context limits and pricing |
@@ -30,9 +31,28 @@
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `ANTHROPIC_BASE_URL` | (none) | Route API calls through Headroom proxy. Set to `http://127.0.0.1:8787` |
+| `ANTHROPIC_TARGET_API_URL` | (none) | Custom upstream Anthropic API URL the Headroom proxy targets. Whetstone exports it from the **Anthropic API URL** setting before launch; an externally-set value takes precedence |
 | `OPENAI_BASE_URL` | (none) | For OpenAI-compatible tools through Headroom. Set to `http://127.0.0.1:8787/v1` |
 | `HEADROOM_LOG_LEVEL` | `INFO` | Proxy logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `HEADROOM_PORT` | `8787` | Alternative to `--port` flag |
 | `HEADROOM_BUDGET` | (none) | Daily USD spending limit |
 | `HEADROOM_DEFAULT_MODE` | `optimize` | `optimize`, `audit` (observe only), or `off` |
 | `WHETSTONE_ASSETS` | (none) | Override path to assets directory |
+
+## Whetstone Settings
+
+`whetstone settings` opens an interactive TUI to edit layered settings. Each
+setting can be scoped **Off**, **Global**, or **Project**, with project values
+taking precedence over global ones.
+
+| Setting | Effect |
+|---------|--------|
+| Headroom Telemetry | Toggle Headroom telemetry |
+| Headroom Memory | Persist the `--memory` flag (Headroom cross-session memory) |
+| API Model | Default model injected into `headroom wrap claude` (otherwise: newest Sonnet, else `claude-opus-4-6`) |
+| Anthropic API URL | Custom upstream Anthropic API URL for the Headroom proxy (exported as `ANTHROPIC_TARGET_API_URL`) |
+
+Values persist to:
+
+- **Global** — `~/.whetstone/settings.json`
+- **Project** — the `settings` block of `.claude/whetstone.json`

--- a/docs/interface-contract.md
+++ b/docs/interface-contract.md
@@ -57,7 +57,7 @@ the pinned 0.23.0. If we later pin a version that lacks `wrap`, the fallback
 is: `headroom proxy` in background + `exec ANTHROPIC_BASE_URL=… claude …`.
 
 Inverse exists: `headroom unwrap` undoes durable wrapping. Useful for the
-v3 `whetstone uninstall` path.
+v3 `whetstone global uninstall` path.
 
 ## 0.2 — Init verbs and ICM import verb
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -91,10 +91,13 @@ cp ~/.claude/settings.json.bak.NEWEST ~/.claude/settings.json
 ## Uninstall
 
 ```bash
-whetstone uninstall
+whetstone project uninstall    # Remove whetstone files from the current project
+whetstone global uninstall     # Remove the whetstone binary, RTK, and Headroom
 ```
 
-Interactive prompts let you choose which components to remove (whetstone binary, RTK, Headroom, project files).
+Interactive prompts let you choose which components to remove. `project uninstall`
+handles per-project files; `global uninstall` handles the whetstone binary, RTK,
+and Headroom.
 
 ### Manual removal
 
@@ -128,7 +131,8 @@ cp ~/.claude/settings.json.bak.TIMESTAMP ~/.claude/settings.json
 
 **Full cleanup:**
 ```bash
-whetstone uninstall
+whetstone project uninstall
+whetstone global uninstall
 rm -f ~/.local/bin/whetstone
 rm -rf ~/.whetstone
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,8 +31,20 @@ pub enum Command {
         headroom_extras: String,
     },
 
-    /// Remove whetstone components
+    /// Deprecated: use `project uninstall` or `global uninstall`
     Uninstall,
+
+    /// Project-scoped operations
+    Project {
+        #[command(subcommand)]
+        action: ProjectCommand,
+    },
+
+    /// Global operations
+    Global {
+        #[command(subcommand)]
+        action: GlobalCommand,
+    },
 
     /// Start Claude Code via headroom wrap (default when no subcommand given)
     Claude {
@@ -126,6 +138,19 @@ pub enum Command {
         #[command(subcommand)]
         action: DbCommand,
     },
+}
+
+#[derive(Subcommand)]
+pub enum ProjectCommand {
+    /// Remove whetstone files from this project directory
+    Uninstall,
+}
+
+#[derive(Subcommand)]
+pub enum GlobalCommand {
+    /// Remove globally-installed whetstone components
+    /// (binaries, RTK, Headroom)
+    Uninstall,
 }
 
 #[derive(Subcommand, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,8 @@ pub struct ProjectSettings {
     pub headroom_memory: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anthropic_api_url: Option<String>,
 }
 
 const GLOBAL_DIR: &str = ".whetstone";
@@ -83,6 +85,8 @@ pub struct GlobalSettings {
     pub headroom_memory: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anthropic_api_url: Option<String>,
 }
 
 impl GlobalSettings {
@@ -117,6 +121,7 @@ pub struct ResolvedSettings {
     pub headroom_telemetry: bool,
     pub headroom_memory: bool,
     pub api_model: Option<String>,
+    pub anthropic_api_url: Option<String>,
 }
 
 impl ResolvedSettings {
@@ -130,6 +135,10 @@ impl ResolvedSettings {
                 .api_model
                 .clone()
                 .or_else(|| global.api_model.clone()),
+            anthropic_api_url: project
+                .anthropic_api_url
+                .clone()
+                .or_else(|| global.anthropic_api_url.clone()),
         }
     }
 }
@@ -222,6 +231,43 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn resolve_prefers_project_anthropic_api_url() {
+        let global = GlobalSettings {
+            anthropic_api_url: Some("https://global.example".into()),
+            ..Default::default()
+        };
+        let project = ProjectSettings {
+            anthropic_api_url: Some("https://project.example".into()),
+            ..Default::default()
+        };
+        let resolved = ResolvedSettings::resolve(&global, &project);
+        assert_eq!(
+            resolved.anthropic_api_url.as_deref(),
+            Some("https://project.example")
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_global_anthropic_api_url() {
+        let global = GlobalSettings {
+            anthropic_api_url: Some("https://global.example".into()),
+            ..Default::default()
+        };
+        let resolved = ResolvedSettings::resolve(&global, &ProjectSettings::default());
+        assert_eq!(
+            resolved.anthropic_api_url.as_deref(),
+            Some("https://global.example")
+        );
+    }
+
+    #[test]
+    fn resolve_anthropic_api_url_none_when_unset() {
+        let resolved =
+            ResolvedSettings::resolve(&GlobalSettings::default(), &ProjectSettings::default());
+        assert!(resolved.anthropic_api_url.is_none());
+    }
 
     #[test]
     fn provider_round_trip() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,11 +118,21 @@ fn main() {
                     ui::fail(&format!("{e:#}"));
                 }
             }
-            Command::Uninstall => {
-                if let Err(e) = uninstall::run() {
-                    ui::fail(&format!("{e:#}"));
+            Command::Uninstall => uninstall::run_deprecated_notice(),
+            Command::Project { action } => match action {
+                cli::ProjectCommand::Uninstall => {
+                    if let Err(e) = uninstall::run_project() {
+                        ui::fail(&format!("{e:#}"));
+                    }
                 }
-            }
+            },
+            Command::Global { action } => match action {
+                cli::GlobalCommand::Uninstall => {
+                    if let Err(e) = uninstall::run_global() {
+                        ui::fail(&format!("{e:#}"));
+                    }
+                }
+            },
             Command::Claude { args } | Command::Code { args } => {
                 if maybe_offer_setup() {
                     return;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -220,12 +220,14 @@ enum SettingId {
     HeadroomTelemetry,
     HeadroomMemory,
     ApiModel,
+    AnthropicApiUrl,
 }
 
 const SETTINGS: &[SettingId] = &[
     SettingId::HeadroomTelemetry,
     SettingId::HeadroomMemory,
     SettingId::ApiModel,
+    SettingId::AnthropicApiUrl,
 ];
 
 struct SettingsState {
@@ -235,6 +237,9 @@ struct SettingsState {
     original_project: ProjectSettings,
     selected: usize,
     models: Vec<String>,
+    /// `Some(buffer)` while the user is typing a free-text value (the Anthropic
+    /// API URL); `None` in normal navigation mode.
+    editing: Option<String>,
 }
 
 impl SettingsState {
@@ -256,6 +261,15 @@ impl SettingsState {
                 if self.project.api_model.is_some() {
                     Scope::Project
                 } else if self.global.api_model.is_some() {
+                    Scope::Global
+                } else {
+                    Scope::Off
+                }
+            }
+            SettingId::AnthropicApiUrl => {
+                if self.project.anthropic_api_url.is_some() {
+                    Scope::Project
+                } else if self.global.anthropic_api_url.is_some() {
                     Scope::Global
                 } else {
                     Scope::Off
@@ -313,6 +327,22 @@ impl SettingsState {
                     self.project.api_model = Some(base);
                 }
             },
+            SettingId::AnthropicApiUrl => match next {
+                Scope::Off => {
+                    self.global.anthropic_api_url = None;
+                    self.project.anthropic_api_url = None;
+                }
+                Scope::Global => {
+                    if self.global.anthropic_api_url.is_none() {
+                        self.global.anthropic_api_url = Some(String::new());
+                    }
+                    self.project.anthropic_api_url = None;
+                }
+                Scope::Project => {
+                    let base = self.global.anthropic_api_url.clone().unwrap_or_default();
+                    self.project.anthropic_api_url = Some(base);
+                }
+            },
         }
     }
 
@@ -337,14 +367,55 @@ impl SettingsState {
         *target = Some(self.models[idx].clone());
     }
 
-    fn current_model_display(&self, id: SettingId) -> Option<&str> {
-        if id != SettingId::ApiModel {
-            return None;
+    /// The stored value shown next to a value-bearing setting (model id or API
+    /// URL), or `None` for toggle settings and `Scope::Off`.
+    fn current_value_display(&self, id: SettingId) -> Option<&str> {
+        match id {
+            SettingId::ApiModel => match self.scope(id) {
+                Scope::Off => None,
+                Scope::Global => self.global.api_model.as_deref(),
+                Scope::Project => self.project.api_model.as_deref(),
+            },
+            SettingId::AnthropicApiUrl => match self.scope(id) {
+                Scope::Off => None,
+                Scope::Global => self.global.anthropic_api_url.as_deref(),
+                Scope::Project => self.project.anthropic_api_url.as_deref(),
+            },
+            _ => None,
         }
-        match self.scope(id) {
-            Scope::Off => None,
-            Scope::Global => self.global.api_model.as_deref(),
-            Scope::Project => self.project.api_model.as_deref(),
+    }
+
+    /// Enter text-editing mode for the currently selected URL setting, seeding
+    /// the buffer with the active value. No-op unless the selection is the
+    /// Anthropic API URL and its scope is active.
+    fn begin_edit(&mut self) {
+        let id = SETTINGS[self.selected];
+        if id != SettingId::AnthropicApiUrl || self.scope(id) == Scope::Off {
+            return;
+        }
+        let current = self
+            .current_value_display(id)
+            .unwrap_or_default()
+            .to_string();
+        self.editing = Some(current);
+    }
+
+    /// Commit the in-progress edit buffer into the active scope, then leave edit
+    /// mode. A blank buffer clears the value (which drops the scope to `Off`).
+    fn commit_edit(&mut self) {
+        let Some(buffer) = self.editing.take() else {
+            return;
+        };
+        let trimmed = buffer.trim();
+        let value = (!trimmed.is_empty()).then(|| trimmed.to_string());
+        match self.scope(SettingId::AnthropicApiUrl) {
+            Scope::Global | Scope::Off => {
+                self.global.anthropic_api_url = value;
+                self.project.anthropic_api_url = None;
+            }
+            Scope::Project => {
+                self.project.anthropic_api_url = value;
+            }
         }
     }
 
@@ -375,7 +446,8 @@ pub fn run() -> Result<()> {
     ratatui::restore();
 
     match result {
-        Ok(Some(saved)) => {
+        Ok(Some(mut saved)) => {
+            normalize_saved(&mut saved);
             let global_changed = saved.global != global;
             let project_changed = saved.project != project;
 
@@ -426,6 +498,18 @@ struct SavedState {
     project: ProjectSettings,
 }
 
+/// Drop blank free-text values (a scope was toggled on but never filled in) to
+/// `None` so an empty API URL never persists to disk.
+fn normalize_saved(saved: &mut SavedState) {
+    let blank = |v: &Option<String>| v.as_deref().map(str::trim).is_some_and(str::is_empty);
+    if blank(&saved.global.anthropic_api_url) {
+        saved.global.anthropic_api_url = None;
+    }
+    if blank(&saved.project.anthropic_api_url) {
+        saved.project.anthropic_api_url = None;
+    }
+}
+
 fn run_loop(
     terminal: &mut DefaultTerminal,
     global: GlobalSettings,
@@ -439,6 +523,7 @@ fn run_loop(
         project,
         selected: 0,
         models,
+        editing: None,
     };
 
     loop {
@@ -447,6 +532,10 @@ fn run_loop(
         if event::poll(Duration::from_millis(250))? {
             if let Event::Key(key) = event::read()? {
                 if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                if state.editing.is_some() {
+                    handle_edit_key(&mut state, key.code);
                     continue;
                 }
                 match key.code {
@@ -462,9 +551,11 @@ fn run_loop(
                     KeyCode::Char(' ') => {
                         state.cycle_scope(SETTINGS[state.selected]);
                     }
-                    KeyCode::Tab | KeyCode::Enter => {
-                        state.cycle_model_value();
-                    }
+                    KeyCode::Tab | KeyCode::Enter => match SETTINGS[state.selected] {
+                        SettingId::ApiModel => state.cycle_model_value(),
+                        SettingId::AnthropicApiUrl => state.begin_edit(),
+                        _ => {}
+                    },
                     KeyCode::Up | KeyCode::Char('k') => {
                         state.selected = state.selected.saturating_sub(1);
                     }
@@ -481,6 +572,28 @@ fn run_loop(
                 }
             }
         }
+    }
+}
+
+/// Route a keypress while the URL text buffer is open. Enter commits, Esc
+/// cancels, and printable characters / Backspace edit the buffer in place.
+fn handle_edit_key(state: &mut SettingsState, code: KeyCode) {
+    match code {
+        KeyCode::Enter => state.commit_edit(),
+        KeyCode::Esc => {
+            state.editing = None;
+        }
+        KeyCode::Backspace => {
+            if let Some(buffer) = state.editing.as_mut() {
+                buffer.pop();
+            }
+        }
+        KeyCode::Char(c) => {
+            if let Some(buffer) = state.editing.as_mut() {
+                buffer.push(c);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -577,9 +690,14 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
                 "Enable Headroom persistent cross-session memory (proxy --memory)",
             ),
             SettingId::ApiModel => ("API Model", "Model used for Claude Code sessions"),
+            SettingId::AnthropicApiUrl => (
+                "Anthropic API URL",
+                "Custom upstream Anthropic API URL for the Headroom proxy",
+            ),
         };
 
         let scope = state.scope(id);
+        let is_editing = is_selected && id == SettingId::AnthropicApiUrl && state.editing.is_some();
 
         let mut row = vec![Span::styled(
             cursor,
@@ -591,9 +709,22 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
         row.push(Span::raw("  "));
         row.push(Span::styled(label.to_string(), label_style));
 
-        if let Some(model) = state.current_model_display(id) {
+        if is_editing {
+            let buffer = state.editing.as_deref().unwrap_or_default();
             row.push(Span::styled(
-                format!("  {model}"),
+                format!("  {buffer}"),
+                Style::default().fg(Color::Yellow),
+            ));
+            row.push(Span::styled(
+                "█",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::DIM),
+            ));
+        } else if let Some(value) = state.current_value_display(id) {
+            let shown = if value.is_empty() { "(unset)" } else { value };
+            row.push(Span::styled(
+                format!("  {shown}"),
                 Style::default().fg(Color::Yellow),
             ));
         }
@@ -602,6 +733,12 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
 
         let desc_line = if id == SettingId::ApiModel && scope != Scope::Off {
             format!("{desc}  (tab to cycle model)")
+        } else if id == SettingId::AnthropicApiUrl && scope != Scope::Off {
+            if is_editing {
+                format!("{desc}  (enter to save, esc to cancel)")
+            } else {
+                format!("{desc}  (enter to edit)")
+            }
         } else {
             desc.to_string()
         };
@@ -679,7 +816,145 @@ mod tests {
             original_project: ProjectSettings::default(),
             selected: 0,
             models: test_models(),
+            editing: None,
         }
+    }
+
+    fn url_index() -> usize {
+        SETTINGS
+            .iter()
+            .position(|&s| s == SettingId::AnthropicApiUrl)
+            .unwrap()
+    }
+
+    #[test]
+    fn api_url_scope_detection() {
+        let mut s = default_state();
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Off);
+
+        s.global.anthropic_api_url = Some("https://global.example".into());
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Global);
+
+        s.project.anthropic_api_url = Some("https://project.example".into());
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Project);
+    }
+
+    #[test]
+    fn api_url_cycle_through_scopes() {
+        let mut s = default_state();
+
+        s.cycle_scope(SettingId::AnthropicApiUrl);
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Global);
+        assert_eq!(s.global.anthropic_api_url.as_deref(), Some(""));
+
+        s.cycle_scope(SettingId::AnthropicApiUrl);
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Project);
+        assert_eq!(s.project.anthropic_api_url.as_deref(), Some(""));
+
+        s.cycle_scope(SettingId::AnthropicApiUrl);
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Off);
+        assert!(s.global.anthropic_api_url.is_none());
+        assert!(s.project.anthropic_api_url.is_none());
+    }
+
+    #[test]
+    fn begin_edit_noop_when_scope_off() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.begin_edit();
+        assert!(s.editing.is_none());
+    }
+
+    #[test]
+    fn begin_edit_seeds_buffer_with_current_value() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.global.anthropic_api_url = Some("https://seed.example".into());
+        s.begin_edit();
+        assert_eq!(s.editing.as_deref(), Some("https://seed.example"));
+    }
+
+    #[test]
+    fn commit_edit_writes_global_value() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.global.anthropic_api_url = Some(String::new());
+        s.editing = Some("https://typed.example".into());
+        s.commit_edit();
+        assert!(s.editing.is_none());
+        assert_eq!(
+            s.global.anthropic_api_url.as_deref(),
+            Some("https://typed.example")
+        );
+    }
+
+    #[test]
+    fn commit_edit_writes_project_value() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.project.anthropic_api_url = Some(String::new());
+        s.editing = Some("  https://project.example  ".into());
+        s.commit_edit();
+        assert_eq!(
+            s.project.anthropic_api_url.as_deref(),
+            Some("https://project.example")
+        );
+    }
+
+    #[test]
+    fn commit_edit_blank_clears_value() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.global.anthropic_api_url = Some("https://old.example".into());
+        s.editing = Some("   ".into());
+        s.commit_edit();
+        assert!(s.global.anthropic_api_url.is_none());
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Off);
+    }
+
+    #[test]
+    fn edit_key_typing_and_backspace() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.editing = Some(String::new());
+        handle_edit_key(&mut s, KeyCode::Char('h'));
+        handle_edit_key(&mut s, KeyCode::Char('i'));
+        handle_edit_key(&mut s, KeyCode::Backspace);
+        assert_eq!(s.editing.as_deref(), Some("h"));
+    }
+
+    #[test]
+    fn normalize_saved_drops_blank_urls() {
+        let mut saved = SavedState {
+            global: GlobalSettings {
+                anthropic_api_url: Some(String::new()),
+                ..Default::default()
+            },
+            project: ProjectSettings {
+                anthropic_api_url: Some("https://keep.example".into()),
+                ..Default::default()
+            },
+        };
+        normalize_saved(&mut saved);
+        assert!(saved.global.anthropic_api_url.is_none());
+        assert_eq!(
+            saved.project.anthropic_api_url.as_deref(),
+            Some("https://keep.example")
+        );
+    }
+
+    #[test]
+    fn edit_key_esc_cancels_without_writing() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.global.anthropic_api_url = Some("https://keep.example".into());
+        s.editing = Some("https://discard.example".into());
+        handle_edit_key(&mut s, KeyCode::Esc);
+        assert!(s.editing.is_none());
+        assert_eq!(
+            s.global.anthropic_api_url.as_deref(),
+            Some("https://keep.example")
+        );
     }
 
     #[test]

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -5,10 +5,35 @@ use std::process::Command;
 
 use crate::ui;
 
-pub fn run() -> Result<()> {
-    ui::info("whetstone uninstall");
+/// Deprecated entry point for the old top-level `uninstall` command.
+/// Guides the user to the scoped replacements without removing anything.
+pub fn run_deprecated_notice() {
+    ui::warn("`whetstone uninstall` is deprecated and does nothing on its own.");
+    ui::info("Use one of the scoped commands instead:");
+    ui::info("  whetstone project uninstall   # remove files from this project");
+    ui::info("  whetstone global uninstall    # remove binaries, RTK, Headroom");
+}
+
+/// Remove whetstone files from the current project directory only.
+pub fn run_project() -> Result<()> {
+    ui::info("whetstone project uninstall");
     let project_dir = std::env::current_dir()?;
     eprintln!("project dir: {}", project_dir.display());
+
+    if ui::confirm("Remove whetstone files from this project directory?", false) {
+        remove_project_files(&project_dir);
+    } else {
+        ui::warn("skipped project file removal");
+        return Ok(());
+    }
+
+    ui::ok("whetstone project uninstall finished");
+    Ok(())
+}
+
+/// Remove globally-installed whetstone components: binaries, RTK, Headroom.
+pub fn run_global() -> Result<()> {
+    ui::info("whetstone global uninstall");
 
     remove_bins();
 
@@ -24,15 +49,9 @@ pub fn run() -> Result<()> {
         ui::warn("skipped Headroom removal");
     }
 
-    if ui::confirm("Remove whetstone files from this project directory?", false) {
-        remove_project_files(&project_dir);
-    } else {
-        ui::warn("skipped project file removal");
-    }
-
     ui::warn("review shell rc files and remove ANTHROPIC_BASE_URL if unwanted");
     ui::info("restore ~/.claude/settings.json from .bak.* backups if needed");
-    ui::ok("whetstone uninstall finished");
+    ui::ok("whetstone global uninstall finished");
     Ok(())
 }
 
@@ -83,8 +102,8 @@ fn remove_headroom() {
 
 fn remove_project_files(project_dir: &Path) {
     let claude = project_dir.join(".claude");
-    if !claude.join("skills").is_dir() {
-        ui::info(&format!("no .claude/skills in {}", project_dir.display()));
+    if !claude.is_dir() {
+        ui::info(&format!("no .claude in {}", project_dir.display()));
         return;
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -19,10 +19,41 @@ fn set_proxy_env() {
     }
 }
 
+// The env var headroom reads for a custom upstream Anthropic API URL (its
+// `proxy --anthropic-api-url` flag mirrors this). Setting it here propagates to
+// both the detached `headroom proxy` child and the exec'd `headroom wrap`.
+const ANTHROPIC_TARGET_API_URL: &str = "ANTHROPIC_TARGET_API_URL";
+
+/// Export the configured upstream Anthropic API URL so a whetstone-spawned
+/// headroom proxy targets it. An externally-set env var wins over the stored
+/// setting, and blank/whitespace settings are ignored.
+fn apply_anthropic_api_url(setting: Option<&str>) {
+    if let Some(url) = resolve_anthropic_api_url(setting, env::var(ANTHROPIC_TARGET_API_URL).ok()) {
+        env::set_var(ANTHROPIC_TARGET_API_URL, url);
+    }
+}
+
+/// Pure resolution for [`apply_anthropic_api_url`]: an existing non-empty env
+/// override takes precedence; otherwise a non-blank setting is used. `None`
+/// means "leave the environment untouched".
+fn resolve_anthropic_api_url(
+    setting: Option<&str>,
+    existing_env: Option<String>,
+) -> Option<String> {
+    if existing_env.is_some_and(|v| !v.trim().is_empty()) {
+        return None;
+    }
+    setting
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 pub fn wrap_claude(args: &[String], memory_flag: bool) -> ! {
     set_proxy_env();
 
     let resolved = resolved_settings();
+    apply_anthropic_api_url(resolved.anthropic_api_url.as_deref());
     let want_memory = memory_flag || resolved.headroom_memory;
     let decision = resolve_proxy(want_memory);
 
@@ -527,6 +558,39 @@ mod tests {
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn resolve_api_url_uses_setting_when_env_unset() {
+        assert_eq!(
+            resolve_anthropic_api_url(Some("https://proxy.example"), None),
+            Some("https://proxy.example".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_api_url_env_override_wins() {
+        assert_eq!(
+            resolve_anthropic_api_url(
+                Some("https://setting.example"),
+                Some("https://env.example".to_string())
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_api_url_ignores_blank_setting() {
+        assert_eq!(resolve_anthropic_api_url(Some("   "), None), None);
+        assert_eq!(resolve_anthropic_api_url(None, None), None);
+    }
+
+    #[test]
+    fn resolve_api_url_ignores_blank_env_override() {
+        assert_eq!(
+            resolve_anthropic_api_url(Some("https://setting.example"), Some("  ".to_string())),
+            Some("https://setting.example".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Split the top-level `whetstone uninstall` into two scoped commands:
  - `whetstone project uninstall` — removes whetstone files from the current project directory
  - `whetstone global uninstall` — removes the whetstone binary, RTK, and Headroom
- Kept `whetstone uninstall` as a **deprecated no-op** that removes nothing and prints guidance toward the two scoped commands.
- Fixed a stale v3 guard in `remove_project_files` (it bailed on missing `.claude/skills`, which v3 projects no longer vendor — now guards on `.claude` existing).
- Also bundles the in-progress **Anthropic API URL** setting for `whetstone settings` (exported as `ANTHROPIC_TARGET_API_URL` before Headroom launch) and doc refreshes noting ICM owns its own skills/hooks/CLI.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy` — no issues
- [x] `cargo test` — 199 passed
- [x] `whetstone project uninstall --help` / `whetstone global uninstall --help` resolve
- [x] `whetstone uninstall` prints the deprecation notice and removes nothing