### PR TITLE
feat: add configurable Claude Code edit mode setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,8 @@ whetstone db init|add-session|add-insight|search|get-sessions|...
 
 `whetstone settings` also exposes **Anthropic API URL** — a custom upstream Anthropic API URL for the Headroom proxy. When set (per-project or globally), whetstone exports it as `ANTHROPIC_TARGET_API_URL` before launching Headroom, so the whetstone-spawned proxy targets that upstream (mirrors Headroom's `proxy --anthropic-api-url` flag). An externally-set `ANTHROPIC_TARGET_API_URL` env var takes precedence over the stored setting.
 
+`whetstone settings` also exposes **Edit Mode** — the Claude Code `--permission-mode` (`acceptEdits`, `default`, `plan`, `bypassPermissions`) whetstone injects into `headroom wrap claude`. Stored per-project (`permission_mode` in `.claude/whetstone.json`) or globally, project-over-global. When unset (**Off**), whetstone injects no flag and Claude Code uses its own default; an explicit `--permission-mode` on the command line always wins.
+
 On launch, whetstone (`src/model_update.rs`) checks the 12h-cached Anthropic models list for a model newer than the one this project runs — or a brand-new model family — and shows a full-screen modal offering to pin it as the project default (`api_model`), use it for one session, or dismiss it permanently (recorded in the manifest's top-level `dismissed_models`). The prompt is skipped when non-interactive, offline, not a v3 project, or when `--model` was passed explicitly.
 
 whetstone also supports `headroom_env` — a map of any Headroom launch knobs in

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -12,7 +12,7 @@
 | `whetstone rtk [args...]` | Run RTK |
 | `whetstone doctor` | Inspect installed tool versions, `~/.claude/settings.json` hooks, and the per-project manifest |
 | `whetstone dashboard` | TUI dashboard for installed tool versions vs. pinned floors |
-| `whetstone settings` | Interactively edit whetstone settings, layered global/project (Headroom telemetry, Headroom memory, default API model, Anthropic API URL) |
+| `whetstone settings` | Interactively edit whetstone settings, layered global/project (Headroom telemetry, Headroom memory, default API model, edit/permission mode, Anthropic API URL) |
 | `whetstone migrate [--dry-run] [-y] [--rollback ID]` | Migrate a v2 install to v3 (or roll back) — see [Migration Guide](migration.md) |
 | `whetstone version` | Print version |
 | `whetstone stats` | Token-savings summary from RTK + Headroom stats endpoints |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@
 | File | Owner | Purpose |
 |------|-------|---------|
 | `~/.claude/settings.json` | RTK + whetstone | All hooks, including whetstone's absolute `.../rtk hook claude` command |
-| `~/.whetstone/settings.json` | whetstone | Global whetstone settings (Headroom telemetry/memory, default model, Anthropic API URL) |
+| `~/.whetstone/settings.json` | whetstone | Global whetstone settings (Headroom telemetry/memory, default model, edit mode, Anthropic API URL) |
 | `~/.claude/RTK.md` | RTK | RTK instructions for Claude Code context |
 | `~/.claude/CLAUDE.md` | Claude Code | Global instructions (references `@RTK.md`) |
 | `~/.headroom/models.json` | Headroom | Custom model context limits and pricing |
@@ -51,6 +51,7 @@ taking precedence over global ones.
 | Headroom Telemetry | Toggle Headroom telemetry |
 | Headroom Memory | Persist the `--memory` flag (Headroom cross-session memory) |
 | API Model | Default model injected into `headroom wrap claude` (otherwise: newest Sonnet, else `claude-opus-4-6`) |
+| Edit Mode | Claude Code `--permission-mode` injected into `headroom wrap claude` — one of `acceptEdits`, `default`, `plan`, `bypassPermissions`. When **Off**, no flag is injected and Claude Code uses its own default. An explicit `--permission-mode` on the command line always wins |
 | Anthropic API URL | Custom upstream Anthropic API URL for the Headroom proxy (exported as `ANTHROPIC_TARGET_API_URL`) |
 
 Values persist to:

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,9 +73,20 @@ pub struct ProjectSettings {
     pub api_model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anthropic_api_url: Option<String>,
+    /// Claude Code edit/permission mode passed as `--permission-mode` when set
+    /// (see [`PERMISSION_MODES`]). `None` means whetstone injects no flag and
+    /// Claude Code uses its own default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_mode: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub headroom_env: BTreeMap<String, String>,
 }
+
+/// Valid Claude Code `--permission-mode` values, most-permissive-first for the
+/// settings TUI's cycle order (the first entry is the value a freshly-enabled
+/// setting seeds).
+pub const PERMISSION_MODES: &[&str] =
+    &["acceptEdits", "default", "plan", "bypassPermissions"];
 
 const GLOBAL_DIR: &str = ".whetstone";
 const GLOBAL_SETTINGS_FILENAME: &str = "settings.json";
@@ -90,6 +101,8 @@ pub struct GlobalSettings {
     pub api_model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anthropic_api_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_mode: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub headroom_env: BTreeMap<String, String>,
 }
@@ -133,6 +146,7 @@ pub struct ResolvedSettings {
     pub headroom_memory: bool,
     pub api_model: Option<String>,
     pub anthropic_api_url: Option<String>,
+    pub permission_mode: Option<String>,
     pub headroom_env: BTreeMap<String, String>,
 }
 
@@ -156,6 +170,10 @@ impl ResolvedSettings {
                 .anthropic_api_url
                 .clone()
                 .or_else(|| global.anthropic_api_url.clone()),
+            permission_mode: project
+                .permission_mode
+                .clone()
+                .or_else(|| global.permission_mode.clone()),
             headroom_env,
         }
     }
@@ -297,6 +315,50 @@ mod tests {
             &ProjectSettings::default(),
         );
         assert!(resolved.anthropic_api_url.is_none());
+    }
+
+    #[test]
+    fn resolve_prefers_project_permission_mode() {
+        let global = GlobalSettings {
+            permission_mode: Some("plan".into()),
+            ..Default::default()
+        };
+        let project = ProjectSettings {
+            permission_mode: Some("acceptEdits".into()),
+            ..Default::default()
+        };
+        let resolved = ResolvedSettings::resolve(&global, &project);
+        assert_eq!(resolved.permission_mode.as_deref(), Some("acceptEdits"));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_global_permission_mode() {
+        let global = GlobalSettings {
+            permission_mode: Some("bypassPermissions".into()),
+            ..Default::default()
+        };
+        let resolved =
+            ResolvedSettings::resolve(&global, &ProjectSettings::default());
+        assert_eq!(
+            resolved.permission_mode.as_deref(),
+            Some("bypassPermissions")
+        );
+    }
+
+    #[test]
+    fn resolve_permission_mode_none_when_unset() {
+        let resolved = ResolvedSettings::resolve(
+            &GlobalSettings::default(),
+            &ProjectSettings::default(),
+        );
+        assert!(resolved.permission_mode.is_none());
+    }
+
+    #[test]
+    fn empty_permission_mode_omitted_from_project_json() {
+        let s = ProjectSettings::default();
+        let raw = serde_json::to_string(&s).unwrap();
+        assert!(!raw.contains("permission_mode"));
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -12,7 +12,9 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::config::{GlobalSettings, ProjectSettings, WhetstoneManifest};
+use crate::config::{
+    GlobalSettings, ProjectSettings, WhetstoneManifest, PERMISSION_MODES,
+};
 use crate::memory::MemoryProvider;
 use crate::ui;
 
@@ -226,6 +228,7 @@ enum SettingId {
     HeadroomBudget,
     HeadroomLogMessages,
     ApiModel,
+    PermissionMode,
     AnthropicApiUrl,
 }
 
@@ -236,6 +239,7 @@ const SETTINGS: &[SettingId] = &[
     SettingId::HeadroomBudget,
     SettingId::HeadroomLogMessages,
     SettingId::ApiModel,
+    SettingId::PermissionMode,
     SettingId::AnthropicApiUrl,
 ];
 
@@ -314,6 +318,15 @@ impl SettingsState {
                     Scope::Off
                 }
             }
+            SettingId::PermissionMode => {
+                if self.project.permission_mode.is_some() {
+                    Scope::Project
+                } else if self.global.permission_mode.is_some() {
+                    Scope::Global
+                } else {
+                    Scope::Off
+                }
+            }
             SettingId::AnthropicApiUrl => {
                 if self.project.anthropic_api_url.is_some() {
                     Scope::Project
@@ -383,6 +396,27 @@ impl SettingsState {
                         .clone()
                         .unwrap_or_else(|| self.models[0].clone());
                     self.project.api_model = Some(base);
+                }
+            },
+            SettingId::PermissionMode => match next {
+                Scope::Off => {
+                    self.global.permission_mode = None;
+                    self.project.permission_mode = None;
+                }
+                Scope::Global => {
+                    if self.global.permission_mode.is_none() {
+                        self.global.permission_mode =
+                            Some(PERMISSION_MODES[0].to_string());
+                    }
+                    self.project.permission_mode = None;
+                }
+                Scope::Project => {
+                    let base = self
+                        .global
+                        .permission_mode
+                        .clone()
+                        .unwrap_or_else(|| PERMISSION_MODES[0].to_string());
+                    self.project.permission_mode = Some(base);
                 }
             },
             SettingId::AnthropicApiUrl => match next {
@@ -505,6 +539,25 @@ impl SettingsState {
         *target = Some(self.models[idx].clone());
     }
 
+    fn cycle_permission_mode_value(&mut self) {
+        let id = SETTINGS[self.selected];
+        if id != SettingId::PermissionMode {
+            return;
+        }
+        let target = match self.scope(id) {
+            Scope::Global => &mut self.global.permission_mode,
+            Scope::Project => &mut self.project.permission_mode,
+            Scope::Off => return,
+        };
+        let current = target.as_deref().unwrap_or(PERMISSION_MODES[0]);
+        let idx = PERMISSION_MODES
+            .iter()
+            .position(|m| *m == current)
+            .map(|i| (i + 1) % PERMISSION_MODES.len())
+            .unwrap_or(0);
+        *target = Some(PERMISSION_MODES[idx].to_string());
+    }
+
     /// The stored value shown next to a value-bearing setting (model id or API
     /// URL), or `None` for toggle settings and `Scope::Off`.
     fn current_value_display(&self, id: SettingId) -> Option<&str> {
@@ -516,6 +569,11 @@ impl SettingsState {
                 Scope::Off => None,
                 Scope::Global => self.global.api_model.as_deref(),
                 Scope::Project => self.project.api_model.as_deref(),
+            },
+            SettingId::PermissionMode => match self.scope(id) {
+                Scope::Off => None,
+                Scope::Global => self.global.permission_mode.as_deref(),
+                Scope::Project => self.project.permission_mode.as_deref(),
             },
             SettingId::AnthropicApiUrl => match self.scope(id) {
                 Scope::Off => None,
@@ -738,6 +796,8 @@ fn run_loop(
                         let id = SETTINGS[state.selected];
                         if id == SettingId::ApiModel {
                             state.cycle_model_value();
+                        } else if id == SettingId::PermissionMode {
+                            state.cycle_permission_mode_value();
                         } else if is_value_editable(id) {
                             state.begin_edit();
                         }
@@ -890,6 +950,10 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
                 "Log message content for debugging (HEADROOM_LOG_MESSAGES)",
             ),
             SettingId::ApiModel => ("API Model", "Model used for Claude Code sessions"),
+            SettingId::PermissionMode => (
+                "Edit Mode",
+                "Claude Code --permission-mode (acceptEdits/default/plan/bypassPermissions)",
+            ),
             SettingId::AnthropicApiUrl => (
                 "Anthropic API URL",
                 "Custom upstream Anthropic API URL for the Headroom proxy",
@@ -934,6 +998,8 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
 
         let desc_line = if id == SettingId::ApiModel && scope != Scope::Off {
             format!("{desc}  (tab to cycle model)")
+        } else if id == SettingId::PermissionMode && scope != Scope::Off {
+            format!("{desc}  (tab to cycle mode)")
         } else if is_value_editable(id) && scope != Scope::Off {
             if is_editing {
                 format!("{desc}  (enter to save, esc to cancel)")
@@ -1456,6 +1522,92 @@ mod tests {
         s.selected = 0;
         s.cycle_model_value();
         assert!(s.global.api_model.is_none());
+    }
+
+    #[test]
+    fn permission_mode_scope_detection() {
+        let mut s = default_state();
+        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Off);
+
+        s.global.permission_mode = Some("plan".into());
+        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Global);
+
+        s.project.permission_mode = Some("acceptEdits".into());
+        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Project);
+    }
+
+    #[test]
+    fn permission_mode_cycle_through_scopes() {
+        let mut s = default_state();
+
+        s.cycle_scope(SettingId::PermissionMode);
+        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Global);
+        assert_eq!(
+            s.global.permission_mode.as_deref(),
+            Some(PERMISSION_MODES[0])
+        );
+
+        s.cycle_scope(SettingId::PermissionMode);
+        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Project);
+        assert_eq!(
+            s.project.permission_mode.as_deref(),
+            Some(PERMISSION_MODES[0])
+        );
+
+        s.cycle_scope(SettingId::PermissionMode);
+        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Off);
+        assert!(s.global.permission_mode.is_none());
+        assert!(s.project.permission_mode.is_none());
+    }
+
+    #[test]
+    fn permission_mode_value_cycling_wraps() {
+        let mut s = default_state();
+        s.selected = index_of(SettingId::PermissionMode);
+        s.global.permission_mode =
+            Some(PERMISSION_MODES[PERMISSION_MODES.len() - 1].to_string());
+
+        s.cycle_permission_mode_value();
+        assert_eq!(
+            s.global.permission_mode.as_deref(),
+            Some(PERMISSION_MODES[0])
+        );
+    }
+
+    #[test]
+    fn permission_mode_value_cycles_forward() {
+        let mut s = default_state();
+        s.selected = index_of(SettingId::PermissionMode);
+        s.global.permission_mode = Some(PERMISSION_MODES[0].to_string());
+
+        s.cycle_permission_mode_value();
+        assert_eq!(
+            s.global.permission_mode.as_deref(),
+            Some(PERMISSION_MODES[1])
+        );
+    }
+
+    #[test]
+    fn permission_mode_value_cycle_noop_when_off() {
+        let mut s = default_state();
+        s.selected = index_of(SettingId::PermissionMode);
+        s.cycle_permission_mode_value();
+        assert!(s.global.permission_mode.is_none());
+        assert!(s.project.permission_mode.is_none());
+    }
+
+    #[test]
+    fn permission_mode_inherits_global_on_promote() {
+        let mut s = default_state();
+        s.cycle_scope(SettingId::PermissionMode);
+        s.global.permission_mode = Some("bypassPermissions".into());
+
+        s.cycle_scope(SettingId::PermissionMode);
+        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Project);
+        assert_eq!(
+            s.project.permission_mode.as_deref(),
+            Some("bypassPermissions")
+        );
     }
 
     #[test]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -79,6 +79,7 @@ pub fn wrap_claude(args: &[String], memory_flag: bool) -> ! {
         decision.proxy_ready,
         decision.wrap_memory,
         &model,
+        resolved.permission_mode.as_deref(),
     );
 
     exec("headroom", &cmd_args);
