### PR TITLE
feat: launch-time model-update prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to whetstone will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Launch-time model-update prompt: when Anthropic ships a model newer than the one this project runs — or a brand-new model family — `whetstone` shows a full-screen modal offering to pin it as the project default, use it for one session only, or dismiss it. Dismissals are remembered per-project (`dismissed_models` in `.claude/whetstone.json`). The prompt is skipped when non-interactive, offline, not a v3 project, or when `--model` is passed explicitly.
+- Anthropic API URL setting in `whetstone settings` — a custom upstream Anthropic API URL for the Headroom proxy, exported as `ANTHROPIC_TARGET_API_URL` before launch (project- or global-scoped; an externally-set env var takes precedence)
+
 ## [3.7.0] - 2026-07-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,12 @@ Whetstone is a Rust CLI that installs and configures three token optimization to
 
 - **Headroom** — HTTP proxy between Claude Code and the Anthropic API (50-90% context compression)
 - **RTK** — Hook that rewrites CLI commands to compress output before entering context (60-90% savings)
-- **Memory** — Persistent memory via ICM (embedded SQLite) or AutoMem (graph memory), with bundled skills and session hooks
+- **Memory** — Persistent project memory via ICM (embedded SQLite). ICM owns its own skills, hooks, and CLI, installed by `icm init --mode standard`.
 
-Single binary distribution. Users run `whetstone setup` from inside a git project. Global tools (Headroom, RTK) install once; skills, rules, and memory provider are configured per-project.
+Single binary distribution. Users run `whetstone setup` from inside a git project. Global tools (Headroom, RTK) install once; the memory provider and version-pinned manifest are configured per-project.
 
