### PR TITLE
feat: add HEADROOM_BEACON opt-out toggle to settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,7 @@ rtk pnpm install        # Compact install output (90%)
 rtk npm run <script>    # Compact npm script output
 rtk npx <cmd>           # Compact npx command output
 rtk prisma              # Prisma without ASCII art (88%)
+rtk uv run <cmd>        # Compact uv project command output
 ```
 
 ### Files & Search (60-75% savings)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -223,6 +223,7 @@ impl Scope {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SettingId {
     HeadroomTelemetry,
+    HeadroomBeacon,
     HeadroomMemory,
     HeadroomTargetRatio,
     HeadroomBudget,
@@ -234,6 +235,7 @@ enum SettingId {
 
 const SETTINGS: &[SettingId] = &[
     SettingId::HeadroomTelemetry,
+    SettingId::HeadroomBeacon,
     SettingId::HeadroomMemory,
     SettingId::HeadroomTargetRatio,
     SettingId::HeadroomBudget,
@@ -262,6 +264,9 @@ fn env_knob(id: SettingId) -> Option<(&'static str, EnvKind)> {
         SettingId::HeadroomBudget => Some(("HEADROOM_BUDGET", EnvKind::Value)),
         SettingId::HeadroomLogMessages => {
             Some(("HEADROOM_LOG_MESSAGES", EnvKind::Toggle("1")))
+        }
+        SettingId::HeadroomBeacon => {
+            Some(("HEADROOM_BEACON", EnvKind::Toggle("off")))
         }
         _ => None,
     }
@@ -292,7 +297,8 @@ impl SettingsState {
         match id {
             SettingId::HeadroomTargetRatio
             | SettingId::HeadroomBudget
-            | SettingId::HeadroomLogMessages => {
+            | SettingId::HeadroomLogMessages
+            | SettingId::HeadroomBeacon => {
                 self.env_scope(env_knob(id).unwrap().0)
             }
             SettingId::HeadroomTelemetry => {
@@ -351,7 +357,8 @@ impl SettingsState {
         match id {
             SettingId::HeadroomTargetRatio
             | SettingId::HeadroomBudget
-            | SettingId::HeadroomLogMessages => unreachable!(),
+            | SettingId::HeadroomLogMessages
+            | SettingId::HeadroomBeacon => unreachable!(),
             SettingId::HeadroomTelemetry => match next {
                 Scope::Off => {
                     self.global.headroom_telemetry = false;
@@ -933,6 +940,10 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
                 "Headroom Telemetry",
                 "Send anonymous usage data to Headroom",
             ),
+            SettingId::HeadroomBeacon => (
+                "Headroom Beacon",
+                "Opt out of the anonymous telemetry upload beacon (HEADROOM_BEACON=off)",
+            ),
             SettingId::HeadroomMemory => (
                 "Headroom Memory",
                 "Enable Headroom persistent cross-session memory (proxy --memory)",
@@ -1272,6 +1283,43 @@ mod tests {
         assert_eq!(s.scope(id), Scope::Off);
         assert!(s.global.headroom_env.is_empty());
         assert!(s.project.headroom_env.is_empty());
+    }
+
+    #[test]
+    fn beacon_toggle_cycle_writes_opt_out_value() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomBeacon;
+        assert_eq!(s.scope(id), Scope::Off);
+
+        s.cycle_scope(id);
+        assert_eq!(s.scope(id), Scope::Global);
+        assert_eq!(
+            s.global
+                .headroom_env
+                .get("HEADROOM_BEACON")
+                .map(String::as_str),
+            Some("off")
+        );
+
+        s.cycle_scope(id);
+        assert_eq!(s.scope(id), Scope::Project);
+        assert_eq!(
+            s.project
+                .headroom_env
+                .get("HEADROOM_BEACON")
+                .map(String::as_str),
+            Some("off")
+        );
+
+        s.cycle_scope(id);
+        assert_eq!(s.scope(id), Scope::Off);
+        assert!(s.global.headroom_env.is_empty());
+        assert!(s.project.headroom_env.is_empty());
+    }
+
+    #[test]
+    fn beacon_is_not_free_text_editable() {
+        assert!(!is_value_editable(SettingId::HeadroomBeacon));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds the Headroom **anonymous telemetry upload beacon** (`HEADROOM_BEACON`) as a first-class setting in `whetstone settings`.

The beacon is **on by default (opt-out)** in Headroom. Since the only meaningful action is opting out, the entry is an `EnvKind::Toggle("off")` — cycling it to global/project scope writes `HEADROOM_BEACON=off` into the `headroom_env` map; **Off** leaves it unset so Headroom's default (on) applies.

It sits directly after **Headroom Telemetry**, grouping the two data-privacy switches together.

## Behavior

```
  off | g | p   Headroom Beacon
                  Opt out of the anonymous telemetry upload beacon (HEADROOM_BEACON=off)
```

- **Off** → nothing written, beacon stays on (Headroom default)
- **g / p** → writes `HEADROOM_BEACON=off` to global or project `headroom_env`

No launch-path changes needed — `HEADROOM_BEACON` already flows through `build_headroom_env`'s passthrough map, and an externally-set `HEADROOM_BEACON` env var still wins over the stored setting.

## Implementation

Follows the existing `env_knob` pattern (identical shape to `HEADROOM_LOG_MESSAGES`): new `SettingId::HeadroomBeacon`, added to `SETTINGS`, `env_knob`, both exhaustive `scope()`/`cycle_scope()` arms, and the `draw_entries` label/description.

## Tests

- `beacon_toggle_cycle_writes_opt_out_value` — Off → Global → Project → Off, asserting `HEADROOM_BEACON=off` at each active scope
- `beacon_is_not_free_text_editable`

`cargo fmt --check`, `cargo clippy --all-targets`, and the full suite (260 passed, 0 failed) all green.