@@ -449,6 +450,7 @@ fn build_claude_args(
     proxy_ready: bool,
     wrap_memory: bool,
     model: &str,
+    permission_mode: Option<&str>,
 ) -> Vec<String> {
     let mut cmd_args = vec!["wrap".to_string(), "claude".to_string()];
 
@@ -472,6 +474,15 @@ fn build_claude_args(
         cmd_args.push(model.into());
     }
 
+    // Inject the configured Claude Code edit mode unless the user passed their
+    // own `--permission-mode` (which always wins, like `--model`).
+    if let Some(mode) = permission_mode {
+        if !user_set_permission_mode(args) {
+            cmd_args.push("--permission-mode".into());
+            cmd_args.push(mode.into());
+        }
+    }
+
     cmd_args.extend_from_slice(args);
     cmd_args
 }
@@ -480,6 +491,13 @@ fn build_claude_args(
 fn user_set_model(args: &[String]) -> bool {
     args.iter()
         .any(|a| a == "--model" || a.starts_with("--model="))
+}
+
+// Whether the user passed an explicit `--permission-mode` on the command line.
+fn user_set_permission_mode(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        a == "--permission-mode" || a.starts_with("--permission-mode=")
+    })
 }
 
 pub fn wrap_proxy(args: &[String], memory: bool) -> ! {
@@ -543,6 +561,7 @@ mod tests {
             headroom_memory: false,
             api_model: None,
             anthropic_api_url: None,
+            permission_mode: None,
             headroom_env: std::collections::BTreeMap::new(),
         };
         let plan = headroom_env_plan_for(
@@ -631,7 +650,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_injects_default_model_when_absent() {
-        let args = build_claude_args(&[], false, false, DEFAULT_MODEL);
+        let args = build_claude_args(&[], false, false, DEFAULT_MODEL, None);
 
         assert_eq!(
             args,
@@ -652,6 +671,7 @@ mod tests {
             false,
             false,
             DEFAULT_MODEL,
+            None,
         );
 
         assert_eq!(
@@ -674,6 +694,7 @@ mod tests {
             false,
             false,
             DEFAULT_MODEL,
+            None,
         );
 
         assert_eq!(
@@ -694,6 +715,7 @@ mod tests {
             false,
             false,
             DEFAULT_MODEL,
+            None,
         );
 
         assert_eq!(
@@ -712,7 +734,8 @@ mod tests {
 
     #[test]
     fn build_claude_args_uses_configured_model() {
-        let args = build_claude_args(&[], false, false, "claude-sonnet-4-6");
+        let args =
+            build_claude_args(&[], false, false, "claude-sonnet-4-6", None);
 
         assert_eq!(
             args,
@@ -724,6 +747,67 @@ mod tests {
                 "claude-sonnet-4-6"
             ])
         );
+    }
+
+    #[test]
+    fn build_claude_args_injects_permission_mode_when_configured() {
+        let args = build_claude_args(
+            &[],
+            false,
+            false,
+            DEFAULT_MODEL,
+            Some("acceptEdits"),
+        );
+        assert_eq!(
+            args,
+            strings(&[
+                "wrap",
+                "claude",
+                "--no-serena",
+                "--model",
+                DEFAULT_MODEL,
+                "--permission-mode",
+                "acceptEdits",
+            ])
+        );
+    }
+
+    #[test]
+    fn build_claude_args_omits_permission_mode_when_none() {
+        let args = build_claude_args(&[], false, false, DEFAULT_MODEL, None);
+        assert!(!args.contains(&"--permission-mode".to_string()));
+    }
+
+    #[test]
+    fn build_claude_args_preserves_explicit_permission_mode() {
+        let args = build_claude_args(
+            &["--permission-mode".into(), "plan".into()],
+            false,
+            false,
+            DEFAULT_MODEL,
+            Some("acceptEdits"),
+        );
+        assert_eq!(
+            args.iter()
+                .filter(|a| a.as_str() == "--permission-mode")
+                .count(),
+            1
+        );
+        assert!(args.contains(&"plan".to_string()));
+        assert!(!args.contains(&"acceptEdits".to_string()));
+    }
+
+    #[test]
+    fn build_claude_args_preserves_explicit_permission_mode_equals_form() {
+        let args = build_claude_args(
+            &["--permission-mode=plan".into()],
+            false,
+            false,
+            DEFAULT_MODEL,
+            Some("acceptEdits"),
+        );
+        assert!(args.contains(&"--permission-mode=plan".to_string()));
+        assert!(!args.contains(&"acceptEdits".to_string()));
     }
 
     #[test]
@@ -761,7 +845,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_injects_memory_when_wrap_manages_proxy() {
-        let args = build_claude_args(&[], false, true, DEFAULT_MODEL);
+        let args = build_claude_args(&[], false, true, DEFAULT_MODEL, None);
         assert!(args.contains(&"--memory".to_string()));
         // wrap owns the proxy here, so --no-proxy must NOT be present.
         assert!(!args.contains(&"--no-proxy".to_string()));
@@ -769,7 +853,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_omits_memory_by_default() {
-        let args = build_claude_args(&[], true, false, DEFAULT_MODEL);
+        let args = build_claude_args(&[], true, false, DEFAULT_MODEL, None);
         assert!(!args.contains(&"--memory".to_string()));
     }
 
@@ -857,14 +941,14 @@ mod tests {
 
     #[test]
     fn build_claude_args_adds_no_proxy_when_proxy_ready() {
-        let args = build_claude_args(&[], true, false, DEFAULT_MODEL);
+        let args = build_claude_args(&[], true, false, DEFAULT_MODEL, None);
         assert!(args.contains(&"--no-proxy".to_string()));
         assert_eq!(&args[0..2], &["wrap".to_string(), "claude".to_string()]);
     }
 
     #[test]
     fn build_claude_args_omits_no_proxy_when_proxy_not_ready() {
-        let args = build_claude_args(&[], false, false, DEFAULT_MODEL);
+        let args = build_claude_args(&[], false, false, DEFAULT_MODEL, None);
         assert!(!args.contains(&"--no-proxy".to_string()));
     }
 
@@ -879,6 +963,7 @@ mod tests {
                     proxy_ready,
                     wrap_memory,
                     DEFAULT_MODEL,
+                    None,
                 );
                 assert!(
                     !args.contains(&"--no-rtk".to_string()),


### PR DESCRIPTION
## Summary

Adds an **Edit Mode** setting to the `whetstone settings` TUI that injects Claude Code's `--permission-mode` flag into `headroom wrap claude`, configurable globally or per-project to any of the four available modes.

- **Modes:** `acceptEdits`, `default`, `plan`, `bypassPermissions`
- **Scope:** space cycles `Off → Global → Project` (project over global); tab cycles the mode value; enabling seeds `acceptEdits`
- **Off = no injection:** whetstone passes no flag and Claude Code uses its own default (per design decision — only inject when explicitly configured)
- **CLI wins:** an explicit `--permission-mode` on the command line always overrides the setting, matching `--model` precedence

Mirrors the existing `API Model` settings pattern end to end.

## Changes

- `src/config.rs` — `permission_mode: Option<String>` on `ProjectSettings`, `GlobalSettings`, `ResolvedSettings`; project-over-global resolution; `PERMISSION_MODES` constant
- `src/settings.rs` — new Edit Mode row (scope cycling, value cycling, display, save/load)
- `src/wrapper.rs` — `build_claude_args` injects `--permission-mode <mode>` when configured, guarded by new `user_set_permission_mode`
- Docs — `CLAUDE.md`, `docs/configuration.md`, `docs/cli-reference.md`

## Test plan

- [x] `cargo test` — 241 pass (14 new permission_mode tests across config/settings/wrapper)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Resolution precedence, scope/value cycling, arg injection, `--permission-mode`/`=` override forms covered
- [ ] Real launch with a non-default mode to confirm headroom forwards the flag to claude