-**Bundled assets** in this repo:
-- `assets/skills/` — 20 skill directories (copied to project's `.claude/skills/`)
-- `assets/hooks/` — 5 hook `.sh` scripts (copied to `~/.claude/hooks/`)
-- `assets/rules/` — 8 rule `.md` files (copied to project's `.claude/rules/`)
-- `assets/commands/` — 2 command `.md` files (copied to project's `.claude/commands/`)
+**Bundled assets** in this repo (v3 ships only slash commands and the DB schema — skills, rules, and hook scripts are no longer vendored):
+- `assets/commands/` — slash command `.md` files (copied to project's `.claude/commands/`)
 - `assets/db/schema.sql` — SQLite schema for session database
 
 ## Commands
@@ -54,9 +51,15 @@ whetstone code [args...]               # Alias for claude
 whetstone proxy [args...]
 whetstone rtk [args...]
 whetstone version
+whetstone dashboard                    # TUI: installed tool versions vs pinned floors
+whetstone settings                     # Interactive layered settings (global/project)
+whetstone doctor                       # Inspect ~/.claude/settings.json + manifest, report drift
+whetstone migrate [--dry-run] [-y] [--rollback ID]   # v2 → v3 migration (reversible)
+whetstone stats                        # Token savings across RTK + Headroom
 whetstone update [--full]
 whetstone release patch|minor|major|set X.Y.Z
 whetstone release-publish patch|minor|major|set X.Y.Z # Deprecated
+whetstone changelog-sync [--input F] [--output F] [--limit N]  # regen site/src/changelog.js
 whetstone db init|add-session|add-insight|search|get-sessions|...
 ```
 <!-- AUTO-GENERATED: end -->
@@ -65,37 +68,32 @@ whetstone db init|add-session|add-insight|search|get-sessions|...
 
 `--memory` is a global flag (e.g. `whetstone --memory`, `whetstone --memory claude`). It enables Headroom persistent cross-session memory by passing `--memory` to the proxy whetstone spawns. If a proxy is already running *without* memory, whetstone prompts: restart it with memory (replaces the global proxy), start a memory proxy for this session only, or cancel. It can also be set persistently per-project or globally via `whetstone settings` (Headroom Memory).
 
+`whetstone settings` also exposes **Anthropic API URL** — a custom upstream Anthropic API URL for the Headroom proxy. When set (per-project or globally), whetstone exports it as `ANTHROPIC_TARGET_API_URL` before launching Headroom, so the whetstone-spawned proxy targets that upstream (mirrors Headroom's `proxy --anthropic-api-url` flag). An externally-set `ANTHROPIC_TARGET_API_URL` env var takes precedence over the stored setting.
+
 ## Architecture
 
 ```
 User → Claude Code
          ├── Bash calls → [RTK Hook] → rtk <cmd> → compressed output
          ├── Context    → [Headroom Proxy :8787] → Anthropic API
-         └── Memory     → [ICM or AutoMem] → persistent context
+         └── Memory     → [ICM, embedded SQLite] → persistent context
 ```
 
-**Setup flow** (`whetstone setup`, orchestrated by `src/setup.rs`):
-1. Preflight: verify Python 3.10+, git, curl, uv; confirm inside git repo
+**Setup flow** (`whetstone setup`, orchestrated by `src/setup.rs`). Setup first self-updates and offers v2→v3 migration; if the terminal is interactive it runs `src/wizard.rs`, otherwise the headless sequence below:
+1. Resolve assets; preflight-check dependencies (python, git, curl, uv)
 2. Install Headroom via `uv tool install "headroom-ai[EXTRAS]"` (extras configurable)
 3. Install RTK from GitHub (detects name collision with Rust Type Kit)
-4. Configure RTK hook globally + set `ANTHROPIC_BASE_URL` in shell profile
+4. Shell profile: set `ANTHROPIC_BASE_URL` + ensure `~/.local/bin` on PATH
 5. Self-install binary to `~/.local/bin/whetstone`
-6. Prompt for memory provider (ICM, AutoMem, or Skip)
-7. Copy skills, rules, commands, MEMSTACK.md; create config.local.json
-8. Install and configure chosen memory provider
-9. Copy hook scripts to `~/.claude/hooks/`; merge into `~/.claude/settings.json` (backed up with timestamp)
-10. Generate `STACK-SETUP.md`
+6. Prompt for memory provider (ICM or Skip)
+7. If a provider was chosen, `complete_setup`: copy slash commands, install the provider binary, run tool integrations (`src/integrations.rs`), run `doctor`, write the `.claude/whetstone.json` manifest, generate `STACK-SETUP.md`
 
-**Hook system** — registered in `~/.claude/settings.json`:
+**Hook system** — v3 no longer hand-writes `~/.claude/settings.json`. Whetstone delegates to each tool's own installer (`src/integrations.rs`), which writes its own hook entries; `whetstone doctor` reports drift.
 
-| Event | What Fires | Source |
-|-------|-----------|--------|
-| PreToolUse (Bash) | RTK rewrites command | RTK |
-| PreToolUse (Write/Edit/Bash) | TTS notification | whetstone |
-| PreToolUse (Bash, git push) | Build check + secrets scan | whetstone |
-| PostToolUse (git commit) | Debug artifact scan | whetstone |
-| SessionStart | Headroom auto-start + indexing | whetstone |
-| Stop | Session reporting | whetstone |
+| What Fires | Installed by |
+|-----------|--------------|
+| PreToolUse (Bash) — RTK rewrites the command | `rtk init --auto-patch` |
+| ICM slash commands, CLAUDE.md block, session hooks | `icm init --mode standard` |
 
 ## Source Layout
 
@@ -104,15 +102,23 @@ User → Claude Code
 src/
 ├── main.rs          # Entry: parse CLI, dispatch subcommands
 ├── cli.rs           # clap derive structs for all subcommands
-├── setup.rs         # whetstone setup orchestrator (8 steps)
+├── setup.rs         # whetstone setup orchestrator (headless path)
+├── wizard.rs        # Interactive setup wizard
 ├── uninstall.rs     # Interactive component removal
-├── wrapper.rs       # claude/proxy/rtk exec wrappers
-├── update.rs        # 12h-cached remote version check
+├── wrapper.rs       # claude/proxy/rtk exec wrappers; proxy + model resolution
+├── claude_code.rs   # Claude Code launch/detection helpers
+├── integrations.rs  # Delegates to `rtk init` / `icm init` (tool-managed hooks)
+├── migrate.rs       # v2 → v3 migration + reversible rollback
+├── doctor.rs        # Inspect settings.json + manifest, report drift
+├── dashboard.rs     # TUI: installed tool versions vs pinned floors
+├── settings.rs      # Interactive layered global/project settings TUI
+├── stats.rs         # Token-savings summary (RTK + Headroom)
+├── update.rs        # 12h-cached remote version check + self-update
 ├── release.rs       # Release preflight, version bump, and PR creation
+├── changelog.rs     # CHANGELOG.md parsing / site changelog sync
 ├── db.rs            # SQLite ops for session/memory database
-├── memory.rs        # MemoryProvider enum (ICM, AutoMem, Skip)
-├── hooks.rs         # Hook script copy + settings.json merge
-├── config.rs        # Typed structs for config.local.json
+├── memory.rs        # MemoryProvider enum (ICM, Skip)
+├── config.rs        # ProjectSettings/GlobalSettings + .claude/whetstone.json manifest
 ├── shell.rs         # Shell profile detection, env var injection
 ├── preflight.rs     # Dependency checks (python, git, curl, uv)
 ├── headroom.rs      # Headroom install/upgrade (extras configurable)
@@ -127,9 +133,9 @@ src/
 - **Single Rust binary**: replaces ~1200 lines Bash + ~460 lines Python
 - **Idempotent**: setup skips already-installed components; safe to rerun
 - **Absolute paths in hooks**: avoids PATH/shell-state issues
-- **Global tools, per-project config**: RTK/Headroom installed globally; memory provider and config are per-project
-- **Backup before modify**: `settings.json` backed up with timestamp before any merge
-- **No jq dependency**: serde_json replaces jq for settings.json manipulation
+- **Global tools, per-project config**: RTK/Headroom installed globally; memory provider and version-pinned manifest are per-project
+- **Tool-managed hooks**: v3 delegates `~/.claude/settings.json` hook entries to `rtk init` / `icm init`; whetstone never hand-merges them (`doctor` reports drift, `migrate` archives before touching state)
+- **Layered settings**: `GlobalSettings` (`~/.whetstone/settings.json`) and per-project `ProjectSettings` (in `.claude/whetstone.json`) resolve with project-over-global precedence
 - **rusqlite bundled**: statically links SQLite, no system dependency
 - **Asset resolution**: `WHETSTONE_ASSETS` env → `<binary_dir>/../assets/` → `~/.whetstone/assets/`
 
@@ -147,14 +153,13 @@ src/
 
 ### Repository Layout — Bundled Assets
 *~4,000 tokens/session saved*
-- `assets/skills/` contains ONLY skill files (flat, no subdirectories from external repos)
-- `assets/hooks/`, `assets/rules/`, `assets/commands/` contain runtime files
-- These directories are **static/vendored** — do NOT clone or pull external repos into them at install time; files are shipped with whetstone and should only change on a new whetstone release
+- v3 vendors **only** `assets/commands/` (slash commands) and `assets/db/schema.sql`. Skills, rules, and hook scripts are no longer bundled — ICM owns those via `icm init --mode standard`
+- These directories are **static/vendored** — do NOT clone or pull external repos into them at install time; files are shipped with whetstone and change only on a new whetstone release
 
 ### Install Constraints
 *~3,000 tokens/session saved*
-- `src/setup.rs` copies skills flat into `.claude/skills/` via `copy_dir_recursive` (no nested repo structure)
-- Never use `git clone` or `git submodule` for skills during install; copy bundled files only
+- `src/setup.rs` copies slash commands into `.claude/commands/` via `copy_dir_recursive`; provider assets come from the provider's own `init`
+- Never use `git clone` or `git submodule` during install; copy bundled files only
 - Verify with `cargo clippy` and `cargo test` after any edits
 
 ### Available Commands

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,6 +11,7 @@
 | `whetstone rtk [args...]` | Run RTK |
 | `whetstone doctor` | Inspect installed tool versions, `~/.claude/settings.json` hooks, and the per-project manifest |
 | `whetstone dashboard` | TUI dashboard for installed tool versions vs. pinned floors |
+| `whetstone settings` | Interactively edit whetstone settings, layered global/project (Headroom telemetry, Headroom memory, default API model, Anthropic API URL) |
 | `whetstone migrate [--dry-run] [-y] [--rollback ID]` | Migrate a v2 install to v3 (or roll back) — see [Migration Guide](migration.md) |
 | `whetstone version` | Print version |
 | `whetstone stats` | Token-savings summary from RTK + Headroom stats endpoints |
@@ -18,6 +19,25 @@
 | `whetstone release patch\|minor\|major\|set X.Y.Z` | Verify, bump version, and open a release PR |
 | `whetstone release-publish ...` | **Deprecated** — use `whetstone release` |
 | `whetstone db <subcommand>` | Session database operations (init / add-session / add-insight / search / get-sessions / get-insights / stats) |
+| `whetstone changelog-sync [--input F] [--output F] [--limit N]` | Regenerate `site/src/changelog.js` from `CHANGELOG.md` (maintainer tooling) |
+
+The global `--memory` flag (e.g. `whetstone --memory` or `whetstone --memory claude`)
+enables Headroom persistent cross-session memory for that run. Persist it per-project
+or globally via `whetstone settings` (Headroom Memory).
+
+## Model Update Prompt
+
+On launch (`whetstone` / `whetstone claude`), whetstone checks the 12h-cached
+Anthropic models list. If a model newer than the one this project runs — or a
+brand-new model family — is available, it shows a full-screen modal offering to:
+
+- **Pin** it as the project default (writes `api_model` to `.claude/whetstone.json`)
+- **Use for this session** only (no persistence)
+- **Dismiss** it permanently for this project (recorded in `dismissed_models`)
+- **Not now** (offered again next launch)
+
+The prompt is skipped when the terminal is non-interactive, whetstone is offline,
+the directory is not a v3 project, or `--model` was passed explicitly.
 
 ## Headroom Extras
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,7 @@
 | File | Owner | Purpose |
 |------|-------|---------|
 | `~/.claude/settings.json` | RTK + whetstone | All hooks, including whetstone's absolute `.../rtk hook claude` command |
+| `~/.whetstone/settings.json` | whetstone | Global whetstone settings (Headroom telemetry/memory, default model, Anthropic API URL) |
 | `~/.claude/RTK.md` | RTK | RTK instructions for Claude Code context |
 | `~/.claude/CLAUDE.md` | Claude Code | Global instructions (references `@RTK.md`) |
 | `~/.headroom/models.json` | Headroom | Custom model context limits and pricing |
@@ -30,9 +31,33 @@
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `ANTHROPIC_BASE_URL` | (none) | Route API calls through Headroom proxy. Set to `http://127.0.0.1:8787` |
+| `ANTHROPIC_TARGET_API_URL` | (none) | Custom upstream Anthropic API URL the Headroom proxy targets. Whetstone exports it from the **Anthropic API URL** setting before launch; an externally-set value takes precedence |
 | `OPENAI_BASE_URL` | (none) | For OpenAI-compatible tools through Headroom. Set to `http://127.0.0.1:8787/v1` |
 | `HEADROOM_LOG_LEVEL` | `INFO` | Proxy logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `HEADROOM_PORT` | `8787` | Alternative to `--port` flag |
 | `HEADROOM_BUDGET` | (none) | Daily USD spending limit |
 | `HEADROOM_DEFAULT_MODE` | `optimize` | `optimize`, `audit` (observe only), or `off` |
 | `WHETSTONE_ASSETS` | (none) | Override path to assets directory |
+
+## Whetstone Settings
+
+`whetstone settings` opens an interactive TUI to edit layered settings. Each
+setting can be scoped **Off**, **Global**, or **Project**, with project values
+taking precedence over global ones.
+
+| Setting | Effect |
+|---------|--------|
+| Headroom Telemetry | Toggle Headroom telemetry |
+| Headroom Memory | Persist the `--memory` flag (Headroom cross-session memory) |
+| API Model | Default model injected into `headroom wrap claude` (otherwise: newest Sonnet, else `claude-opus-4-6`) |
+| Anthropic API URL | Custom upstream Anthropic API URL for the Headroom proxy (exported as `ANTHROPIC_TARGET_API_URL`) |
+
+Values persist to:
+
+- **Global** — `~/.whetstone/settings.json`
+- **Project** — the `settings` block of `.claude/whetstone.json`
+
+The launch-time model-update prompt (see the CLI Reference) also writes the
+project **API Model** when you pin a newer model. Models you permanently dismiss
+from that prompt are recorded in the top-level `dismissed_models` array of
+`.claude/whetstone.json` so they are not offered again for that project.

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,8 @@ pub struct ProjectSettings {
     pub headroom_memory: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anthropic_api_url: Option<String>,
 }
 
 const GLOBAL_DIR: &str = ".whetstone";
@@ -83,6 +85,8 @@ pub struct GlobalSettings {
     pub headroom_memory: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anthropic_api_url: Option<String>,
 }
 
 impl GlobalSettings {
@@ -117,6 +121,7 @@ pub struct ResolvedSettings {
     pub headroom_telemetry: bool,
     pub headroom_memory: bool,
     pub api_model: Option<String>,
+    pub anthropic_api_url: Option<String>,
 }
 
 impl ResolvedSettings {
@@ -130,6 +135,10 @@ impl ResolvedSettings {
                 .api_model
                 .clone()
                 .or_else(|| global.api_model.clone()),
+            anthropic_api_url: project
+                .anthropic_api_url
+                .clone()
+                .or_else(|| global.anthropic_api_url.clone()),
         }
     }
 }
@@ -146,6 +155,10 @@ pub struct WhetstoneManifest {
     pub settings: ProjectSettings,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migration_id: Option<String>,
+    /// Model ids the user chose to permanently dismiss from the launch-time
+    /// update prompt. Bookkeeping, not a settings-TUI knob — hence top-level.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dismissed_models: Vec<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -162,6 +175,7 @@ impl WhetstoneManifest {
             tool_versions,
             settings: ProjectSettings::default(),
             migration_id: None,
+            dismissed_models: Vec::new(),
             created_at: now,
             updated_at: now,
         }
@@ -224,6 +238,43 @@ mod tests {
     use tempfile::NamedTempFile;
 
     #[test]
+    fn resolve_prefers_project_anthropic_api_url() {
+        let global = GlobalSettings {
+            anthropic_api_url: Some("https://global.example".into()),
+            ..Default::default()
+        };
+        let project = ProjectSettings {
+            anthropic_api_url: Some("https://project.example".into()),
+            ..Default::default()
+        };
+        let resolved = ResolvedSettings::resolve(&global, &project);
+        assert_eq!(
+            resolved.anthropic_api_url.as_deref(),
+            Some("https://project.example")
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_global_anthropic_api_url() {
+        let global = GlobalSettings {
+            anthropic_api_url: Some("https://global.example".into()),
+            ..Default::default()
+        };
+        let resolved = ResolvedSettings::resolve(&global, &ProjectSettings::default());
+        assert_eq!(
+            resolved.anthropic_api_url.as_deref(),
+            Some("https://global.example")
+        );
+    }
+
+    #[test]
+    fn resolve_anthropic_api_url_none_when_unset() {
+        let resolved =
+            ResolvedSettings::resolve(&GlobalSettings::default(), &ProjectSettings::default());
+        assert!(resolved.anthropic_api_url.is_none());
+    }
+
+    #[test]
     fn provider_round_trip() {
         let icm: ProviderTag = MemoryProvider::Icm.into();
         assert_eq!(MemoryProvider::from(icm), MemoryProvider::Icm);
@@ -281,6 +332,37 @@ mod tests {
     fn path_for_uses_dot_claude() {
         let p = WhetstoneManifest::path_for(Path::new("/tmp/proj"));
         assert!(p.ends_with(".claude/whetstone.json"));
+    }
+
+    #[test]
+    fn manifest_round_trips_dismissed_models() {
+        let mut m = WhetstoneManifest::new(MemoryProvider::Icm, ToolVersions::default());
+        m.dismissed_models.push("claude-opus-4-8".into());
+        m.dismissed_models.push("claude-fable-5".into());
+        let f = NamedTempFile::new().unwrap();
+        m.save(f.path()).unwrap();
+        let loaded = WhetstoneManifest::load(f.path()).unwrap().unwrap();
+        assert_eq!(
+            loaded.dismissed_models,
+            vec!["claude-opus-4-8".to_string(), "claude-fable-5".to_string()]
+        );
+    }
+
+    #[test]
+    fn legacy_manifest_without_dismissed_models_parses() {
+        let m = WhetstoneManifest::new(MemoryProvider::Skip, ToolVersions::default());
+        let mut value = serde_json::to_value(&m).unwrap();
+        value.as_object_mut().unwrap().remove("dismissed_models");
+        let raw = serde_json::to_string(&value).unwrap();
+        let parsed: WhetstoneManifest = serde_json::from_str(&raw).unwrap();
+        assert!(parsed.dismissed_models.is_empty());
+    }
+
+    #[test]
+    fn empty_dismissed_models_omitted_from_json() {
+        let m = WhetstoneManifest::new(MemoryProvider::Skip, ToolVersions::default());
+        let raw = serde_json::to_string(&m).unwrap();
+        assert!(!raw.contains("dismissed_models"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod headroom;
 mod integrations;
 mod memory;
 mod migrate;
+mod model_update;
 mod preflight;
 mod release;
 mod rtk;

--- a/src/model_update.rs
+++ b/src/model_update.rs
@@ -8,7 +8,10 @@
 //! The decision logic here is pure and exhaustively unit-tested; the effectful
 //! shell (guards, state I/O, TUI) lives alongside it but is kept thin.
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
 
 use crate::settings::family_order;
 
@@ -94,6 +97,64 @@ fn model_offers(
         .collect()
 }
 
+/// Stable hex hash of a project directory, used to name its seen-cache file.
+/// Canonicalizes when possible so `.`/symlinks map to one file; falls back to
+/// the raw path (e.g. for a not-yet-existing dir in tests).
+fn hash_project_dir(project_dir: &Path) -> String {
+    let canon = std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.to_path_buf());
+    let mut hasher = DefaultHasher::new();
+    canon.to_string_lossy().hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// Path to a project's seen-cache file under an arbitrary cache base.
+fn seen_cache_path_in(base: &Path, project_dir: &Path) -> PathBuf {
+    base.join("model-seen")
+        .join(format!("{}.json", hash_project_dir(project_dir)))
+}
+
+/// Real cache base: `~/.cache/whetstone`.
+fn seen_cache_base() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".cache").join("whetstone"))
+}
+
+/// Read the seen baseline under an arbitrary base. Missing or garbage ⇒ `[]`.
+fn read_seen_in(base: &Path, project_dir: &Path) -> Vec<String> {
+    let path = seen_cache_path_in(base, project_dir);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+/// Best-effort write of the seen baseline under an arbitrary base.
+fn write_seen_in(base: &Path, project_dir: &Path, models: &[String]) {
+    let path = seen_cache_path_in(base, project_dir);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string(models) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+/// Seen baseline for `project_dir` from the real cache; `[]` if unavailable.
+#[allow(dead_code)] // wired into `maybe_prompt` in a later task
+fn read_seen(project_dir: &Path) -> Vec<String> {
+    match seen_cache_base() {
+        Some(base) => read_seen_in(&base, project_dir),
+        None => Vec::new(),
+    }
+}
+
+/// Persist the seen baseline for `project_dir` to the real cache (best-effort).
+#[allow(dead_code)] // wired into `maybe_prompt` in a later task
+fn write_seen(project_dir: &Path, models: &[String]) {
+    if let Some(base) = seen_cache_base() {
+        write_seen_in(&base, project_dir, models);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,6 +238,40 @@ mod tests {
             &s(&["claude-sonnet-6"]),
         );
         assert!(offers.is_empty());
+    }
+
+    #[test]
+    fn read_seen_missing_returns_empty() {
+        let base = tempfile::tempdir().unwrap();
+        let proj = Path::new("/some/project");
+        assert!(read_seen_in(base.path(), proj).is_empty());
+    }
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let base = tempfile::tempdir().unwrap();
+        let proj = Path::new("/some/project");
+        let models = s(&["claude-opus-4-8", "claude-sonnet-5"]);
+        write_seen_in(base.path(), proj, &models);
+        assert_eq!(read_seen_in(base.path(), proj), models);
+    }
+
+    #[test]
+    fn seen_path_stable_for_same_dir() {
+        let base = tempfile::tempdir().unwrap();
+        let proj = Path::new("/some/project");
+        assert_eq!(
+            seen_cache_path_in(base.path(), proj),
+            seen_cache_path_in(base.path(), proj)
+        );
+    }
+
+    #[test]
+    fn seen_path_differs_across_dirs() {
+        let base = tempfile::tempdir().unwrap();
+        let a = seen_cache_path_in(base.path(), Path::new("/proj/a"));
+        let b = seen_cache_path_in(base.path(), Path::new("/proj/b"));
+        assert_ne!(a, b);
     }
 
     #[test]

--- a/src/model_update.rs
+++ b/src/model_update.rs
@@ -12,8 +12,15 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::{DefaultTerminal, Frame};
 
 use crate::config::{ResolvedSettings, WhetstoneManifest};
 use crate::settings::family_order;
@@ -34,9 +41,7 @@ pub enum ModelDecision {
 
 /// The action a user picks in the modal, orthogonal to which model is
 /// highlighted (that id is supplied separately to [`apply_action`]).
-// Variants are constructed by the TUI modal (Task 6); allow until then.
 #[derive(Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum ModalAction {
     /// Pin the highlighted model as the project default.
     Pin,
@@ -249,10 +254,135 @@ pub fn maybe_prompt(resolved: &ResolvedSettings) -> ModelDecision {
     apply_action(action, &selected, &manifest_path).unwrap_or(ModelDecision::NoChange)
 }
 
-/// Full-screen modal implemented in a later task; returns the chosen action
-/// and the highlighted model id.
-fn prompt_modal(_offered: &[String]) -> (ModalAction, String) {
-    todo!("TUI modal implemented in Task 6")
+/// Full-screen modal offering the newer/new model(s). Returns the chosen
+/// action and the highlighted model id. Falls back to `NotNow` on any terminal
+/// error so a launch never hangs on TUI failure.
+fn prompt_modal(offered: &[String]) -> (ModalAction, String) {
+    let fallback = || {
+        (
+            ModalAction::NotNow,
+            offered.first().cloned().unwrap_or_default(),
+        )
+    };
+    let mut terminal = ratatui::init();
+    let result = modal_loop(&mut terminal, offered);
+    ratatui::restore();
+    result.unwrap_or_else(|_| fallback())
+}
+
+/// Render/input loop for the modal. `Enter`/`p` pin, `s` session, `d` dismiss,
+/// `Esc`/`q` not now; `↑↓`/`j`/`k` move the highlight when >1 model is offered.
+fn modal_loop(terminal: &mut DefaultTerminal, offered: &[String]) -> Result<(ModalAction, String)> {
+    let mut selected = 0usize;
+    loop {
+        terminal.draw(|frame| draw_modal(frame, offered, selected))?;
+
+        if !event::poll(Duration::from_millis(250))? {
+            continue;
+        }
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        let current = offered.get(selected).cloned().unwrap_or_default();
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                selected = selected.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') if selected + 1 < offered.len() => {
+                selected += 1;
+            }
+            KeyCode::Char('p') | KeyCode::Enter => {
+                return Ok((ModalAction::Pin, current));
+            }
+            KeyCode::Char('s') => {
+                return Ok((ModalAction::Session, current));
+            }
+            KeyCode::Char('d') => {
+                return Ok((ModalAction::Dismiss, current));
+            }
+            KeyCode::Char('q') | KeyCode::Esc => {
+                return Ok((ModalAction::NotNow, current));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn draw_modal(frame: &mut Frame, offered: &[String], selected: usize) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5),
+            Constraint::Min(3),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+    draw_modal_header(frame, chunks[0]);
+    draw_modal_list(frame, chunks[1], offered, selected);
+    draw_modal_footer(frame, chunks[2]);
+}
+
+fn draw_modal_header(frame: &mut Frame, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Span::styled(
+            " New model available ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let body = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            " Anthropic published a model newer than this project uses.",
+            Style::default().add_modifier(Modifier::DIM),
+        )),
+        Line::from(Span::styled(
+            " Pin it as the project default, use it once, or dismiss it.",
+            Style::default().add_modifier(Modifier::DIM),
+        )),
+    ])
+    .block(block);
+    frame.render_widget(body, area);
+}
+
+fn draw_modal_list(frame: &mut Frame, area: Rect, offered: &[String], selected: usize) {
+    let lines: Vec<Line<'_>> = offered
+        .iter()
+        .enumerate()
+        .map(|(i, model)| {
+            let marker = if i == selected { " ▶ " } else { "   " };
+            let style = if i == selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            Line::from(Span::styled(format!("{marker}{model}"), style))
+        })
+        .collect();
+
+    let list =
+        Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title(" Offered "));
+    frame.render_widget(list, area);
+}
+
+fn draw_modal_footer(frame: &mut Frame, area: Rect) {
+    let footer = Paragraph::new(Line::from(Span::styled(
+        " ↑/↓ select   p pin as default   s this session   \
+         d dismiss   Esc not now",
+        Style::default().fg(Color::DarkGray),
+    )))
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(footer, area);
 }
 
 #[cfg(test)]

--- a/src/model_update.rs
+++ b/src/model_update.rs
@@ -13,13 +13,16 @@ use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
+
+use crate::config::{ResolvedSettings, WhetstoneManifest};
 use crate::settings::family_order;
 
 /// `family_order` value assigned to models we don't recognize; never matches.
 const UNKNOWN_FAMILY: u8 = 4;
 
 /// What the caller does with the model list after the prompt resolves.
-#[allow(dead_code)] // consumed by later tasks (maybe_prompt / wrap_claude)
+#[derive(Debug, PartialEq, Eq)]
 pub enum ModelDecision {
     /// Pin as project default and launch with it.
     UsePinned(String),
@@ -27,6 +30,22 @@ pub enum ModelDecision {
     UseSession(String),
     /// Leave resolution to the existing default path.
     NoChange,
+}
+
+/// The action a user picks in the modal, orthogonal to which model is
+/// highlighted (that id is supplied separately to [`apply_action`]).
+// Variants are constructed by the TUI modal (Task 6); allow until then.
+#[derive(Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum ModalAction {
+    /// Pin the highlighted model as the project default.
+    Pin,
+    /// Use the highlighted model for this session only.
+    Session,
+    /// Never offer the highlighted model again.
+    Dismiss,
+    /// Do nothing; ask again next launch.
+    NotNow,
 }
 
 /// Two ids belong to the same recognized model family.
@@ -54,9 +73,6 @@ fn newest_in_family(available: &[String], model: &str) -> Option<String> {
 /// recognized family present in `available` but absent from `seen`. `effective`
 /// and `dismissed` ids are removed and the result is deduped in stable order.
 /// On first run (`seen` empty) the brand-new-family signal is suppressed.
-// Wired into `maybe_prompt` in a later task; its callees are reachable through
-// it, so this single allow keeps the whole pure core clippy-clean until then.
-#[allow(dead_code)]
 fn model_offers(
     effective: &str,
     available: &[String],
@@ -139,7 +155,6 @@ fn write_seen_in(base: &Path, project_dir: &Path, models: &[String]) {
 }
 
 /// Seen baseline for `project_dir` from the real cache; `[]` if unavailable.
-#[allow(dead_code)] // wired into `maybe_prompt` in a later task
 fn read_seen(project_dir: &Path) -> Vec<String> {
     match seen_cache_base() {
         Some(base) => read_seen_in(&base, project_dir),
@@ -148,19 +163,170 @@ fn read_seen(project_dir: &Path) -> Vec<String> {
 }
 
 /// Persist the seen baseline for `project_dir` to the real cache (best-effort).
-#[allow(dead_code)] // wired into `maybe_prompt` in a later task
 fn write_seen(project_dir: &Path, models: &[String]) {
     if let Some(base) = seen_cache_base() {
         write_seen_in(&base, project_dir, models);
     }
 }
 
+/// The model a launch would use today: the project's pin, else the newest
+/// available Sonnet. `None` only when neither is determinable.
+fn effective_model(resolved: &ResolvedSettings) -> Option<String> {
+    resolved
+        .api_model
+        .clone()
+        .or_else(crate::settings::preferred_default_model)
+}
+
+/// Persist (or not) the user's modal choice and map it to a [`ModelDecision`].
+/// `selected` is the highlighted model id the action applies to.
+fn apply_action(
+    action: ModalAction,
+    selected: &str,
+    manifest_path: &Path,
+) -> Result<ModelDecision> {
+    match action {
+        ModalAction::Pin => {
+            let Some(mut manifest) = WhetstoneManifest::load(manifest_path)? else {
+                return Ok(ModelDecision::NoChange);
+            };
+            manifest.settings.api_model = Some(selected.to_string());
+            manifest.touch_and_save(manifest_path)?;
+            Ok(ModelDecision::UsePinned(selected.to_string()))
+        }
+        ModalAction::Session => Ok(ModelDecision::UseSession(selected.to_string())),
+        ModalAction::Dismiss => {
+            let Some(mut manifest) = WhetstoneManifest::load(manifest_path)? else {
+                return Ok(ModelDecision::NoChange);
+            };
+            if !manifest.dismissed_models.iter().any(|d| d == selected) {
+                manifest.dismissed_models.push(selected.to_string());
+                manifest.touch_and_save(manifest_path)?;
+            }
+            Ok(ModelDecision::NoChange)
+        }
+        ModalAction::NotNow => Ok(ModelDecision::NoChange),
+    }
+}
+
+/// Launch-time entry point. Returns [`ModelDecision::NoChange`] on any guard
+/// (non-interactive, no cwd, no v3 manifest, offline) so every existing launch
+/// path is unaffected. Otherwise computes offers, seeds the seen baseline, and
+/// — when there is something to offer — drives the modal and applies the choice.
+// Wired into `wrap_claude` in Task 7; keeps the reachable core clippy-clean.
+#[allow(dead_code)]
+pub fn maybe_prompt(resolved: &ResolvedSettings) -> ModelDecision {
+    if !crate::ui::is_interactive() {
+        return ModelDecision::NoChange;
+    }
+    let Ok(cwd) = std::env::current_dir() else {
+        return ModelDecision::NoChange;
+    };
+    let manifest_path = WhetstoneManifest::path_for(&cwd);
+    let Ok(Some(manifest)) = WhetstoneManifest::load(&manifest_path) else {
+        return ModelDecision::NoChange;
+    };
+    let Some(available) = crate::settings::live_available_models() else {
+        return ModelDecision::NoChange;
+    };
+
+    let effective =
+        effective_model(resolved).unwrap_or_else(|| crate::wrapper::DEFAULT_MODEL.to_string());
+    let seen = read_seen(&cwd);
+    let offers = model_offers(&effective, &available, &seen, &manifest.dismissed_models);
+
+    // Record the current list as the new baseline whenever it changed (this is
+    // also the first-run seeding that suppresses brand-new-family until later).
+    if seen != available {
+        write_seen(&cwd, &available);
+    }
+
+    if offers.is_empty() {
+        return ModelDecision::NoChange;
+    }
+
+    let (action, selected) = prompt_modal(&offers);
+    apply_action(action, &selected, &manifest_path).unwrap_or(ModelDecision::NoChange)
+}
+
+/// Full-screen modal implemented in a later task; returns the chosen action
+/// and the highlighted model id.
+fn prompt_modal(_offered: &[String]) -> (ModalAction, String) {
+    todo!("TUI modal implemented in Task 6")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{ToolVersions, WhetstoneManifest};
+    use crate::memory::MemoryProvider;
 
     fn s(v: &[&str]) -> Vec<String> {
         v.iter().map(|x| x.to_string()).collect()
+    }
+
+    fn seed_manifest(path: &Path) {
+        WhetstoneManifest::new(MemoryProvider::Icm, ToolVersions::default())
+            .save(path)
+            .unwrap();
+    }
+
+    #[test]
+    fn apply_pin_writes_api_model_and_returns_use_pinned() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        seed_manifest(f.path());
+        let decision = apply_action(ModalAction::Pin, "claude-opus-4-8", f.path()).unwrap();
+        assert_eq!(decision, ModelDecision::UsePinned("claude-opus-4-8".into()));
+        let loaded = WhetstoneManifest::load(f.path()).unwrap().unwrap();
+        assert_eq!(
+            loaded.settings.api_model.as_deref(),
+            Some("claude-opus-4-8")
+        );
+    }
+
+    #[test]
+    fn apply_dismiss_appends_to_dismissed_models_and_returns_no_change() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        seed_manifest(f.path());
+        let decision = apply_action(ModalAction::Dismiss, "claude-fable-5", f.path()).unwrap();
+        assert_eq!(decision, ModelDecision::NoChange);
+        let loaded = WhetstoneManifest::load(f.path()).unwrap().unwrap();
+        assert_eq!(loaded.dismissed_models, s(&["claude-fable-5"]));
+    }
+
+    #[test]
+    fn apply_session_persists_nothing_returns_use_session() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        seed_manifest(f.path());
+        let decision = apply_action(ModalAction::Session, "claude-sonnet-5", f.path()).unwrap();
+        assert_eq!(
+            decision,
+            ModelDecision::UseSession("claude-sonnet-5".into())
+        );
+        let loaded = WhetstoneManifest::load(f.path()).unwrap().unwrap();
+        assert!(loaded.settings.api_model.is_none());
+        assert!(loaded.dismissed_models.is_empty());
+    }
+
+    #[test]
+    fn apply_not_now_persists_nothing_returns_no_change() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        seed_manifest(f.path());
+        let decision = apply_action(ModalAction::NotNow, "claude-sonnet-5", f.path()).unwrap();
+        assert_eq!(decision, ModelDecision::NoChange);
+        let loaded = WhetstoneManifest::load(f.path()).unwrap().unwrap();
+        assert!(loaded.settings.api_model.is_none());
+        assert!(loaded.dismissed_models.is_empty());
+    }
+
+    #[test]
+    fn dismiss_does_not_duplicate_existing_ids() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        seed_manifest(f.path());
+        apply_action(ModalAction::Dismiss, "claude-fable-5", f.path()).unwrap();
+        apply_action(ModalAction::Dismiss, "claude-fable-5", f.path()).unwrap();
+        let loaded = WhetstoneManifest::load(f.path()).unwrap().unwrap();
+        assert_eq!(loaded.dismissed_models, s(&["claude-fable-5"]));
     }
 
     #[test]

--- a/src/model_update.rs
+++ b/src/model_update.rs
@@ -1,0 +1,196 @@
+//! Launch-time model update prompt.
+//!
+//! On the default `headroom wrap claude` launch, whetstone notices that
+//! Anthropic has published a model newer than the one this project runs — or a
+//! brand-new model family — and offers, via a full-screen modal, to pin it as
+//! the project default, use it for one session, or dismiss it permanently.
+//!
+//! The decision logic here is pure and exhaustively unit-tested; the effectful
+//! shell (guards, state I/O, TUI) lives alongside it but is kept thin.
+
+use std::collections::HashSet;
+
+use crate::settings::family_order;
+
+/// `family_order` value assigned to models we don't recognize; never matches.
+const UNKNOWN_FAMILY: u8 = 4;
+
+/// What the caller does with the model list after the prompt resolves.
+#[allow(dead_code)] // consumed by later tasks (maybe_prompt / wrap_claude)
+pub enum ModelDecision {
+    /// Pin as project default and launch with it.
+    UsePinned(String),
+    /// Launch with it once; nothing persisted.
+    UseSession(String),
+    /// Leave resolution to the existing default path.
+    NoChange,
+}
+
+/// Two ids belong to the same recognized model family.
+fn same_family(a: &str, b: &str) -> bool {
+    let fa = family_order(a);
+    fa != UNKNOWN_FAMILY && fa == family_order(b)
+}
+
+/// `candidate` is a newer release of `current`'s own family.
+fn is_model_newer(candidate: &str, current: &str) -> bool {
+    same_family(candidate, current) && candidate > current
+}
+
+/// Newest id in `available` that shares `model`'s family (lexical max).
+fn newest_in_family(available: &[String], model: &str) -> Option<String> {
+    available
+        .iter()
+        .filter(|id| same_family(id, model))
+        .max()
+        .cloned()
+}
+
+/// Models worth offering, per the trigger rule in the design doc:
+/// a newer release within `effective`'s own family, plus the flagship of any
+/// recognized family present in `available` but absent from `seen`. `effective`
+/// and `dismissed` ids are removed and the result is deduped in stable order.
+/// On first run (`seen` empty) the brand-new-family signal is suppressed.
+// Wired into `maybe_prompt` in a later task; its callees are reachable through
+// it, so this single allow keeps the whole pure core clippy-clean until then.
+#[allow(dead_code)]
+fn model_offers(
+    effective: &str,
+    available: &[String],
+    seen: &[String],
+    dismissed: &[String],
+) -> Vec<String> {
+    let mut offers: Vec<String> = Vec::new();
+
+    // Signal: a newer release within the in-use family.
+    if let Some(newest) = newest_in_family(available, effective) {
+        if is_model_newer(&newest, effective) {
+            offers.push(newest);
+        }
+    }
+
+    // Signal: a brand-new family flagship (only after seeding).
+    if !seen.is_empty() {
+        let seen_families: HashSet<u8> = seen.iter().map(|id| family_order(id)).collect();
+        let mut new_families: Vec<u8> = available
+            .iter()
+            .map(|id| family_order(id))
+            .filter(|f| *f != UNKNOWN_FAMILY && !seen_families.contains(f))
+            .collect();
+        new_families.sort_unstable();
+        new_families.dedup();
+        for f in new_families {
+            if let Some(flagship) = available.iter().filter(|id| family_order(id) == f).max() {
+                offers.push(flagship.clone());
+            }
+        }
+    }
+
+    let mut deduped = HashSet::new();
+    offers
+        .into_iter()
+        .filter(|m| m != effective && !dismissed.contains(m))
+        .filter(|m| deduped.insert(m.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn is_model_newer_within_family() {
+        assert!(is_model_newer("claude-sonnet-5", "claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn is_model_newer_cross_family_false() {
+        assert!(!is_model_newer("claude-opus-4-8", "claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn is_model_newer_same_id_false() {
+        assert!(!is_model_newer("claude-sonnet-5", "claude-sonnet-5"));
+    }
+
+    #[test]
+    fn offers_family_upgrade_for_pinned_older_sonnet() {
+        let available = s(&["claude-sonnet-5", "claude-sonnet-4-6"]);
+        let seen = s(&["claude-sonnet-4-6"]);
+        let offers = model_offers("claude-sonnet-4-6", &available, &seen, &[]);
+        assert_eq!(offers, s(&["claude-sonnet-5"]));
+    }
+
+    #[test]
+    fn offers_family_upgrade_for_pinned_opus() {
+        let available = s(&["claude-opus-4-8", "claude-opus-4-6"]);
+        let seen = s(&["claude-opus-4-6"]);
+        let offers = model_offers("claude-opus-4-6", &available, &seen, &[]);
+        assert_eq!(offers, s(&["claude-opus-4-8"]));
+    }
+
+    #[test]
+    fn no_sonnet_offer_for_opus_pin_when_sonnet_family_seen() {
+        let available = s(&["claude-opus-4-6", "claude-sonnet-5"]);
+        let seen = s(&["claude-opus-4-6", "claude-sonnet-4-6"]);
+        let offers = model_offers("claude-opus-4-6", &available, &seen, &[]);
+        assert!(offers.is_empty());
+    }
+
+    #[test]
+    fn offers_brand_new_family_flagship() {
+        let available = s(&["claude-opus-4-6", "claude-fable-5"]);
+        let seen = s(&["claude-opus-4-6"]);
+        let offers = model_offers("claude-opus-4-6", &available, &seen, &[]);
+        assert_eq!(offers, s(&["claude-fable-5"]));
+    }
+
+    #[test]
+    fn first_run_suppresses_brand_new_family() {
+        // seen empty ⇒ everything looks new; only family-upgrade may fire.
+        let available = s(&["claude-opus-4-6", "claude-opus-4-8", "claude-fable-5"]);
+        let offers = model_offers("claude-opus-4-6", &available, &[], &[]);
+        assert_eq!(offers, s(&["claude-opus-4-8"]));
+    }
+
+    #[test]
+    fn dismissed_excluded_but_newer_still_offered() {
+        let available = s(&["claude-sonnet-4-6", "claude-sonnet-6"]);
+        let seen = s(&["claude-sonnet-4-6"]);
+        // Dismissing an older candidate does not block a newer one.
+        let offers = model_offers(
+            "claude-sonnet-4-6",
+            &available,
+            &seen,
+            &s(&["claude-sonnet-5"]),
+        );
+        assert_eq!(offers, s(&["claude-sonnet-6"]));
+        // Dismissing the actual newest yields nothing.
+        let offers = model_offers(
+            "claude-sonnet-4-6",
+            &available,
+            &seen,
+            &s(&["claude-sonnet-6"]),
+        );
+        assert!(offers.is_empty());
+    }
+
+    #[test]
+    fn effective_never_offered_and_results_deduped() {
+        // effective is already newest in family ⇒ not offered.
+        let available = s(&["claude-sonnet-5"]);
+        let seen = s(&["claude-sonnet-5"]);
+        assert!(model_offers("claude-sonnet-5", &available, &seen, &[]).is_empty());
+
+        // Family-upgrade and brand-new-family compute the same flagship for a
+        // family absent from `seen`; result is deduped.
+        let available = s(&["claude-opus-4-6", "claude-opus-4-8"]);
+        let seen = s(&["claude-sonnet-5"]);
+        let offers = model_offers("claude-opus-4-6", &available, &seen, &[]);
+        assert_eq!(offers, s(&["claude-opus-4-8"]));
+    }
+}

--- a/src/model_update.rs
+++ b/src/model_update.rs
@@ -218,8 +218,6 @@ fn apply_action(
 /// (non-interactive, no cwd, no v3 manifest, offline) so every existing launch
 /// path is unaffected. Otherwise computes offers, seeds the seen baseline, and
 /// — when there is something to offer — drives the modal and applies the choice.
-// Wired into `wrap_claude` in Task 7; keeps the reachable core clippy-clean.
-#[allow(dead_code)]
 pub fn maybe_prompt(resolved: &ResolvedSettings) -> ModelDecision {
     if !crate::ui::is_interactive() {
         return ModelDecision::NoChange;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -103,7 +103,7 @@ fn strip_date_suffix(id: &str) -> Option<&str> {
     None
 }
 
-fn family_order(id: &str) -> u8 {
+pub(crate) fn family_order(id: &str) -> u8 {
     if id.contains("-opus-") {
         0
     } else if id.contains("-sonnet-") {
@@ -161,7 +161,7 @@ fn fetch_models_from_api() -> Option<Vec<String>> {
 /// is reachable. Distinct from [`load_available_models`], which substitutes the
 /// static `FALLBACK_MODELS` — callers that need to know whether availability
 /// was *actually* determined (vs. guessed) use this instead.
-fn live_available_models() -> Option<Vec<String>> {
+pub(crate) fn live_available_models() -> Option<Vec<String>> {
     if let Some(cached) = read_models_cache() {
         return Some(cached);
     }
@@ -182,7 +182,7 @@ fn load_available_models() -> Vec<String> {
 /// Newest Sonnet in `models`, by lexical id (matching the descending sort the
 /// picker uses: `claude-sonnet-5` > `claude-sonnet-4-6`). `None` when the list
 /// has no Sonnet. Independent of input ordering so it's safe to unit-test.
-fn newest_sonnet(models: &[String]) -> Option<String> {
+pub(crate) fn newest_sonnet(models: &[String]) -> Option<String> {
     models
         .iter()
         .filter(|id| id.contains("-sonnet-"))
@@ -220,12 +220,14 @@ enum SettingId {
     HeadroomTelemetry,
     HeadroomMemory,
     ApiModel,
+    AnthropicApiUrl,
 }
 
 const SETTINGS: &[SettingId] = &[
     SettingId::HeadroomTelemetry,
     SettingId::HeadroomMemory,
     SettingId::ApiModel,
+    SettingId::AnthropicApiUrl,
 ];
 
 struct SettingsState {
@@ -235,6 +237,9 @@ struct SettingsState {
     original_project: ProjectSettings,
     selected: usize,
     models: Vec<String>,
+    /// `Some(buffer)` while the user is typing a free-text value (the Anthropic
+    /// API URL); `None` in normal navigation mode.
+    editing: Option<String>,
 }
 
 impl SettingsState {
@@ -256,6 +261,15 @@ impl SettingsState {
                 if self.project.api_model.is_some() {
                     Scope::Project
                 } else if self.global.api_model.is_some() {
+                    Scope::Global
+                } else {
+                    Scope::Off
+                }
+            }
+            SettingId::AnthropicApiUrl => {
+                if self.project.anthropic_api_url.is_some() {
+                    Scope::Project
+                } else if self.global.anthropic_api_url.is_some() {
                     Scope::Global
                 } else {
                     Scope::Off
@@ -313,6 +327,22 @@ impl SettingsState {
                     self.project.api_model = Some(base);
                 }
             },
+            SettingId::AnthropicApiUrl => match next {
+                Scope::Off => {
+                    self.global.anthropic_api_url = None;
+                    self.project.anthropic_api_url = None;
+                }
+                Scope::Global => {
+                    if self.global.anthropic_api_url.is_none() {
+                        self.global.anthropic_api_url = Some(String::new());
+                    }
+                    self.project.anthropic_api_url = None;
+                }
+                Scope::Project => {
+                    let base = self.global.anthropic_api_url.clone().unwrap_or_default();
+                    self.project.anthropic_api_url = Some(base);
+                }
+            },
         }
     }
 
@@ -337,14 +367,55 @@ impl SettingsState {
         *target = Some(self.models[idx].clone());
     }
 
-    fn current_model_display(&self, id: SettingId) -> Option<&str> {
-        if id != SettingId::ApiModel {
-            return None;
+    /// The stored value shown next to a value-bearing setting (model id or API
+    /// URL), or `None` for toggle settings and `Scope::Off`.
+    fn current_value_display(&self, id: SettingId) -> Option<&str> {
+        match id {
+            SettingId::ApiModel => match self.scope(id) {
+                Scope::Off => None,
+                Scope::Global => self.global.api_model.as_deref(),
+                Scope::Project => self.project.api_model.as_deref(),
+            },
+            SettingId::AnthropicApiUrl => match self.scope(id) {
+                Scope::Off => None,
+                Scope::Global => self.global.anthropic_api_url.as_deref(),
+                Scope::Project => self.project.anthropic_api_url.as_deref(),
+            },
+            _ => None,
         }
-        match self.scope(id) {
-            Scope::Off => None,
-            Scope::Global => self.global.api_model.as_deref(),
-            Scope::Project => self.project.api_model.as_deref(),
+    }
+
+    /// Enter text-editing mode for the currently selected URL setting, seeding
+    /// the buffer with the active value. No-op unless the selection is the
+    /// Anthropic API URL and its scope is active.
+    fn begin_edit(&mut self) {
+        let id = SETTINGS[self.selected];
+        if id != SettingId::AnthropicApiUrl || self.scope(id) == Scope::Off {
+            return;
+        }
+        let current = self
+            .current_value_display(id)
+            .unwrap_or_default()
+            .to_string();
+        self.editing = Some(current);
+    }
+
+    /// Commit the in-progress edit buffer into the active scope, then leave edit
+    /// mode. A blank buffer clears the value (which drops the scope to `Off`).
+    fn commit_edit(&mut self) {
+        let Some(buffer) = self.editing.take() else {
+            return;
+        };
+        let trimmed = buffer.trim();
+        let value = (!trimmed.is_empty()).then(|| trimmed.to_string());
+        match self.scope(SettingId::AnthropicApiUrl) {
+            Scope::Global | Scope::Off => {
+                self.global.anthropic_api_url = value;
+                self.project.anthropic_api_url = None;
+            }
+            Scope::Project => {
+                self.project.anthropic_api_url = value;
+            }
         }
     }
 
@@ -375,7 +446,8 @@ pub fn run() -> Result<()> {
     ratatui::restore();
 
     match result {
-        Ok(Some(saved)) => {
+        Ok(Some(mut saved)) => {
+            normalize_saved(&mut saved);
             let global_changed = saved.global != global;
             let project_changed = saved.project != project;
 
@@ -426,6 +498,18 @@ struct SavedState {
     project: ProjectSettings,
 }
 
+/// Drop blank free-text values (a scope was toggled on but never filled in) to
+/// `None` so an empty API URL never persists to disk.
+fn normalize_saved(saved: &mut SavedState) {
+    let blank = |v: &Option<String>| v.as_deref().map(str::trim).is_some_and(str::is_empty);
+    if blank(&saved.global.anthropic_api_url) {
+        saved.global.anthropic_api_url = None;
+    }
+    if blank(&saved.project.anthropic_api_url) {
+        saved.project.anthropic_api_url = None;
+    }
+}
+
 fn run_loop(
     terminal: &mut DefaultTerminal,
     global: GlobalSettings,
@@ -439,6 +523,7 @@ fn run_loop(
         project,
         selected: 0,
         models,
+        editing: None,
     };
 
     loop {
@@ -447,6 +532,10 @@ fn run_loop(
         if event::poll(Duration::from_millis(250))? {
             if let Event::Key(key) = event::read()? {
                 if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                if state.editing.is_some() {
+                    handle_edit_key(&mut state, key.code);
                     continue;
                 }
                 match key.code {
@@ -462,9 +551,11 @@ fn run_loop(
                     KeyCode::Char(' ') => {
                         state.cycle_scope(SETTINGS[state.selected]);
                     }
-                    KeyCode::Tab | KeyCode::Enter => {
-                        state.cycle_model_value();
-                    }
+                    KeyCode::Tab | KeyCode::Enter => match SETTINGS[state.selected] {
+                        SettingId::ApiModel => state.cycle_model_value(),
+                        SettingId::AnthropicApiUrl => state.begin_edit(),
+                        _ => {}
+                    },
                     KeyCode::Up | KeyCode::Char('k') => {
                         state.selected = state.selected.saturating_sub(1);
                     }
@@ -481,6 +572,28 @@ fn run_loop(
                 }
             }
         }
+    }
+}
+
+/// Route a keypress while the URL text buffer is open. Enter commits, Esc
+/// cancels, and printable characters / Backspace edit the buffer in place.
+fn handle_edit_key(state: &mut SettingsState, code: KeyCode) {
+    match code {
+        KeyCode::Enter => state.commit_edit(),
+        KeyCode::Esc => {
+            state.editing = None;
+        }
+        KeyCode::Backspace => {
+            if let Some(buffer) = state.editing.as_mut() {
+                buffer.pop();
+            }
+        }
+        KeyCode::Char(c) => {
+            if let Some(buffer) = state.editing.as_mut() {
+                buffer.push(c);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -577,9 +690,14 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
                 "Enable Headroom persistent cross-session memory (proxy --memory)",
             ),
             SettingId::ApiModel => ("API Model", "Model used for Claude Code sessions"),
+            SettingId::AnthropicApiUrl => (
+                "Anthropic API URL",
+                "Custom upstream Anthropic API URL for the Headroom proxy",
+            ),
         };
 
         let scope = state.scope(id);
+        let is_editing = is_selected && id == SettingId::AnthropicApiUrl && state.editing.is_some();
 
         let mut row = vec![Span::styled(
             cursor,
@@ -591,9 +709,22 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
         row.push(Span::raw("  "));
         row.push(Span::styled(label.to_string(), label_style));
 
-        if let Some(model) = state.current_model_display(id) {
+        if is_editing {
+            let buffer = state.editing.as_deref().unwrap_or_default();
             row.push(Span::styled(
-                format!("  {model}"),
+                format!("  {buffer}"),
+                Style::default().fg(Color::Yellow),
+            ));
+            row.push(Span::styled(
+                "█",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::DIM),
+            ));
+        } else if let Some(value) = state.current_value_display(id) {
+            let shown = if value.is_empty() { "(unset)" } else { value };
+            row.push(Span::styled(
+                format!("  {shown}"),
                 Style::default().fg(Color::Yellow),
             ));
         }
@@ -602,6 +733,12 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
 
         let desc_line = if id == SettingId::ApiModel && scope != Scope::Off {
             format!("{desc}  (tab to cycle model)")
+        } else if id == SettingId::AnthropicApiUrl && scope != Scope::Off {
+            if is_editing {
+                format!("{desc}  (enter to save, esc to cancel)")
+            } else {
+                format!("{desc}  (enter to edit)")
+            }
         } else {
             desc.to_string()
         };
@@ -679,7 +816,145 @@ mod tests {
             original_project: ProjectSettings::default(),
             selected: 0,
             models: test_models(),
+            editing: None,
         }
+    }
+
+    fn url_index() -> usize {
+        SETTINGS
+            .iter()
+            .position(|&s| s == SettingId::AnthropicApiUrl)
+            .unwrap()
+    }
+
+    #[test]
+    fn api_url_scope_detection() {
+        let mut s = default_state();
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Off);
+
+        s.global.anthropic_api_url = Some("https://global.example".into());
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Global);
+
+        s.project.anthropic_api_url = Some("https://project.example".into());
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Project);
+    }
+
+    #[test]
+    fn api_url_cycle_through_scopes() {
+        let mut s = default_state();
+
+        s.cycle_scope(SettingId::AnthropicApiUrl);
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Global);
+        assert_eq!(s.global.anthropic_api_url.as_deref(), Some(""));
+
+        s.cycle_scope(SettingId::AnthropicApiUrl);
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Project);
+        assert_eq!(s.project.anthropic_api_url.as_deref(), Some(""));
+
+        s.cycle_scope(SettingId::AnthropicApiUrl);
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Off);
+        assert!(s.global.anthropic_api_url.is_none());
+        assert!(s.project.anthropic_api_url.is_none());
+    }
+
+    #[test]
+    fn begin_edit_noop_when_scope_off() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.begin_edit();
+        assert!(s.editing.is_none());
+    }
+
+    #[test]
+    fn begin_edit_seeds_buffer_with_current_value() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.global.anthropic_api_url = Some("https://seed.example".into());
+        s.begin_edit();
+        assert_eq!(s.editing.as_deref(), Some("https://seed.example"));
+    }
+
+    #[test]
+    fn commit_edit_writes_global_value() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.global.anthropic_api_url = Some(String::new());
+        s.editing = Some("https://typed.example".into());
+        s.commit_edit();
+        assert!(s.editing.is_none());
+        assert_eq!(
+            s.global.anthropic_api_url.as_deref(),
+            Some("https://typed.example")
+        );
+    }
+
+    #[test]
+    fn commit_edit_writes_project_value() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.project.anthropic_api_url = Some(String::new());
+        s.editing = Some("  https://project.example  ".into());
+        s.commit_edit();
+        assert_eq!(
+            s.project.anthropic_api_url.as_deref(),
+            Some("https://project.example")
+        );
+    }
+
+    #[test]
+    fn commit_edit_blank_clears_value() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.global.anthropic_api_url = Some("https://old.example".into());
+        s.editing = Some("   ".into());
+        s.commit_edit();
+        assert!(s.global.anthropic_api_url.is_none());
+        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Off);
+    }
+
+    #[test]
+    fn edit_key_typing_and_backspace() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.editing = Some(String::new());
+        handle_edit_key(&mut s, KeyCode::Char('h'));
+        handle_edit_key(&mut s, KeyCode::Char('i'));
+        handle_edit_key(&mut s, KeyCode::Backspace);
+        assert_eq!(s.editing.as_deref(), Some("h"));
+    }
+
+    #[test]
+    fn normalize_saved_drops_blank_urls() {
+        let mut saved = SavedState {
+            global: GlobalSettings {
+                anthropic_api_url: Some(String::new()),
+                ..Default::default()
+            },
+            project: ProjectSettings {
+                anthropic_api_url: Some("https://keep.example".into()),
+                ..Default::default()
+            },
+        };
+        normalize_saved(&mut saved);
+        assert!(saved.global.anthropic_api_url.is_none());
+        assert_eq!(
+            saved.project.anthropic_api_url.as_deref(),
+            Some("https://keep.example")
+        );
+    }
+
+    #[test]
+    fn edit_key_esc_cancels_without_writing() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.global.anthropic_api_url = Some("https://keep.example".into());
+        s.editing = Some("https://discard.example".into());
+        handle_edit_key(&mut s, KeyCode::Esc);
+        assert!(s.editing.is_none());
+        assert_eq!(
+            s.global.anthropic_api_url.as_deref(),
+            Some("https://keep.example")
+        );
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -19,10 +19,41 @@ fn set_proxy_env() {
     }
 }
 
+// The env var headroom reads for a custom upstream Anthropic API URL (its
+// `proxy --anthropic-api-url` flag mirrors this). Setting it here propagates to
+// both the detached `headroom proxy` child and the exec'd `headroom wrap`.
+const ANTHROPIC_TARGET_API_URL: &str = "ANTHROPIC_TARGET_API_URL";
+
+/// Export the configured upstream Anthropic API URL so a whetstone-spawned
+/// headroom proxy targets it. An externally-set env var wins over the stored
+/// setting, and blank/whitespace settings are ignored.
+fn apply_anthropic_api_url(setting: Option<&str>) {
+    if let Some(url) = resolve_anthropic_api_url(setting, env::var(ANTHROPIC_TARGET_API_URL).ok()) {
+        env::set_var(ANTHROPIC_TARGET_API_URL, url);
+    }
+}
+
+/// Pure resolution for [`apply_anthropic_api_url`]: an existing non-empty env
+/// override takes precedence; otherwise a non-blank setting is used. `None`
+/// means "leave the environment untouched".
+fn resolve_anthropic_api_url(
+    setting: Option<&str>,
+    existing_env: Option<String>,
+) -> Option<String> {
+    if existing_env.is_some_and(|v| !v.trim().is_empty()) {
+        return None;
+    }
+    setting
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 pub fn wrap_claude(args: &[String], memory_flag: bool) -> ! {
     set_proxy_env();
 
     let resolved = resolved_settings();
+    apply_anthropic_api_url(resolved.anthropic_api_url.as_deref());
     let want_memory = memory_flag || resolved.headroom_memory;
     let decision = resolve_proxy(want_memory);
 
@@ -304,7 +335,7 @@ fn proxy_help_mentions_flag(help_text: &str, flag: &str) -> bool {
 // can't reach the models API to detect a newer Sonnet (offline / no
 // ANTHROPIC_API_KEY). If the user (or a wrapping CLI layer) already passes
 // `--model`, we leave it alone.
-const DEFAULT_MODEL: &str = "claude-opus-4-6";
+pub(crate) const DEFAULT_MODEL: &str = "claude-opus-4-6";
 
 // Resolve the model to launch with, in priority order:
 //   1. an explicit selection stored in whetstone settings (`api_model`)
@@ -527,6 +558,39 @@ mod tests {
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn resolve_api_url_uses_setting_when_env_unset() {
+        assert_eq!(
+            resolve_anthropic_api_url(Some("https://proxy.example"), None),
+            Some("https://proxy.example".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_api_url_env_override_wins() {
+        assert_eq!(
+            resolve_anthropic_api_url(
+                Some("https://setting.example"),
+                Some("https://env.example".to_string())
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_api_url_ignores_blank_setting() {
+        assert_eq!(resolve_anthropic_api_url(Some("   "), None), None);
+        assert_eq!(resolve_anthropic_api_url(None, None), None);
+    }
+
+    #[test]
+    fn resolve_api_url_ignores_blank_env_override() {
+        assert_eq!(
+            resolve_anthropic_api_url(Some("https://setting.example"), Some("  ".to_string())),
+            Some("https://setting.example".to_string())
+        );
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -58,7 +58,16 @@ pub fn wrap_claude(args: &[String], memory_flag: bool) -> ! {
     let decision = resolve_proxy(want_memory);
 
     let skip_rtk_setup = should_skip_headroom_rtk_setup();
-    let model = resolve_model(resolved.api_model.clone());
+    // An explicit `--model` suppresses the launch-time update prompt entirely;
+    // otherwise offer any newer/new-family model and honor the user's choice.
+    let user_set = user_set_model(args);
+    let fallback = resolve_model(resolved.api_model.clone());
+    let model_decision = if user_set {
+        crate::model_update::ModelDecision::NoChange
+    } else {
+        crate::model_update::maybe_prompt(&resolved)
+    };
+    let model = choose_model(user_set, model_decision, &fallback);
     let cmd_args = build_claude_args(
         args,
         skip_rtk_setup,
@@ -347,6 +356,24 @@ fn resolve_model(explicit: Option<String>) -> String {
         .unwrap_or_else(|| DEFAULT_MODEL.to_string())
 }
 
+// Fold the launch-time model-update decision into a concrete model id. An
+// explicit `--model` on the command line always wins, so `user_set` short-
+// circuits to the resolved fallback and the prompt's decision is ignored.
+fn choose_model(
+    user_set: bool,
+    decision: crate::model_update::ModelDecision,
+    fallback: &str,
+) -> String {
+    use crate::model_update::ModelDecision;
+    if user_set {
+        return fallback.to_string();
+    }
+    match decision {
+        ModelDecision::UsePinned(m) | ModelDecision::UseSession(m) => m,
+        ModelDecision::NoChange => fallback.to_string(),
+    }
+}
+
 fn build_claude_args(
     args: &[String],
     skip_rtk_setup: bool,
@@ -372,16 +399,19 @@ fn build_claude_args(
         cmd_args.push("--memory".into());
     }
 
-    let user_set_model = args
-        .iter()
-        .any(|a| a == "--model" || a.starts_with("--model="));
-    if !user_set_model {
+    if !user_set_model(args) {
         cmd_args.push("--model".into());
         cmd_args.push(model.into());
     }
 
     cmd_args.extend_from_slice(args);
     cmd_args
+}
+
+// Whether the user passed an explicit `--model` on the command line.
+fn user_set_model(args: &[String]) -> bool {
+    args.iter()
+        .any(|a| a == "--model" || a.starts_with("--model="))
 }
 
 fn should_skip_headroom_rtk_setup() -> bool {
@@ -599,6 +629,30 @@ mod tests {
             resolve_model(Some("claude-sonnet-5".to_string())),
             "claude-sonnet-5"
         );
+    }
+
+    #[test]
+    fn choose_model_uses_pinned_when_offered() {
+        let decision = crate::model_update::ModelDecision::UsePinned("claude-opus-5".into());
+        assert_eq!(choose_model(false, decision, "fallback"), "claude-opus-5");
+    }
+
+    #[test]
+    fn choose_model_uses_session_when_offered() {
+        let decision = crate::model_update::ModelDecision::UseSession("claude-opus-5".into());
+        assert_eq!(choose_model(false, decision, "fallback"), "claude-opus-5");
+    }
+
+    #[test]
+    fn choose_model_falls_back_on_no_change() {
+        let decision = crate::model_update::ModelDecision::NoChange;
+        assert_eq!(choose_model(false, decision, "fallback"), "fallback");
+    }
+
+    #[test]
+    fn choose_model_ignores_decision_when_user_set() {
+        let decision = crate::model_update::ModelDecision::UsePinned("claude-opus-5".into());
+        assert_eq!(choose_model(true, decision, "fallback"), "fallback");
     }
 
     fn create_fake_rtk_binary() -> (PathBuf, PathBuf) {


### PR DESCRIPTION
## Summary

Adds a launch-time **model-update prompt**. On `whetstone` / `whetstone claude`, whetstone checks the 12h-cached Anthropic models list and, if a model newer than the one this project runs — or a brand-new model family — is available, shows a full-screen modal offering to:

- **Pin** it as the project default (writes `api_model` to `.claude/whetstone.json`)
- **Use for this session** only (no persistence)
- **Dismiss** it permanently for this project (recorded in `dismissed_models`)
- **Not now** (offered again next launch)

The prompt is a no-op when the terminal is non-interactive, whetstone is offline, the directory is not a v3 project, or `--model` was passed explicitly.

## Design

- **Pure decision core** (`src/model_update.rs`): family-upgrade + brand-new-family offer computation, isolated from I/O for unit testing.
- **Per-project seen baseline** cached at `~/.cache/whetstone/model-seen/<hash>.json`, so a brand-new family is only surfaced once there is a prior baseline (avoids prompting on first-ever run).
- **Per-project dismissals** in the manifest's new top-level `dismissed_models` array (serde backward-compatible).
- **Full-screen ratatui modal** following the existing `settings.rs` / `dashboard.rs` TUI pattern.
- **Wiring** via a pure `choose_model(user_set, decision, fallback)` in `wrapper.rs`; an explicit `--model` suppresses the prompt entirely.

## Testing

- 26 new tests (pure offer core, seen-cache round-trips, `apply_action`, `choose_model` branches, manifest round-trips).
- `just release-check` green: `cargo fmt --check` + `cargo clippy --all-targets --all-features -D warnings` + full suite (222 unit + 3 integration).

## Docs

- `CLAUDE.md`, `docs/cli-reference.md`, `docs/configuration.md`, `CHANGELOG.md` (Unreleased).
