### PR TITLE
fix: actually check and upgrade ICM in whetstone update

### DIFF
--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -9,7 +9,7 @@ use ratatui::{
 };
 use std::time::{Duration, Instant};
 
-use crate::{headroom, rtk, update, version};
+use crate::{headroom, icm, rtk, update, version};
 
 const POLL_MS: u64 = 250;
 const REFRESH_SECS: u64 = 30;
@@ -93,6 +93,9 @@ impl DashboardState {
         let headroom_latest = is_outdated("headroom")
             .map(|c| c.latest.clone())
             .or_else(headroom::installed_version);
+        let icm_latest = is_outdated("memory (ICM)")
+            .map(|c| c.latest.clone())
+            .or_else(icm::installed_version);
 
         self.components = vec![
             ComponentInfo {
@@ -111,9 +114,9 @@ impl DashboardState {
                 latest: rtk_latest,
             },
             ComponentInfo {
-                name: "memory",
-                installed: Some("ICM (embedded)".into()),
-                latest: None,
+                name: "memory (ICM)",
+                installed: icm::installed_version(),
+                latest: icm_latest,
             },
         ];
         self.last_refresh = Instant::now();

--- a/src/icm.rs
+++ b/src/icm.rs
@@ -1,0 +1,79 @@
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::process::Command;
+
+use crate::ui;
+use crate::version;
+
+/// ICM publishes GitHub releases tagged `icm-vX.Y.Z` (e.g. `icm-v0.10.61`).
+/// `extract_semver` pulls the `X.Y.Z` out of that tag regardless of prefix.
+const GITHUB_LATEST_URL: &str =
+    "https://api.github.com/repos/rtk-ai/icm/releases/latest";
+
+#[derive(Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+}
+
+pub fn latest_remote_version() -> Option<String> {
+    let resp = ureq::get(GITHUB_LATEST_URL)
+        .set("User-Agent", "whetstone")
+        .call()
+        .ok()?;
+    let body = resp.into_string().ok()?;
+    let release: GithubRelease = serde_json::from_str(&body).ok()?;
+    version::extract_semver(&release.tag_name)
+}
+
+pub fn installed_version() -> Option<String> {
+    let output = Command::new("icm").arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    version::extract_semver(&raw)
+}
+
+/// Upgrade ICM via its own self-updater (`icm upgrade --apply`). ICM owns its
+/// install/upgrade path, so we delegate rather than re-run the install script.
+pub fn update() -> Result<ui::ComponentStatus> {
+    let Some(old_ver) = installed_version() else {
+        return Ok(ui::ComponentStatus::NotInstalled);
+    };
+
+    let output = Command::new("icm")
+        .arg("upgrade")
+        .arg("--apply")
+        .output()
+        .context("failed to run icm upgrade --apply")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("icm upgrade failed: {stderr}");
+    }
+
+    let new_ver = installed_version().unwrap_or_else(|| old_ver.clone());
+    if new_ver != old_ver {
+        Ok(ui::ComponentStatus::Updated(old_ver, new_ver))
+    } else {
+        Ok(ui::ComponentStatus::UpToDate(old_ver))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_prefixed_icm_release_tag() {
+        // ICM tags releases `icm-vX.Y.Z`, not a bare `vX.Y.Z` — the extractor
+        // must still recover the semver from the prefixed tag.
+        let json = r#"{"tag_name":"icm-v0.10.61"}"#;
+        let release: GithubRelease = serde_json::from_str(json).unwrap();
+        assert_eq!(release.tag_name, "icm-v0.10.61");
+        assert_eq!(
+            version::extract_semver(&release.tag_name),
+            Some("0.10.61".into()),
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod db;
 mod doctor;
 mod headroom;
 mod headroom_env;
+mod icm;
 mod integrations;
 mod memory;
 mod memory_consolidate;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -234,7 +234,7 @@ pub(crate) fn refresh_all_assets(assets: &Path) -> Result<()> {
 /// (e.g. `whetstone update`'s per-project refresh) can update
 /// [`crate::config::ToolVersions`] without duplicating the spawn.
 pub(crate) fn current_icm_version() -> Option<String> {
-    installed_icm_version()
+    crate::icm::installed_version()
 }
 
 /// Install the memory provider's binary only. Integration (init) happens in
@@ -283,7 +283,7 @@ fn write_manifest(provider: MemoryProvider) -> Result<()> {
     let manifest_path = WhetstoneManifest::path_for(&project_dir);
     let tools = ToolVersions {
         rtk: rtk::installed_version(),
-        icm: installed_icm_version(),
+        icm: crate::icm::installed_version(),
         headroom: headroom::installed_version(),
     };
     let mut manifest = config::WhetstoneManifest::new(provider, tools);
@@ -297,15 +297,6 @@ fn write_manifest(provider: MemoryProvider) -> Result<()> {
     manifest.save(&manifest_path)?;
     ui::ok(&format!("wrote manifest to {}", manifest_path.display()));
     Ok(())
-}
-
-fn installed_icm_version() -> Option<String> {
-    let output = std::process::Command::new("icm")
-        .arg("--version")
-        .output()
-        .ok()?;
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    crate::version::extract_semver(&raw)
 }
 
 fn copy_subdirs(assets: &Path, claude_dir: &Path, force: bool) -> Result<()> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -8,7 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::config::{ToolVersions, WhetstoneManifest, INTEGRATION_VERSION};
 use crate::memory::MemoryProvider;
 use crate::{
-    claude_code, doctor, headroom, integrations, migrate, rtk, setup, ui,
+    claude_code, doctor, headroom, icm, integrations, migrate, rtk, setup, ui,
     version,
 };
 
@@ -33,6 +33,10 @@ struct VersionCache {
     claude_code_latest: Option<String>,
     #[serde(default)]
     claude_code_current: Option<String>,
+    #[serde(default)]
+    icm_latest: Option<String>,
+    #[serde(default)]
+    icm_current: Option<String>,
     /// Phase 4.3: bundled `INTEGRATION_VERSION` at last cache write.
     /// `#[serde(default)]` so v1-format caches still parse.
     #[serde(default)]
@@ -84,6 +88,8 @@ fn read_cache() -> Option<VersionCache> {
         headroom_current: None,
         claude_code_latest: None,
         claude_code_current: None,
+        icm_latest: None,
+        icm_current: None,
         integration_version_bundled: None,
         integration_version_project: None,
         timestamp: ts,
@@ -158,6 +164,18 @@ pub fn check_cached_upgrade() -> Vec<OutdatedComponent> {
         if version::is_older(current, latest) {
             outdated.push(OutdatedComponent {
                 name: "claude code",
+                current: current.clone(),
+                latest: latest.clone(),
+            });
+        }
+    }
+
+    if let (Some(current), Some(latest)) =
+        (&cache.icm_current, &cache.icm_latest)
+    {
+        if version::is_older(current, latest) {
+            outdated.push(OutdatedComponent {
+                name: "memory (ICM)",
                 current: current.clone(),
                 latest: latest.clone(),
             });
@@ -577,7 +595,26 @@ pub fn run(full: bool) -> Result<()> {
     };
     ui::component_line("claude code", &claude_code_status);
 
-    let memory_status = ui::ComponentStatus::UpToDate("embedded".into());
+    let icm_current = icm::installed_version();
+    let icm_remote = icm::latest_remote_version();
+    let memory_status = match dependency_decision(
+        icm_current.as_deref(),
+        icm_remote.as_deref(),
+        full,
+    ) {
+        DependencyDecision::UpToDate(v) => ui::ComponentStatus::UpToDate(v),
+        DependencyDecision::Refresh => match icm::update() {
+            Ok(status) => {
+                warn_if_upgrade_stuck("icm", &status, icm_remote.as_deref());
+                status
+            }
+            Err(e) => ui::ComponentStatus::Failed(format!("{e:#}")),
+        },
+        DependencyDecision::NotInstalled => ui::ComponentStatus::NotInstalled,
+    };
+    if matches!(&memory_status, ui::ComponentStatus::Updated(_, _)) {
+        updated_count += 1;
+    }
     ui::component_line("memory (ICM)", &memory_status);
 
     // Phase 4.1: per-project integration refresh. Logs and never aborts
@@ -603,6 +640,8 @@ pub fn run(full: bool) -> Result<()> {
         claude_code_current: claude_code::installed_version(),
         claude_code_latest: claude_code::installed_version()
             .or(claude_code_remote),
+        icm_current: icm::installed_version(),
+        icm_latest: icm::installed_version().or(icm_remote),
         integration_version_bundled: Some(INTEGRATION_VERSION),
         integration_version_project: project_integration_version,
         timestamp: now_epoch(),
@@ -624,7 +663,8 @@ pub fn run(full: bool) -> Result<()> {
                 || matches!(
                     &claude_code_status,
                     ui::ComponentStatus::Failed(_)
-                );
+                )
+                || matches!(&memory_status, ui::ComponentStatus::Failed(_));
 
         if has_failures {
             ui::summary_info(
@@ -786,6 +826,8 @@ mod tests {
             headroom_current: Some("0.23.0".into()),
             claude_code_latest: Some("2.1.172".into()),
             claude_code_current: Some("2.1.153".into()),
+            icm_latest: Some("0.10.61".into()),
+            icm_current: Some("0.10.43".into()),
             integration_version_bundled: Some(INTEGRATION_VERSION),
             integration_version_project: Some(1),
             timestamp: 1_700_000_000,
@@ -800,6 +842,8 @@ mod tests {
         assert_eq!(parsed.integration_version_project, Some(1));
         assert_eq!(parsed.claude_code_latest, Some("2.1.172".into()));
         assert_eq!(parsed.claude_code_current, Some("2.1.153".into()));
+        assert_eq!(parsed.icm_latest, Some("0.10.61".into()));
+        assert_eq!(parsed.icm_current, Some("0.10.43".into()));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

\`whetstone update\` (and \`whetstone dashboard\`) hardcoded the memory provider's status as **\"embedded (up to date)\"**:

\`\`\`rust
let memory_status = ui::ComponentStatus::UpToDate("embedded".into());
\`\`\`

It never ran \`icm --version\` or \`icm upgrade\`, so a stale ICM was always reported as current. In practice \`icm\` was at \`0.10.43\` while \`0.10.61\` was released, yet \`whetstone update\` still said "up to date". ICM is no longer embedded — it's an external binary (\`~/.local/bin/icm\`) with GitHub releases and its own \`icm upgrade --apply\`.

## Fix

- **New \`src/icm.rs\`** (mirrors \`rtk.rs\`): \`installed_version()\`, \`latest_remote_version()\` (GitHub \`rtk-ai/icm\` releases; tags are \`icm-vX.Y.Z\`, so \`extract_semver\` recovers the semver), and \`update()\` delegating to \`icm upgrade --apply\` with old→new reporting.
- **\`update.rs\`**: routes ICM through the same \`dependency_decision → update\` path as rtk/headroom (respects \`--full\`, counts toward the updated total, surfaces failures). Caches \`icm_current\`/\`icm_latest\` so the 12h startup banner nags about ICM too.
- **\`dashboard.rs\`**: the memory row now shows real installed vs latest ICM versions.
- **\`setup.rs\`**: reuses \`icm::installed_version()\`, dropping the duplicate helper.

## Test plan

- [x] \`cargo build\`, \`cargo clippy --all-targets\` (clean), \`cargo fmt --check\` (clean)
- [x] \`cargo test\` — 258 pass, incl. new coverage for the \`icm-v\` prefixed tag parsing
- [ ] Manual: run \`whetstone update\` with an out-of-date \`icm\` and confirm it upgrades instead of reporting "embedded"