### PR TITLE
feat: add install-tools command and doctor startup/extras verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ AGENTS.md
 # local agent shit
 /.headroom
 /.tokensave
+.tokensave

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to whetstone will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `whetstone install-tools` — install or repair every managed dependency
+  (headroom, rtk, claude code, memory provider), re-run their `init` hooks,
+  and resync the project manifest; `--force` reinstalls everything
+- `whetstone doctor` now checks that the managed dependencies still exist
+  before inspecting `~/.claude/settings.json`, offers to reinstall the missing
+  ones (`--fix` skips the prompt), and reports missing system prerequisites
+- launching a managed tool that was uninstalled now offers to reinstall it
+  instead of failing with a bare `exec` error
+
+- `whetstone doctor` now verifies that headroom actually **starts**: it probes
+  the running proxy, or spawns a throwaway one on a free port with the same
+  args and env whetstone launches with, and reports headroom's own startup
+  error when it dies. A start blocked by a rollout-gated flag (e.g.
+  `read_maturation` in `~/.headroom/settings.json`) is offered for removal —
+  `--fix` removes it, with a backup, and re-checks
+
+### Fixed
+
+- whetstone now verifies headroom's *extras*, not just its version: an install
+  recorded by uv without `proxy`/`code`/`mcp` is reported by `doctor` and
+  reinstalled as `headroom-ai[proxy,code,mcp]` instead of passing as healthy
+
 ## [3.11.0] - 2026-08-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,8 @@ whetstone rtk [args...]
 whetstone version
 whetstone dashboard                    # TUI: installed tool versions vs pinned floors
 whetstone settings                     # Interactive layered settings (global/project)
-whetstone doctor                       # Inspect ~/.claude/settings.json + manifest, report drift
+whetstone doctor [--fix]               # Check dependencies + ~/.claude/settings.json, report drift
+whetstone install-tools [--force]      # Install/repair headroom, rtk, claude code, memory provider
 whetstone migrate [--dry-run] [-y] [--rollback ID]   # v2 → v3 migration (reversible)
 whetstone stats                        # Token savings across RTK + Headroom
 whetstone update [--full]
@@ -69,6 +70,37 @@ whetstone memory consolidate [--dry-run]   # drain stray project-local .headroom
 `--headroom-extras` accepts: `all` (default = `proxy,code,mcp`), `none`, or comma-separated like `proxy,code`.
 
 `--memory` is a global flag (e.g. `whetstone --memory`, `whetstone --memory claude`). It enables Headroom persistent cross-session memory by passing `--memory` to the proxy whetstone spawns. If a proxy is already running *without* memory, whetstone prompts: restart it with memory (replaces the global proxy), start a memory proxy for this session only, or cancel. It can also be set persistently per-project or globally via `whetstone settings` (Headroom Memory).
+
+`whetstone doctor` checks the managed dependencies (headroom, rtk, claude
+code, and the project's memory provider) before it looks at hooks: a tool that
+is missing or no longer runnable is offered for reinstall in interactive runs,
+reported with a pointer to `whetstone install-tools` otherwise, and reinstalled
+without prompting under `--fix`. A repaired tool's own `init` is re-run so its
+hooks come back before the settings checks look for them.
+`whetstone install-tools` drives the same repair path directly, also installing
+`uv` if it went missing, restoring the `~/.local/bin/whetstone` symlink, and
+resyncing `tool_versions` in the project manifest.
+
+Doctor also runs a **startup check**: if a proxy is already answering on
+`127.0.0.1:8787` that counts as proof, otherwise whetstone spawns a throwaway
+`headroom proxy` on a free port (same args/env as a real launch, killed after a
+6s grace window) and reports headroom's own error if it exits. This catches the
+case every other check misses — headroom installed, current, and complete, but
+dead on arrival because its own `~/.headroom/settings.json` asks for a flag the
+current rollout channel rejects. When the error names such a flag, doctor maps
+it back to the settings key and offers to remove it (prompt when interactive,
+automatic under `--fix`, backing the file up first), then re-runs the check.
+Note the fast path's blind spot: a proxy still running from before a settings
+change reports OK even though the next start would fail.
+
+Headroom is checked by *extras* as well as version: whetstone reads uv's
+receipt (`$UV_TOOL_DIR`/`~/.local/share/uv/tools/headroom-ai/uv-receipt.toml`)
+and treats an install missing any requested extra as needing repair, so a bare
+`headroom-ai` can't pass as healthy while `headroom proxy`/`headroom mcp` are
+absent. Both commands default to `--headroom-extras all`
+(`headroom-ai[proxy,code,mcp]`); pass the same value you set up with if you
+deliberately installed a smaller set. An install uv didn't record (e.g. pip)
+reports unknown extras and is left alone.
 
 `whetstone settings` also exposes **Anthropic API URL** — a custom upstream Anthropic API URL for the Headroom proxy. When set (per-project or globally), whetstone exports it as `ANTHROPIC_TARGET_API_URL` before launching Headroom, so the whetstone-spawned proxy targets that upstream (mirrors Headroom's `proxy --anthropic-api-url` flag). An externally-set `ANTHROPIC_TARGET_API_URL` env var takes precedence over the stored setting.
 
@@ -120,10 +152,11 @@ src/
 ├── claude_code.rs   # Claude Code launch/detection helpers
 ├── integrations.rs  # Delegates to `rtk init` / `icm init` (tool-managed hooks)
 ├── migrate.rs       # v2 → v3 migration + reversible rollback
-├── doctor.rs        # Inspect settings.json + manifest, report drift
+├── doctor.rs        # Check dependencies + settings.json, repair/report drift
 ├── dashboard.rs     # TUI: installed tool versions vs pinned floors
 ├── settings.rs      # Interactive layered global/project settings TUI
 ├── stats.rs         # Token-savings summary (RTK + Headroom)
+├── tools.rs         # Managed-dependency inventory: presence checks, repair, install-tools
 ├── update.rs        # 12h-cached remote version check + self-update
 ├── release.rs       # Release preflight, version bump, and PR creation
 ├── changelog.rs     # CHANGELOG.md parsing / site changelog sync

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,8 +1,31 @@
 # Troubleshooting
 
+## `headroom proxy` exits immediately
+
+```bash
+whetstone doctor          # runs headroom and reports its actual startup error
+whetstone doctor --fix    # removes a rollout-blocked key from ~/.headroom/settings.json
+```
+
+Headroom turns keys in its own `~/.headroom/settings.json` into proxy flags. A
+feature that later moves behind a rollout channel (`headroom rollout status`
+shows `decision=blocked_by_channel`) then fails every start. Remove the key, or
+keep the feature with `HEADROOM_ROLLOUT_CHANNEL=beta` — for whetstone-spawned
+proxies, set that in the `headroom_env` map via `whetstone settings`.
+
+## A tool whetstone installed is suddenly gone
+
+```bash
+whetstone doctor           # says what's missing, offers to reinstall
+whetstone install-tools    # install/repair everything without the questions
+whetstone install-tools --force   # reinstall even what looks healthy
+```
+
 ## "headroom: command not found"
 
 ```bash
+whetstone install-tools
+# Or by hand:
 uv tool install "headroom-ai[proxy,code,mcp]"
 # If installed but not on PATH:
 python3 -m headroom proxy --port 8787
@@ -11,7 +34,8 @@ python3 -m headroom proxy --port 8787
 ## "rtk: command not found"
 
 ```bash
-# Install
+whetstone install-tools
+# Or by hand:
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
 # Add to PATH
 export PATH="$HOME/.local/bin:$PATH"

--- a/src/claude_code.rs
+++ b/src/claude_code.rs
@@ -90,6 +90,36 @@ fn detect_install_method_from_path(
     InstallMethod::Unknown
 }
 
+/// Install Claude Code globally via npm.
+///
+/// Claude Code is the one managed dependency whetstone can't install without
+/// a Node toolchain, so bail with an actionable message rather than letting
+/// `npm` fail obscurely.
+pub fn install() -> Result<()> {
+    if which::which("npm").is_err() {
+        bail!(
+            "npm not found — install Node.js (https://nodejs.org) then rerun, \
+             or install Claude Code yourself"
+        );
+    }
+
+    ui::info(
+        "installing claude code (npm install -g @anthropic-ai/claude-code)",
+    );
+    run_npm_install()?;
+    ensure_config_install_method_is_npm();
+
+    match installed_version() {
+        Some(ver) => {
+            ui::ok(&format!("claude code {ver}"));
+            Ok(())
+        }
+        None => bail!(
+            "claude code installed but `claude` is not on PATH — check your npm global bin dir"
+        ),
+    }
+}
+
 pub fn update() -> Result<ui::ComponentStatus> {
     let Some(old_ver) = installed_version() else {
         return Ok(ui::ComponentStatus::NotInstalled);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,8 +79,30 @@ pub enum Command {
     /// Modify project settings interactively
     Settings,
 
-    /// Inspect ~/.claude/settings.json and report problems (Phase 1 task 1.2)
-    Doctor,
+    /// Check dependencies + ~/.claude/settings.json and report problems
+    Doctor {
+        /// Reinstall missing dependencies without prompting
+        #[arg(long)]
+        fix: bool,
+
+        /// Headroom pip extras used when reinstalling: "all" (default),
+        /// "none", or comma-separated like "proxy,code"
+        #[arg(long, default_value = "all")]
+        headroom_extras: String,
+    },
+
+    /// Install or repair every managed dependency (headroom, rtk, claude
+    /// code, memory provider) and re-wire their hooks
+    InstallTools {
+        /// Reinstall/upgrade everything, not just what is missing
+        #[arg(long)]
+        force: bool,
+
+        /// Headroom pip extras: "all" (default), "none", or
+        /// comma-separated like "proxy,code"
+        #[arg(long, default_value = "all")]
+        headroom_extras: String,
+    },
 
     /// Migrate a v2 install to v3 (Phase 3)
     Migrate {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -11,6 +11,13 @@
 //!
 //! Anything else found in `settings.json` (custom user hooks, other MCP
 //! servers, model preferences, etc.) is left alone.
+//!
+//! Before touching settings at all, doctor now checks that the managed
+//! dependencies themselves still exist (`src/tools.rs`). A hook entry that
+//! points at a binary somebody uninstalled is not a settings problem, and
+//! reordering it would have reported "green" on a broken machine. Missing
+//! tools are offered for reinstall (interactive runs) or reported with a
+//! pointer to `whetstone install-tools`.
 
 use anyhow::{Context, Result};
 use serde_json::Value;
@@ -18,7 +25,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::headroom;
+use crate::tools::{self, RepairMode, ToolOutcome};
 use crate::ui;
+use crate::wrapper::{self, ProxyStartCheck};
 
 /// Status of a single check.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,6 +62,12 @@ impl DoctorReport {
             .all(|f| !matches!(f.status, Status::Warning(_)))
     }
 
+    /// Fold another report's findings in, preserving `mutated`.
+    fn merge(&mut self, other: DoctorReport) {
+        self.mutated |= other.mutated;
+        self.findings.extend(other.findings);
+    }
+
     fn push(&mut self, label: &str, status: Status) {
         if matches!(status, Status::Normalized(_)) {
             self.mutated = true;
@@ -65,11 +81,167 @@ impl DoctorReport {
 
 /// Entry point for `whetstone doctor`. Returns the report so callers (setup,
 /// tests, future TUI) can examine it; also prints a human-readable summary.
+///
+/// Interactive runs prompt before reinstalling anything that went missing;
+/// non-interactive runs degrade to reporting (see [`RepairMode::effective`]).
 pub fn run() -> Result<DoctorReport> {
+    run_with(RepairMode::Prompt, "all")
+}
+
+/// `whetstone doctor --fix`: reinstall missing dependencies without asking.
+pub fn run_fix(extras: &str) -> Result<DoctorReport> {
+    run_with(RepairMode::Force, extras)
+}
+
+/// Shared body. Dependencies are checked (and optionally repaired) *first* so
+/// that a freshly reinstalled tool has already re-run its own `init` by the
+/// time we inspect `settings.json` — otherwise doctor would report a missing
+/// hook it had just caused to be rewritten.
+pub(crate) fn run_with(mode: RepairMode, extras: &str) -> Result<DoctorReport> {
+    let mut report = DoctorReport::default();
+    check_dependencies(&mut report, mode, extras);
+
     let settings_path = settings_path()?;
-    let report = inspect_and_normalize(&settings_path)?;
+    report.merge(inspect_and_normalize(&settings_path)?);
+
     print_report(&report);
     Ok(report)
+}
+
+/// Check every managed dependency and system prerequisite, repairing as the
+/// mode allows. Findings land in `report` so they print with everything else.
+fn check_dependencies(
+    report: &mut DoctorReport,
+    mode: RepairMode,
+    extras: &str,
+) {
+    for prereq in tools::repair_prereqs(mode) {
+        report.push(
+            prereq.name,
+            Status::Warning(format!("missing — {}", prereq.hint)),
+        );
+    }
+
+    let provider = tools::project_provider();
+    let reports = tools::repair(provider, mode, extras);
+    let headroom_ok = reports
+        .iter()
+        .any(|r| r.tool == tools::Tool::Headroom && r.is_healthy());
+
+    for tool_report in reports {
+        let label = tool_report.tool.label();
+        let (label, status) = match tool_report.outcome {
+            ToolOutcome::Ok(ver) => (format!("{label} {ver}"), Status::Ok),
+            ToolOutcome::Repaired { from, version } => (
+                label.to_string(),
+                Status::Normalized(format!(
+                    "was {}, reinstalled {version}",
+                    from.describe(),
+                )),
+            ),
+            ToolOutcome::Unrepaired(presence) => (
+                label.to_string(),
+                Status::Warning(format!(
+                    "{} — run `whetstone install-tools` to reinstall",
+                    presence.describe(),
+                )),
+            ),
+            ToolOutcome::Failed { presence, error } => (
+                label.to_string(),
+                Status::Warning(format!(
+                    "{} and reinstall failed: {error}",
+                    presence.describe(),
+                )),
+            ),
+        };
+        report.push(&label, status);
+    }
+
+    if headroom_ok {
+        check_proxy_starts(report, mode);
+    }
+}
+
+/// The check the earlier ones can't make: does headroom actually *run*?
+///
+/// A tool can be installed, current, and complete and still fail every start
+/// because of what's in its own `settings.json` — which is exactly how a dead
+/// proxy hid behind a green doctor. When the failure is a flag the rollout
+/// channel rejects, the offending key can be removed (with a backup), which is
+/// the only startup failure whetstone can honestly diagnose on its own.
+fn check_proxy_starts(report: &mut DoctorReport, mode: RepairMode) {
+    const LABEL: &str = "headroom proxy";
+
+    let detail = match wrapper::check_proxy_starts() {
+        ProxyStartCheck::AlreadyRunning => {
+            report.push(LABEL, Status::Ok);
+            return;
+        }
+        ProxyStartCheck::Starts => {
+            report.push(LABEL, Status::Ok);
+            return;
+        }
+        ProxyStartCheck::Failed { detail } => detail,
+    };
+
+    let Some(key) = headroom::blocked_setting_key(&detail) else {
+        report
+            .push(LABEL, Status::Warning(format!("does not start: {detail}")));
+        return;
+    };
+
+    let hint = format!(
+        "does not start: {detail} \
+         — `{key}` in ~/.headroom/settings.json asks for it"
+    );
+
+    let may_fix = match mode.effective() {
+        RepairMode::Report => false,
+        RepairMode::Force => true,
+        RepairMode::Prompt => ui::confirm(
+            &format!(
+                "headroom {hint}. Remove `{key}` from headroom's settings?"
+            ),
+            true,
+        ),
+    };
+
+    if !may_fix {
+        report.push(
+            LABEL,
+            Status::Warning(format!(
+                "{hint}; run `whetstone doctor --fix` to remove it"
+            )),
+        );
+        return;
+    }
+
+    match headroom::disable_setting(&key) {
+        Ok(true) => match wrapper::check_proxy_starts() {
+            ProxyStartCheck::Failed { detail } => report.push(
+                LABEL,
+                Status::Warning(format!(
+                    "removed `{key}` but headroom still does not start: {detail}"
+                )),
+            ),
+            _ => report.push(
+                LABEL,
+                Status::Normalized(format!(
+                    "removed `{key}` from headroom settings; proxy starts"
+                )),
+            ),
+        },
+        Ok(false) => report.push(
+            LABEL,
+            Status::Warning(format!(
+                "{hint}, but no such key is set — check headroom's own config"
+            )),
+        ),
+        Err(e) => report.push(
+            LABEL,
+            Status::Warning(format!("{hint}; could not remove it: {e:#}")),
+        ),
+    }
 }
 
 fn settings_path() -> Result<PathBuf> {
@@ -490,6 +662,37 @@ mod tests {
                 .unwrap();
         assert_eq!(rewritten["model"], "claude-opus-4-7");
         assert!(rewritten["mcpServers"].is_object());
+    }
+
+    #[test]
+    fn merge_preserves_findings_and_mutated_flag() {
+        // `run_with` folds the dependency pass and the settings pass into one
+        // report; a normalization in either half has to survive the merge or
+        // doctor would skip writing settings.json back.
+        let mut deps = DoctorReport::default();
+        deps.push("headroom", Status::Ok);
+
+        let mut settings = DoctorReport::default();
+        settings
+            .push("rtk PreToolUse hook", Status::Normalized("moved".into()));
+
+        deps.merge(settings);
+
+        assert!(deps.mutated);
+        assert_eq!(deps.findings.len(), 2);
+        assert_eq!(deps.findings[0].label, "headroom");
+        assert_eq!(deps.findings[1].label, "rtk PreToolUse hook");
+    }
+
+    #[test]
+    fn merge_of_clean_report_leaves_mutated_false() {
+        let mut a = DoctorReport::default();
+        a.push("headroom", Status::Ok);
+        let mut b = DoctorReport::default();
+        b.push("icm hooks", Status::Warning("nope".into()));
+        a.merge(b);
+        assert!(!a.mutated);
+        assert!(!a.green());
     }
 
     #[test]

--- a/src/headroom.rs
+++ b/src/headroom.rs
@@ -53,15 +53,158 @@ pub fn installed_version() -> Option<String> {
     version::extract_semver(&raw)
 }
 
+/// Extras uv recorded for the installed `headroom-ai` tool.
+///
+/// `None` means "unknown" — no uv receipt, or a receipt shape we don't
+/// recognize (a pip install, for instance). Callers must never read that as
+/// "no extras", or whetstone would reinstall on every run.
+pub fn recorded_extras() -> Option<Vec<String>> {
+    let receipt = fs::read_to_string(uv_receipt_path()?).ok()?;
+    parse_receipt_extras(&receipt)
+}
+
+fn uv_receipt_path() -> Option<PathBuf> {
+    let tool_dir = match std::env::var("UV_TOOL_DIR") {
+        Ok(dir) if !dir.trim().is_empty() => PathBuf::from(dir),
+        _ => dirs::data_dir()?.join("uv").join("tools"),
+    };
+    Some(tool_dir.join("headroom-ai").join("uv-receipt.toml"))
+}
+
+/// Pull the extras out of uv's receipt, which pins the requirement on one
+/// line: `requirements = [{ name = "headroom-ai", extras = ["proxy", …] }]`.
+/// Deliberately a narrow scan rather than a TOML dependency — anything that
+/// doesn't match the expected shape returns `None` (unknown), and a receipt
+/// naming the package with no `extras` key returns an empty list (installed
+/// bare).
+fn parse_receipt_extras(receipt: &str) -> Option<Vec<String>> {
+    let line = receipt
+        .lines()
+        .find(|line| line.contains(r#"name = "headroom-ai""#))?;
+
+    let Some(rest) = line.split_once("extras = [") else {
+        return Some(Vec::new());
+    };
+    let list = rest.1.split_once(']')?.0;
+
+    Some(
+        list.split(',')
+            .map(|item| item.trim().trim_matches('"').to_string())
+            .filter(|item| !item.is_empty())
+            .collect(),
+    )
+}
+
+/// Extras requested by `extras` that the recorded install doesn't have.
+///
+/// Empty when everything asked for is present *or* when the install predates
+/// uv (unknown extras) — this only reports what it can prove is missing.
+pub fn missing_extras(extras: &str) -> Vec<String> {
+    let Some(installed) = recorded_extras() else {
+        return Vec::new();
+    };
+    diff_extras(&resolve_extras(extras), &installed)
+}
+
+fn diff_extras(requested: &str, installed: &[String]) -> Vec<String> {
+    requested
+        .split(',')
+        .map(str::trim)
+        .filter(|want| !want.is_empty())
+        .filter(|want| !installed.iter().any(|have| have == want))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Headroom's own settings file (not whetstone's). Keys here are turned into
+/// proxy flags at launch, which is how a setting saved when a feature was
+/// ungated can hard-fail every start after an upgrade.
+pub fn settings_path() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".headroom").join("settings.json"))
+}
+
+/// Given headroom's startup complaint, name the settings key that caused it.
+///
+/// Headroom rejects a gated flag with:
+/// `error: --read-maturation is not available in the current rollout channel`
+/// and that flag is the kebab-case spelling of the JSON key
+/// (`read_maturation`) whetstone can remove.
+pub fn blocked_setting_key(detail: &str) -> Option<String> {
+    if !detail.contains("not available in the current rollout channel") {
+        return None;
+    }
+    let flag = detail
+        .split_whitespace()
+        .find(|token| token.starts_with("--") && token.len() > 2)?;
+    Some(flag.trim_start_matches('-').replace('-', "_"))
+}
+
+/// Remove `key` from headroom's settings file, backing the file up first.
+/// `Ok(false)` means the key wasn't there — nothing was written.
+pub fn disable_setting(key: &str) -> Result<bool> {
+    let path = settings_path().context("could not determine home directory")?;
+    disable_setting_in(&path, key)
+}
+
+fn disable_setting_in(path: &Path, key: &str) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+    let mut settings: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing {}", path.display()))?;
+
+    let Some(obj) = settings.as_object_mut() else {
+        return Ok(false);
+    };
+    if obj.remove(key).is_none() {
+        return Ok(false);
+    }
+
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let backup = path.with_file_name(format!("settings.json.bak.{ts}"));
+    fs::copy(path, &backup)
+        .with_context(|| format!("backing up {}", path.display()))?;
+
+    let pretty = serde_json::to_string_pretty(&settings)
+        .context("serializing headroom settings")?;
+    fs::write(path, format!("{pretty}\n"))
+        .with_context(|| format!("writing {}", path.display()))?;
+
+    ui::info(&format!(
+        "removed `{key}` from {} (backup: {})",
+        path.display(),
+        backup.display(),
+    ));
+    Ok(true)
+}
+
 pub fn install(extras: &str, force: bool) -> Result<()> {
     let spec = package_spec(extras);
 
     if let Some(ver) = installed_version() {
-        if !force && !version::is_older(&ver, MIN_VERSION) {
+        let missing = missing_extras(extras);
+
+        if !force && !version::is_older(&ver, MIN_VERSION) && missing.is_empty()
+        {
             ui::ok(&format!("headroom {ver} (>= {MIN_VERSION})"));
             return Ok(());
         }
-        ui::info(&format!("upgrading headroom from {ver}"));
+
+        // A version-only check calls a bare `headroom-ai` healthy forever,
+        // and then `headroom proxy` / `headroom mcp` don't exist at runtime.
+        if missing.is_empty() {
+            ui::info(&format!("upgrading headroom from {ver}"));
+        } else {
+            ui::info(&format!(
+                "headroom {ver} is missing extras ({}) — reinstalling as {spec}",
+                missing.join(", "),
+            ));
+        }
         run_uv_install(&spec, true)?;
     } else {
         ui::info("installing headroom");
@@ -71,6 +214,14 @@ pub fn install(extras: &str, force: bool) -> Result<()> {
     match installed_version() {
         Some(ver) => ui::ok(&format!("headroom {ver}")),
         None => bail!("headroom installation failed — check uv output above"),
+    }
+
+    let still_missing = missing_extras(extras);
+    if !still_missing.is_empty() {
+        ui::warn(&format!(
+            "headroom installed but extras are still missing: {}",
+            still_missing.join(", "),
+        ));
     }
     Ok(())
 }
@@ -325,6 +476,143 @@ mod tests {
     fn ignores_config_without_mcp_servers() {
         let json = serde_json::json!({ "projects": {} });
         assert!(!json_has_headroom_mcp(&json));
+    }
+
+    const RECEIPT_WITH_EXTRAS: &str = r#"[tool]
+requirements = [{ name = "headroom-ai", extras = ["proxy", "code", "mcp"] }]
+entrypoints = [
+    { name = "headroom", install-path = "/home/u/.local/bin/headroom", from = "headroom-ai" },
+]
+"#;
+
+    const RECEIPT_BARE: &str = r#"[tool]
+requirements = [{ name = "headroom-ai" }]
+"#;
+
+    #[test]
+    fn names_the_settings_key_behind_a_blocked_flag() {
+        let detail = "error: --read-maturation is not available in the current \
+                      rollout channel (stable). Set HEADROOM_ROLLOUT_CHANNEL=beta";
+        assert_eq!(
+            blocked_setting_key(detail),
+            Some("read_maturation".to_string()),
+        );
+    }
+
+    #[test]
+    fn unrelated_startup_errors_name_no_key() {
+        // Only the rollout-channel rejection maps cleanly onto a settings key;
+        // whetstone must not start deleting keys for other failures.
+        assert_eq!(
+            blocked_setting_key("Error: Proxy dependencies not installed."),
+            None,
+        );
+        assert_eq!(blocked_setting_key("error: address already in use"), None);
+    }
+
+    #[test]
+    fn disable_setting_removes_the_key_and_leaves_the_rest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(
+            &path,
+            r#"{"anthropic_base_url":"https://api.anthropic.com","read_maturation":true}"#,
+        )
+        .unwrap();
+
+        assert!(disable_setting_in(&path, "read_maturation").unwrap());
+
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(after.get("read_maturation").is_none());
+        assert_eq!(
+            after.get("anthropic_base_url").and_then(|v| v.as_str()),
+            Some("https://api.anthropic.com"),
+        );
+    }
+
+    #[test]
+    fn disable_setting_backs_the_file_up_before_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(&path, r#"{"read_maturation":true}"#).unwrap();
+
+        disable_setting_in(&path, "read_maturation").unwrap();
+
+        let backups: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .contains("settings.json.bak.")
+            })
+            .collect();
+        assert_eq!(backups.len(), 1, "expected exactly one backup file");
+    }
+
+    #[test]
+    fn disable_setting_is_a_no_op_for_an_absent_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        fs::write(&path, r#"{"anthropic_base_url":"x"}"#).unwrap();
+
+        assert!(!disable_setting_in(&path, "read_maturation").unwrap());
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            r#"{"anthropic_base_url":"x"}"#
+        );
+    }
+
+    #[test]
+    fn disable_setting_on_a_missing_file_is_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        assert!(!disable_setting_in(&path, "read_maturation").unwrap());
+    }
+
+    #[test]
+    fn parses_extras_from_a_uv_receipt() {
+        assert_eq!(
+            parse_receipt_extras(RECEIPT_WITH_EXTRAS),
+            Some(vec!["proxy".into(), "code".into(), "mcp".into()]),
+        );
+    }
+
+    #[test]
+    fn receipt_without_extras_means_installed_bare() {
+        // Distinct from "unknown": uv knows about this install and it has no
+        // extras, so whetstone should repair it.
+        assert_eq!(parse_receipt_extras(RECEIPT_BARE), Some(Vec::new()));
+    }
+
+    #[test]
+    fn unrecognized_receipt_is_unknown_not_empty() {
+        // Anything we can't read must NOT look like "no extras", or every run
+        // would reinstall headroom.
+        assert_eq!(parse_receipt_extras("[tool]\nrequirements = []\n"), None);
+        assert_eq!(parse_receipt_extras(""), None);
+    }
+
+    #[test]
+    fn diff_reports_only_the_extras_that_are_absent() {
+        let installed = vec!["proxy".to_string(), "code".to_string()];
+        assert_eq!(
+            diff_extras(&resolve_extras("all"), &installed),
+            vec!["mcp".to_string()],
+        );
+        assert!(
+            diff_extras(&resolve_extras("proxy,code"), &installed).is_empty()
+        );
+        assert!(diff_extras(&resolve_extras("none"), &installed).is_empty());
+    }
+
+    #[test]
+    fn bare_install_is_missing_every_requested_extra() {
+        assert_eq!(
+            diff_extras(&resolve_extras("all"), &[]),
+            vec!["proxy".to_string(), "code".to_string(), "mcp".to_string()],
+        );
     }
 
     #[test]

--- a/src/icm.rs
+++ b/src/icm.rs
@@ -34,6 +34,39 @@ pub fn installed_version() -> Option<String> {
     version::extract_semver(&raw)
 }
 
+const INSTALL_URL: &str =
+    "https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh";
+
+/// Install ICM via its own install script. `force` reinstalls even when a
+/// working binary is already on `PATH` (used by `whetstone install-tools
+/// --force` and `setup --full`).
+pub fn install(force: bool) -> Result<()> {
+    if !force {
+        if let Some(ver) = installed_version() {
+            ui::ok(&format!("icm already installed ({ver})"));
+            return Ok(());
+        }
+    }
+
+    ui::info("installing ICM...");
+    let status = Command::new("sh")
+        .arg("-c")
+        .arg(format!("curl -fsSL {INSTALL_URL} | sh"))
+        .status()
+        .context("failed to run ICM install script")?;
+
+    if !status.success() {
+        bail!("ICM installation failed");
+    }
+
+    if which::which("icm").is_err() {
+        bail!("ICM binary not found after installation — check your PATH");
+    }
+
+    ui::ok("ICM installed");
+    Ok(())
+}
+
 /// Upgrade ICM via its own self-updater (`icm upgrade --apply`). ICM owns its
 /// install/upgrade path, so we delegate rather than re-run the install script.
 pub fn update() -> Result<ui::ComponentStatus> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod settings;
 mod setup;
 mod shell;
 mod stats;
+mod tools;
 mod ui;
 mod uninstall;
 mod update;
@@ -40,6 +41,7 @@ fn show_upgrade_banner(cmd: &Option<Command>) {
                 | Command::Dashboard
                 | Command::Stats
                 | Command::Migrate { .. }
+                | Command::InstallTools { .. }
         )
     );
     if skip {
@@ -199,8 +201,26 @@ fn main() {
                     ui::fail(&format!("{e:#}"));
                 }
             }
-            Command::Doctor => {
-                if let Err(e) = doctor::run() {
+            Command::Doctor {
+                fix,
+                headroom_extras,
+            } => {
+                let result = if fix {
+                    doctor::run_fix(&headroom_extras)
+                } else {
+                    doctor::run()
+                };
+                if let Err(e) = result {
+                    ui::fail(&format!("{e:#}"));
+                }
+            }
+            Command::InstallTools {
+                force,
+                headroom_extras,
+            } => {
+                if let Err(e) =
+                    tools::run_install_tools(force, &headroom_extras)
+                {
                     ui::fail(&format!("{e:#}"));
                 }
             }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -203,6 +203,10 @@ pub fn preferred_default_model() -> Option<String> {
     newest_sonnet(&live_available_models()?)
 }
 
+/// Where a setting's value is stored. This is a *separate axis* from the
+/// value itself: a setting is `Off` (unset / default behaviour), or active at
+/// `Global` scope (`~/.whetstone/settings.json`, all projects) or `Project`
+/// scope (`.claude/whetstone.json`, this project only, wins over global).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Scope {
     Off,
@@ -210,14 +214,11 @@ enum Scope {
     Project,
 }
 
-impl Scope {
-    fn cycle(self) -> Self {
-        match self {
-            Self::Off => Self::Global,
-            Self::Global => Self::Project,
-            Self::Project => Self::Off,
-        }
-    }
+/// Direction a value control moves when the user presses ←/→.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Dir {
+    Prev,
+    Next,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -245,17 +246,56 @@ const SETTINGS: &[SettingId] = &[
     SettingId::AnthropicApiUrl,
 ];
 
-/// How a `headroom_env` map-backed setting behaves in the TUI: a free-text
-/// `Value` the user types, or a `Toggle` that writes a fixed value when active.
+/// The shape of a setting's *value* control, independent of its scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Control {
+    /// A plain On/Off switch (←/→ toggles).
+    Bool,
+    /// A pick from a fixed list (←/→ cycles through Off + each choice).
+    Choice,
+    /// A free-text value the user types (enter to edit).
+    Text,
+}
+
+fn control_kind(id: SettingId) -> Control {
+    match id {
+        SettingId::HeadroomTelemetry
+        | SettingId::HeadroomBeacon
+        | SettingId::HeadroomMemory
+        | SettingId::HeadroomLogMessages => Control::Bool,
+        SettingId::ApiModel | SettingId::PermissionMode => Control::Choice,
+        SettingId::HeadroomTargetRatio
+        | SettingId::HeadroomBudget
+        | SettingId::AnthropicApiUrl => Control::Text,
+    }
+}
+
+/// Display name shown next to the value control.
+fn label(id: SettingId) -> &'static str {
+    match id {
+        SettingId::HeadroomTelemetry => "Headroom Telemetry",
+        SettingId::HeadroomBeacon => "Headroom Beacon",
+        SettingId::HeadroomMemory => "Headroom Memory",
+        SettingId::HeadroomTargetRatio => "Headroom Target Ratio",
+        SettingId::HeadroomBudget => "Headroom Budget",
+        SettingId::HeadroomLogMessages => "Headroom Log Messages",
+        SettingId::ApiModel => "API Model",
+        SettingId::PermissionMode => "Edit Mode",
+        SettingId::AnthropicApiUrl => "Anthropic API URL",
+    }
+}
+
+/// How a `headroom_env` map-backed setting behaves: a free-text `Value` the
+/// user types, or a `Toggle` that writes a fixed value when active.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EnvKind {
     Value,
     Toggle(&'static str),
 }
 
-/// The `HEADROOM_*` map key and behaviour for the settings that are backed by
-/// the `headroom_env` passthrough map. `None` for the settings that live in
-/// their own dedicated fields (telemetry, memory, model, API URL).
+/// The `HEADROOM_*` map key and behaviour for the settings backed by the
+/// `headroom_env` passthrough map. `None` for settings that live in their own
+/// dedicated fields (telemetry, memory, model, edit mode, API URL).
 fn env_knob(id: SettingId) -> Option<(&'static str, EnvKind)> {
     match id {
         SettingId::HeadroomTargetRatio => {
@@ -272,12 +312,9 @@ fn env_knob(id: SettingId) -> Option<(&'static str, EnvKind)> {
     }
 }
 
-/// Whether a setting accepts a typed free-text value (enter to edit): the
-/// Anthropic API URL and any `EnvKind::Value` map knob. Toggle knobs and the
-/// on/off/model settings are excluded.
+/// Whether a setting accepts a typed free-text value (enter to edit).
 fn is_value_editable(id: SettingId) -> bool {
-    id == SettingId::AnthropicApiUrl
-        || matches!(env_knob(id), Some((_, EnvKind::Value)))
+    control_kind(id) == Control::Text
 }
 
 struct SettingsState {
@@ -287,20 +324,18 @@ struct SettingsState {
     original_project: ProjectSettings,
     selected: usize,
     models: Vec<String>,
-    /// `Some(buffer)` while the user is typing a free-text value (the Anthropic
-    /// API URL); `None` in normal navigation mode.
+    /// `Some(buffer)` while the user is typing a free-text value; `None` in
+    /// normal navigation mode.
     editing: Option<String>,
 }
 
 impl SettingsState {
+    /// Where the given setting is currently stored (or `Off` when unset).
     fn scope(&self, id: SettingId) -> Scope {
+        if let Some((key, _)) = env_knob(id) {
+            return self.env_scope(key);
+        }
         match id {
-            SettingId::HeadroomTargetRatio
-            | SettingId::HeadroomBudget
-            | SettingId::HeadroomLogMessages
-            | SettingId::HeadroomBeacon => {
-                self.env_scope(env_knob(id).unwrap().0)
-            }
             SettingId::HeadroomTelemetry => {
                 match self.project.headroom_telemetry {
                     Some(true) => Scope::Project,
@@ -342,24 +377,28 @@ impl SettingsState {
                     Scope::Off
                 }
             }
-        }
-    }
-
-    fn cycle_scope(&mut self, id: SettingId) {
-        if let Some((key, kind)) = env_knob(id) {
-            match kind {
-                EnvKind::Toggle(on) => self.env_cycle_toggle(key, on),
-                EnvKind::Value => self.env_cycle_value(key),
-            }
-            return;
-        }
-        let next = self.scope(id).cycle();
-        match id {
+            // env-backed settings handled above
             SettingId::HeadroomTargetRatio
             | SettingId::HeadroomBudget
             | SettingId::HeadroomLogMessages
             | SettingId::HeadroomBeacon => unreachable!(),
-            SettingId::HeadroomTelemetry => match next {
+        }
+    }
+
+    /// Move a setting to a specific scope, preserving its value where possible.
+    /// This is the single writer that both the value controls and the scope
+    /// toggle drive.
+    fn set_scope(&mut self, id: SettingId, target: Scope) {
+        if let Some((key, kind)) = env_knob(id) {
+            let default_val = match kind {
+                EnvKind::Toggle(v) => v,
+                EnvKind::Value => "",
+            };
+            self.set_env_scope(key, default_val, target);
+            return;
+        }
+        match id {
+            SettingId::HeadroomTelemetry => match target {
                 Scope::Off => {
                     self.global.headroom_telemetry = false;
                     self.project.headroom_telemetry = None;
@@ -372,7 +411,7 @@ impl SettingsState {
                     self.project.headroom_telemetry = Some(true);
                 }
             },
-            SettingId::HeadroomMemory => match next {
+            SettingId::HeadroomMemory => match target {
                 Scope::Off => {
                     self.global.headroom_memory = false;
                     self.project.headroom_memory = None;
@@ -385,7 +424,7 @@ impl SettingsState {
                     self.project.headroom_memory = Some(true);
                 }
             },
-            SettingId::ApiModel => match next {
+            SettingId::ApiModel => match target {
                 Scope::Off => {
                     self.global.api_model = None;
                     self.project.api_model = None;
@@ -405,7 +444,7 @@ impl SettingsState {
                     self.project.api_model = Some(base);
                 }
             },
-            SettingId::PermissionMode => match next {
+            SettingId::PermissionMode => match target {
                 Scope::Off => {
                     self.global.permission_mode = None;
                     self.project.permission_mode = None;
@@ -426,7 +465,7 @@ impl SettingsState {
                     self.project.permission_mode = Some(base);
                 }
             },
-            SettingId::AnthropicApiUrl => match next {
+            SettingId::AnthropicApiUrl => match target {
                 Scope::Off => {
                     self.global.anthropic_api_url = None;
                     self.project.anthropic_api_url = None;
@@ -446,6 +485,10 @@ impl SettingsState {
                     self.project.anthropic_api_url = Some(base);
                 }
             },
+            SettingId::HeadroomTargetRatio
+            | SettingId::HeadroomBudget
+            | SettingId::HeadroomLogMessages
+            | SettingId::HeadroomBeacon => unreachable!(),
         }
     }
 
@@ -474,99 +517,131 @@ impl SettingsState {
         }
     }
 
-    /// Advance a toggle-style key through Off → Global → Project, writing
-    /// `on_value` when it becomes active.
-    fn env_cycle_toggle(&mut self, key: &str, on_value: &str) {
-        match self.env_scope(key).cycle() {
+    /// Move a `headroom_env` key to `target`, keeping any value the user has
+    /// already typed and falling back to `default_val` when there is none.
+    fn set_env_scope(&mut self, key: &str, default_val: &str, target: Scope) {
+        let cur = self.env_value(key).map(str::to_string);
+        match target {
             Scope::Off => {
                 self.global.headroom_env.remove(key);
                 self.project.headroom_env.remove(key);
             }
             Scope::Global => {
-                self.global
-                    .headroom_env
-                    .insert(key.to_string(), on_value.to_string());
+                let v = cur.unwrap_or_else(|| default_val.to_string());
+                self.global.headroom_env.insert(key.to_string(), v);
                 self.project.headroom_env.remove(key);
             }
             Scope::Project => {
-                let val = self
-                    .global
-                    .headroom_env
-                    .get(key)
-                    .cloned()
-                    .unwrap_or_else(|| on_value.to_string());
-                self.project.headroom_env.insert(key.to_string(), val);
+                let v = cur.unwrap_or_else(|| default_val.to_string());
+                self.project.headroom_env.insert(key.to_string(), v);
             }
         }
     }
 
-    /// Advance a value-style key through Off → Global → Project. When it
-    /// becomes active it holds an empty string until the user edits it, mirror-
-    /// ing the Anthropic API URL flow (a blank value is dropped on save).
-    fn env_cycle_value(&mut self, key: &str) {
-        match self.env_scope(key).cycle() {
-            Scope::Off => {
-                self.global.headroom_env.remove(key);
-                self.project.headroom_env.remove(key);
-            }
-            Scope::Global => {
-                self.global.headroom_env.entry(key.to_string()).or_default();
-                self.project.headroom_env.remove(key);
-            }
-            Scope::Project => {
-                let base = self
-                    .global
-                    .headroom_env
-                    .get(key)
-                    .cloned()
-                    .unwrap_or_default();
-                self.project.headroom_env.insert(key.to_string(), base);
-            }
+    /// Whether the setting reads as "On" to the user. For most booleans that is
+    /// simply "stored somewhere". Beacon is inverted (opt-out): being *unset*
+    /// leaves the beacon on, and storing `HEADROOM_BEACON=off` turns it off.
+    fn value_on(&self, id: SettingId) -> bool {
+        let active = self.scope(id) != Scope::Off;
+        if id == SettingId::HeadroomBeacon {
+            !active
+        } else {
+            active
         }
     }
 
-    fn cycle_model_value(&mut self) {
-        let id = SETTINGS[self.selected];
-        if id != SettingId::ApiModel {
+    /// Toggle a boolean setting on/off. Turning on lands at `Global` scope; the
+    /// user moves it to `Project` afterwards with the scope key.
+    fn toggle_bool(&mut self, id: SettingId) {
+        if self.scope(id) == Scope::Off {
+            self.set_scope(id, Scope::Global);
+        } else {
+            self.set_scope(id, Scope::Off);
+        }
+    }
+
+    /// Advance the value control in the given direction. Booleans flip; choice
+    /// lists cycle through `Off` + each option; text opens the editor.
+    fn cycle_value(&mut self, id: SettingId, dir: Dir) {
+        match control_kind(id) {
+            Control::Bool => self.toggle_bool(id),
+            Control::Choice => self.cycle_choice(id, dir),
+            Control::Text => self.begin_edit(),
+        }
+    }
+
+    /// The choices for a `Control::Choice` setting (excluding the leading Off).
+    fn choices(&self, id: SettingId) -> Vec<String> {
+        match id {
+            SettingId::ApiModel => self.models.clone(),
+            SettingId::PermissionMode => {
+                PERMISSION_MODES.iter().map(|s| s.to_string()).collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    /// Cycle a choice setting through `[Off, choice_0, choice_1, ...]`, writing
+    /// the selected value into the active scope (defaulting to `Global` when it
+    /// was previously `Off`).
+    fn cycle_choice(&mut self, id: SettingId, dir: Dir) {
+        let list = self.choices(id);
+        if list.is_empty() {
             return;
         }
-        let scope = self.scope(id);
-        let target = match scope {
-            Scope::Global => &mut self.global.api_model,
-            Scope::Project => &mut self.project.api_model,
-            Scope::Off => return,
+        let ring = list.len() + 1; // slot 0 == Off
+        let cur = if self.scope(id) == Scope::Off {
+            0
+        } else {
+            let value = self.current_value_display(id).unwrap_or_default();
+            list.iter().position(|m| m == value).map_or(0, |i| i + 1)
         };
-        let current = target.as_deref().unwrap_or(&self.models[0]);
-        let idx = self
-            .models
-            .iter()
-            .position(|m| m == current)
-            .map(|i| (i + 1) % self.models.len())
-            .unwrap_or(0);
-        *target = Some(self.models[idx].clone());
-    }
-
-    fn cycle_permission_mode_value(&mut self) {
-        let id = SETTINGS[self.selected];
-        if id != SettingId::PermissionMode {
-            return;
+        let next = match dir {
+            Dir::Next => (cur + 1) % ring,
+            Dir::Prev => (cur + ring - 1) % ring,
+        };
+        if next == 0 {
+            self.set_scope(id, Scope::Off);
+        } else {
+            if self.scope(id) == Scope::Off {
+                self.set_scope(id, Scope::Global);
+            }
+            self.set_choice_value(id, list[next - 1].clone());
         }
-        let target = match self.scope(id) {
-            Scope::Global => &mut self.global.permission_mode,
-            Scope::Project => &mut self.project.permission_mode,
-            Scope::Off => return,
-        };
-        let current = target.as_deref().unwrap_or(PERMISSION_MODES[0]);
-        let idx = PERMISSION_MODES
-            .iter()
-            .position(|m| *m == current)
-            .map(|i| (i + 1) % PERMISSION_MODES.len())
-            .unwrap_or(0);
-        *target = Some(PERMISSION_MODES[idx].to_string());
     }
 
-    /// The stored value shown next to a value-bearing setting (model id or API
-    /// URL), or `None` for toggle settings and `Scope::Off`.
+    /// Write a choice value into whichever scope is currently active.
+    fn set_choice_value(&mut self, id: SettingId, value: String) {
+        match (id, self.scope(id)) {
+            (SettingId::ApiModel, Scope::Global) => {
+                self.global.api_model = Some(value)
+            }
+            (SettingId::ApiModel, Scope::Project) => {
+                self.project.api_model = Some(value)
+            }
+            (SettingId::PermissionMode, Scope::Global) => {
+                self.global.permission_mode = Some(value)
+            }
+            (SettingId::PermissionMode, Scope::Project) => {
+                self.project.permission_mode = Some(value)
+            }
+            _ => {}
+        }
+    }
+
+    /// Flip an active setting between `Global` and `Project`. No-op when the
+    /// setting is `Off` (scope is meaningless with no stored value).
+    fn toggle_scope(&mut self, id: SettingId) {
+        let other = match self.scope(id) {
+            Scope::Global => Scope::Project,
+            Scope::Project => Scope::Global,
+            Scope::Off => return,
+        };
+        self.set_scope(id, other);
+    }
+
+    /// The stored value shown next to a value-bearing setting (model id, edit
+    /// mode, or text), or `None` for `Scope::Off`.
     fn current_value_display(&self, id: SettingId) -> Option<&str> {
         if let Some((key, EnvKind::Value)) = env_knob(id) {
             return self.env_value(key);
@@ -591,12 +666,94 @@ impl SettingsState {
         }
     }
 
-    /// Enter text-editing mode for the currently selected URL setting, seeding
-    /// the buffer with the active value. No-op unless the selection is the
-    /// Anthropic API URL and its scope is active.
+    /// The short label shown in the value chip: `On`/`Off`, a chosen value, or
+    /// the typed text.
+    fn value_label(&self, id: SettingId) -> String {
+        match control_kind(id) {
+            Control::Bool => {
+                if self.value_on(id) { "On" } else { "Off" }.to_string()
+            }
+            Control::Choice | Control::Text => {
+                match self.current_value_display(id) {
+                    Some(v) if !v.trim().is_empty() => v.to_string(),
+                    _ => "Off".to_string(),
+                }
+            }
+        }
+    }
+
+    /// Helper text describing what the setting does *in its current state*. This
+    /// updates as the user cycles the value, so the meaning of the selected
+    /// option is always spelled out.
+    fn helper(&self, id: SettingId) -> String {
+        match id {
+            SettingId::HeadroomTelemetry => if self.value_on(id) {
+                "On — Headroom sends anonymous usage data back to Headroom for service improvement."
+            } else {
+                "Off — no usage data is sent to Headroom."
+            }
+            .to_string(),
+            SettingId::HeadroomBeacon => if self.value_on(id) {
+                "On — Headroom uploads its anonymous telemetry beacon (Headroom default)."
+            } else {
+                "Off — opts out of the telemetry upload beacon (writes HEADROOM_BEACON=off)."
+            }
+            .to_string(),
+            SettingId::HeadroomMemory => if self.value_on(id) {
+                "On — Headroom keeps persistent cross-session memory (proxy --memory)."
+            } else {
+                "Off — each session starts fresh; no cross-session memory."
+            }
+            .to_string(),
+            SettingId::HeadroomLogMessages => if self.value_on(id) {
+                "On — Headroom logs full message content for debugging (HEADROOM_LOG_MESSAGES=1)."
+            } else {
+                "Off — message content is not logged."
+            }
+            .to_string(),
+            SettingId::ApiModel => match self.current_value_display(id) {
+                Some(m) => format!("Claude Code sessions use {m}."),
+                None => {
+                    "Off — Claude Code uses its own default model.".to_string()
+                }
+            },
+            SettingId::PermissionMode => match self.current_value_display(id) {
+                Some(m) => {
+                    format!("Claude Code runs with --permission-mode {m}.")
+                }
+                None => "Off — Claude Code uses its own default permission mode."
+                    .to_string(),
+            },
+            SettingId::AnthropicApiUrl => match self.current_value_display(id) {
+                Some(u) if !u.trim().is_empty() => {
+                    format!("Headroom proxies to {u} instead of the default Anthropic API.")
+                }
+                _ => "Off — Headroom uses the default Anthropic API endpoint."
+                    .to_string(),
+            },
+            SettingId::HeadroomTargetRatio => {
+                match self.current_value_display(id) {
+                    Some(v) if !v.trim().is_empty() => format!(
+                        "Headroom keeps ~{v} of the context window (HEADROOM_TARGET_RATIO)."
+                    ),
+                    _ => "Off — Headroom uses its default context keep-ratio."
+                        .to_string(),
+                }
+            }
+            SettingId::HeadroomBudget => match self.current_value_display(id) {
+                Some(v) if !v.trim().is_empty() => {
+                    format!("Headroom stops after ${v} of proxy spend (HEADROOM_BUDGET).")
+                }
+                _ => "Off — no spend cap on the Headroom proxy.".to_string(),
+            },
+        }
+    }
+
+    /// Enter text-editing mode for the selected text setting, seeding the buffer
+    /// with the active value. No-op unless the selection is a text control.
     fn begin_edit(&mut self) {
         let id = SETTINGS[self.selected];
-        if !is_value_editable(id) || self.scope(id) == Scope::Off {
+        if !is_value_editable(id) {
             return;
         }
         let current = self
@@ -606,8 +763,9 @@ impl SettingsState {
         self.editing = Some(current);
     }
 
-    /// Commit the in-progress edit buffer into the active scope, then leave edit
-    /// mode. A blank buffer clears the value (which drops the scope to `Off`).
+    /// Commit the in-progress edit buffer into the active scope (defaulting to
+    /// `Global` when the setting was `Off`), then leave edit mode. A blank
+    /// buffer clears the value (dropping the scope to `Off`).
     fn commit_edit(&mut self) {
         let Some(buffer) = self.editing.take() else {
             return;
@@ -786,6 +944,7 @@ fn run_loop(
                     handle_edit_key(&mut state, key.code);
                     continue;
                 }
+                let id = SETTINGS[state.selected];
                 match key.code {
                     KeyCode::Char('q') | KeyCode::Esc => {
                         if state.dirty() {
@@ -796,18 +955,23 @@ fn run_loop(
                         }
                         return Ok(None);
                     }
-                    KeyCode::Char(' ') => {
-                        state.cycle_scope(SETTINGS[state.selected]);
+                    KeyCode::Left | KeyCode::Char('h') => {
+                        state.cycle_value(id, Dir::Prev);
                     }
-                    KeyCode::Tab | KeyCode::Enter => {
-                        let id = SETTINGS[state.selected];
-                        if id == SettingId::ApiModel {
-                            state.cycle_model_value();
-                        } else if id == SettingId::PermissionMode {
-                            state.cycle_permission_mode_value();
-                        } else if is_value_editable(id) {
+                    KeyCode::Right
+                    | KeyCode::Char('l')
+                    | KeyCode::Char(' ') => {
+                        state.cycle_value(id, Dir::Next);
+                    }
+                    KeyCode::Enter => {
+                        if control_kind(id) == Control::Text {
                             state.begin_edit();
+                        } else {
+                            state.cycle_value(id, Dir::Next);
                         }
+                    }
+                    KeyCode::Char('g') | KeyCode::Char('G') => {
+                        state.toggle_scope(id);
                     }
                     KeyCode::Up | KeyCode::Char('k') => {
                         state.selected = state.selected.saturating_sub(1);
@@ -830,8 +994,8 @@ fn run_loop(
     }
 }
 
-/// Route a keypress while the URL text buffer is open. Enter commits, Esc
-/// cancels, and printable characters / Backspace edit the buffer in place.
+/// Route a keypress while a text buffer is open. Enter commits, Esc cancels, and
+/// printable characters / Backspace edit the buffer in place.
 fn handle_edit_key(state: &mut SettingsState, code: KeyCode) {
     match code {
         KeyCode::Enter => state.commit_edit(),
@@ -892,34 +1056,32 @@ fn draw_header(frame: &mut Frame, area: Rect, dirty: bool) {
     frame.render_widget(paragraph, area);
 }
 
-fn scope_spans(scope: Scope) -> Vec<Span<'static>> {
-    let dim = Style::default().fg(Color::DarkGray);
-    let active = Style::default()
-        .fg(Color::Green)
-        .add_modifier(Modifier::BOLD);
+/// The `[ … ]` value chip. Green for On, dim for Off, yellow for a set value.
+fn value_chip(state: &SettingsState, id: SettingId) -> Span<'static> {
+    let text = state.value_label(id);
+    let is_off = text == "Off";
+    let style = if is_off {
+        Style::default().fg(Color::DarkGray)
+    } else if control_kind(id) == Control::Bool {
+        Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Yellow)
+    };
+    Span::styled(format!("[ {text} ]"), style)
+}
 
+/// The `· Global` / `· Project` badge shown only when the value is stored
+/// somewhere (i.e. not Off).
+fn scope_badge(scope: Scope) -> Option<Span<'static>> {
+    let style = Style::default()
+        .fg(Color::Magenta)
+        .add_modifier(Modifier::BOLD);
     match scope {
-        Scope::Off => vec![
-            Span::styled("off", active),
-            Span::styled(" | ", dim),
-            Span::styled("g", dim),
-            Span::styled(" | ", dim),
-            Span::styled("p", dim),
-        ],
-        Scope::Global => vec![
-            Span::styled("off", dim),
-            Span::styled(" | ", dim),
-            Span::styled("g", active),
-            Span::styled(" | ", dim),
-            Span::styled("p", dim),
-        ],
-        Scope::Project => vec![
-            Span::styled("off", dim),
-            Span::styled(" | ", dim),
-            Span::styled("g", dim),
-            Span::styled(" | ", dim),
-            Span::styled("p", active),
-        ],
+        Scope::Off => None,
+        Scope::Global => Some(Span::styled("· Global", style)),
+        Scope::Project => Some(Span::styled("· Project", style)),
     }
 }
 
@@ -934,61 +1096,23 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
         } else {
             Style::default()
         };
-
-        let (label, desc) = match id {
-            SettingId::HeadroomTelemetry => (
-                "Headroom Telemetry",
-                "Send anonymous usage data to Headroom",
-            ),
-            SettingId::HeadroomBeacon => (
-                "Headroom Beacon",
-                "Opt out of the anonymous telemetry upload beacon (HEADROOM_BEACON=off)",
-            ),
-            SettingId::HeadroomMemory => (
-                "Headroom Memory",
-                "Enable Headroom persistent cross-session memory (proxy --memory)",
-            ),
-            SettingId::HeadroomTargetRatio => (
-                "Headroom Target Ratio",
-                "Pin the context keep-ratio (HEADROOM_TARGET_RATIO, e.g. 0.5)",
-            ),
-            SettingId::HeadroomBudget => (
-                "Headroom Budget",
-                "Spend cap in USD for the proxy (HEADROOM_BUDGET)",
-            ),
-            SettingId::HeadroomLogMessages => (
-                "Headroom Log Messages",
-                "Log message content for debugging (HEADROOM_LOG_MESSAGES)",
-            ),
-            SettingId::ApiModel => ("API Model", "Model used for Claude Code sessions"),
-            SettingId::PermissionMode => (
-                "Edit Mode",
-                "Claude Code --permission-mode (acceptEdits/default/plan/bypassPermissions)",
-            ),
-            SettingId::AnthropicApiUrl => (
-                "Anthropic API URL",
-                "Custom upstream Anthropic API URL for the Headroom proxy",
-            ),
-        };
-
-        let scope = state.scope(id);
         let is_editing =
             is_selected && is_value_editable(id) && state.editing.is_some();
 
-        let mut row = vec![Span::styled(
-            cursor,
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )];
-        row.extend(scope_spans(scope));
-        row.push(Span::raw("  "));
-        row.push(Span::styled(label.to_string(), label_style));
+        let mut row = vec![
+            Span::styled(
+                cursor,
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(format!("{:<22}", label(id)), label_style),
+        ];
 
         if is_editing {
             let buffer = state.editing.as_deref().unwrap_or_default();
             row.push(Span::styled(
-                format!("  {buffer}"),
+                format!("[ {buffer}"),
                 Style::default().fg(Color::Yellow),
             ));
             row.push(Span::styled(
@@ -997,36 +1121,29 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::DIM),
             ));
-        } else if let Some(value) = state.current_value_display(id) {
-            let shown = if value.is_empty() { "(unset)" } else { value };
-            row.push(Span::styled(
-                format!("  {shown}"),
-                Style::default().fg(Color::Yellow),
-            ));
+            row.push(Span::styled(" ]", Style::default().fg(Color::Yellow)));
+        } else {
+            row.push(value_chip(state, id));
+        }
+
+        if let Some(badge) = scope_badge(state.scope(id)) {
+            row.push(Span::raw("  "));
+            row.push(badge);
         }
 
         lines.push(Line::from(row));
 
-        let desc_line = if id == SettingId::ApiModel && scope != Scope::Off {
-            format!("{desc}  (tab to cycle model)")
-        } else if id == SettingId::PermissionMode && scope != Scope::Off {
-            format!("{desc}  (tab to cycle mode)")
-        } else if is_value_editable(id) && scope != Scope::Off {
-            if is_editing {
-                format!("{desc}  (enter to save, esc to cancel)")
-            } else {
-                format!("{desc}  (enter to edit)")
-            }
-        } else {
-            desc.to_string()
-        };
+        // Helper text reflects the *current* value and updates as it changes.
+        let mut helper = state.helper(id);
+        if is_editing {
+            helper = format!("{helper}  (enter to save, esc to cancel)");
+        } else if is_selected && control_kind(id) == Control::Text {
+            helper = format!("{helper}  (enter to edit)");
+        }
 
         lines.push(Line::from(vec![
-            Span::raw("                  "),
-            Span::styled(
-                desc_line,
-                Style::default().add_modifier(Modifier::DIM),
-            ),
+            Span::raw("     "),
+            Span::styled(helper, Style::default().add_modifier(Modifier::DIM)),
         ]));
 
         lines.push(Line::from(""));
@@ -1038,42 +1155,28 @@ fn draw_entries(frame: &mut Frame, area: Rect, state: &SettingsState) {
 }
 
 fn draw_footer(frame: &mut Frame, area: Rect) {
+    let key = |s: &'static str| {
+        Span::styled(
+            s,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+    };
     let help = Line::from(vec![
-        Span::styled(
-            " space",
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(":scope "),
-        Span::styled(
-            "tab",
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(":value "),
-        Span::styled(
-            "s",
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::raw(" "),
+        key("←/→"),
+        Span::raw(":change "),
+        key("g"),
+        Span::raw(":global/project "),
+        key("enter"),
+        Span::raw(":edit "),
+        key("s"),
         Span::raw(":save "),
-        Span::styled(
-            "q",
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        key("q"),
         Span::raw(":quit "),
-        Span::styled(
-            "↑↓",
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(":navigate"),
+        key("↑↓"),
+        Span::raw(":move"),
     ]);
 
     let block = Block::default().borders(Borders::ALL);
@@ -1101,12 +1204,204 @@ mod tests {
         }
     }
 
-    fn url_index() -> usize {
-        SETTINGS
-            .iter()
-            .position(|&s| s == SettingId::AnthropicApiUrl)
-            .unwrap()
+    fn index_of(id: SettingId) -> usize {
+        SETTINGS.iter().position(|&s| s == id).unwrap()
     }
+
+    fn url_index() -> usize {
+        index_of(SettingId::AnthropicApiUrl)
+    }
+
+    // ---- boolean value + scope ------------------------------------------
+
+    #[test]
+    fn telemetry_toggle_on_off() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomTelemetry;
+        assert!(!s.value_on(id));
+        assert_eq!(s.scope(id), Scope::Off);
+
+        s.toggle_bool(id);
+        assert!(s.value_on(id));
+        assert_eq!(s.scope(id), Scope::Global);
+        assert!(s.global.headroom_telemetry);
+
+        s.toggle_bool(id);
+        assert!(!s.value_on(id));
+        assert_eq!(s.scope(id), Scope::Off);
+    }
+
+    #[test]
+    fn telemetry_scope_toggle_moves_global_project() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomTelemetry;
+        s.toggle_bool(id); // On @ Global
+        s.toggle_scope(id);
+        assert_eq!(s.scope(id), Scope::Project);
+        assert_eq!(s.project.headroom_telemetry, Some(true));
+
+        s.toggle_scope(id);
+        assert_eq!(s.scope(id), Scope::Global);
+        assert!(s.global.headroom_telemetry);
+    }
+
+    #[test]
+    fn scope_toggle_noop_when_off() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomTelemetry;
+        s.toggle_scope(id);
+        assert_eq!(s.scope(id), Scope::Off);
+    }
+
+    #[test]
+    fn memory_toggle_on_off() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomMemory;
+        s.toggle_bool(id);
+        assert!(s.value_on(id));
+        assert!(s.global.headroom_memory);
+        s.toggle_bool(id);
+        assert!(!s.value_on(id));
+        assert!(!s.global.headroom_memory);
+    }
+
+    #[test]
+    fn beacon_is_inverted_opt_out() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomBeacon;
+        // Unset => beacon On (Headroom default).
+        assert!(s.value_on(id));
+        assert_eq!(s.scope(id), Scope::Off);
+
+        // Toggling Off writes HEADROOM_BEACON=off at global scope.
+        s.toggle_bool(id);
+        assert!(!s.value_on(id));
+        assert_eq!(s.scope(id), Scope::Global);
+        assert_eq!(
+            s.global
+                .headroom_env
+                .get("HEADROOM_BEACON")
+                .map(String::as_str),
+            Some("off")
+        );
+
+        // Move the opt-out to project scope.
+        s.toggle_scope(id);
+        assert_eq!(s.scope(id), Scope::Project);
+        assert_eq!(
+            s.project
+                .headroom_env
+                .get("HEADROOM_BEACON")
+                .map(String::as_str),
+            Some("off")
+        );
+
+        // Toggling back On removes the key entirely.
+        s.toggle_bool(id);
+        assert!(s.value_on(id));
+        assert!(s.global.headroom_env.is_empty());
+        assert!(s.project.headroom_env.is_empty());
+    }
+
+    #[test]
+    fn log_messages_toggle_writes_fixed_value() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomLogMessages;
+        s.toggle_bool(id);
+        assert_eq!(
+            s.global
+                .headroom_env
+                .get("HEADROOM_LOG_MESSAGES")
+                .map(String::as_str),
+            Some("1")
+        );
+        s.toggle_scope(id);
+        assert_eq!(
+            s.project
+                .headroom_env
+                .get("HEADROOM_LOG_MESSAGES")
+                .map(String::as_str),
+            Some("1")
+        );
+        s.toggle_bool(id);
+        assert!(s.global.headroom_env.is_empty());
+        assert!(s.project.headroom_env.is_empty());
+    }
+
+    // ---- choice value + scope -------------------------------------------
+
+    #[test]
+    fn model_cycles_off_through_list_and_back() {
+        let mut s = default_state();
+        let id = SettingId::ApiModel;
+        assert_eq!(s.scope(id), Scope::Off);
+
+        s.cycle_choice(id, Dir::Next);
+        assert_eq!(s.scope(id), Scope::Global);
+        assert_eq!(s.global.api_model.as_deref(), Some(FALLBACK_MODELS[0]));
+
+        s.cycle_choice(id, Dir::Next);
+        assert_eq!(s.global.api_model.as_deref(), Some(FALLBACK_MODELS[1]));
+
+        // Advance to the last model, then one more lands on Off.
+        for _ in 2..FALLBACK_MODELS.len() {
+            s.cycle_choice(id, Dir::Next);
+        }
+        assert_eq!(
+            s.global.api_model.as_deref(),
+            Some(FALLBACK_MODELS[FALLBACK_MODELS.len() - 1])
+        );
+        s.cycle_choice(id, Dir::Next);
+        assert_eq!(s.scope(id), Scope::Off);
+        assert!(s.global.api_model.is_none());
+    }
+
+    #[test]
+    fn model_cycle_prev_from_off_selects_last() {
+        let mut s = default_state();
+        let id = SettingId::ApiModel;
+        s.cycle_choice(id, Dir::Prev);
+        assert_eq!(
+            s.global.api_model.as_deref(),
+            Some(FALLBACK_MODELS[FALLBACK_MODELS.len() - 1])
+        );
+    }
+
+    #[test]
+    fn model_scope_toggle_preserves_value() {
+        let mut s = default_state();
+        let id = SettingId::ApiModel;
+        s.cycle_choice(id, Dir::Next); // Global, models[0]
+        s.set_choice_value(id, "claude-sonnet-5".to_string());
+        s.toggle_scope(id);
+        assert_eq!(s.scope(id), Scope::Project);
+        assert_eq!(s.project.api_model.as_deref(), Some("claude-sonnet-5"));
+    }
+
+    #[test]
+    fn edit_mode_cycles_off_through_modes() {
+        let mut s = default_state();
+        let id = SettingId::PermissionMode;
+        assert_eq!(s.scope(id), Scope::Off);
+
+        s.cycle_choice(id, Dir::Next);
+        assert_eq!(
+            s.global.permission_mode.as_deref(),
+            Some(PERMISSION_MODES[0])
+        );
+
+        for _ in 1..PERMISSION_MODES.len() {
+            s.cycle_choice(id, Dir::Next);
+        }
+        assert_eq!(
+            s.global.permission_mode.as_deref(),
+            Some(PERMISSION_MODES[PERMISSION_MODES.len() - 1])
+        );
+        s.cycle_choice(id, Dir::Next);
+        assert_eq!(s.scope(id), Scope::Off);
+    }
+
+    // ---- text value + scope ---------------------------------------------
 
     #[test]
     fn api_url_scope_detection() {
@@ -1121,29 +1416,12 @@ mod tests {
     }
 
     #[test]
-    fn api_url_cycle_through_scopes() {
-        let mut s = default_state();
-
-        s.cycle_scope(SettingId::AnthropicApiUrl);
-        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Global);
-        assert_eq!(s.global.anthropic_api_url.as_deref(), Some(""));
-
-        s.cycle_scope(SettingId::AnthropicApiUrl);
-        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Project);
-        assert_eq!(s.project.anthropic_api_url.as_deref(), Some(""));
-
-        s.cycle_scope(SettingId::AnthropicApiUrl);
-        assert_eq!(s.scope(SettingId::AnthropicApiUrl), Scope::Off);
-        assert!(s.global.anthropic_api_url.is_none());
-        assert!(s.project.anthropic_api_url.is_none());
-    }
-
-    #[test]
-    fn begin_edit_noop_when_scope_off() {
+    fn cycle_value_on_text_opens_editor() {
         let mut s = default_state();
         s.selected = url_index();
-        s.begin_edit();
-        assert!(s.editing.is_none());
+        s.global.anthropic_api_url = Some("https://seed.example".into());
+        s.cycle_value(SettingId::AnthropicApiUrl, Dir::Next);
+        assert_eq!(s.editing.as_deref(), Some("https://seed.example"));
     }
 
     #[test]
@@ -1159,7 +1437,6 @@ mod tests {
     fn commit_edit_writes_global_value() {
         let mut s = default_state();
         s.selected = url_index();
-        s.global.anthropic_api_url = Some(String::new());
         s.editing = Some("https://typed.example".into());
         s.commit_edit();
         assert!(s.editing.is_none());
@@ -1194,6 +1471,39 @@ mod tests {
     }
 
     #[test]
+    fn commit_edit_writes_env_value_knob() {
+        let mut s = default_state();
+        s.selected = index_of(SettingId::HeadroomTargetRatio);
+        s.editing = Some("0.6".into());
+        s.commit_edit();
+        assert_eq!(
+            s.global
+                .headroom_env
+                .get("HEADROOM_TARGET_RATIO")
+                .map(String::as_str),
+            Some("0.6")
+        );
+    }
+
+    #[test]
+    fn ratio_scope_toggle_preserves_typed_value() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomTargetRatio;
+        s.global
+            .headroom_env
+            .insert("HEADROOM_TARGET_RATIO".into(), "0.6".into());
+        s.toggle_scope(id);
+        assert_eq!(s.scope(id), Scope::Project);
+        assert_eq!(
+            s.project
+                .headroom_env
+                .get("HEADROOM_TARGET_RATIO")
+                .map(String::as_str),
+            Some("0.6")
+        );
+    }
+
+    #[test]
     fn edit_key_typing_and_backspace() {
         let mut s = default_state();
         s.selected = url_index();
@@ -1203,6 +1513,61 @@ mod tests {
         handle_edit_key(&mut s, KeyCode::Backspace);
         assert_eq!(s.editing.as_deref(), Some("h"));
     }
+
+    #[test]
+    fn edit_key_esc_cancels_without_writing() {
+        let mut s = default_state();
+        s.selected = url_index();
+        s.global.anthropic_api_url = Some("https://keep.example".into());
+        s.editing = Some("https://discard.example".into());
+        handle_edit_key(&mut s, KeyCode::Esc);
+        assert!(s.editing.is_none());
+        assert_eq!(
+            s.global.anthropic_api_url.as_deref(),
+            Some("https://keep.example")
+        );
+    }
+
+    // ---- display helpers -------------------------------------------------
+
+    #[test]
+    fn value_label_reflects_state() {
+        let mut s = default_state();
+        assert_eq!(s.value_label(SettingId::HeadroomTelemetry), "Off");
+        s.toggle_bool(SettingId::HeadroomTelemetry);
+        assert_eq!(s.value_label(SettingId::HeadroomTelemetry), "On");
+
+        // Beacon reads On while unset (opt-out default).
+        assert_eq!(s.value_label(SettingId::HeadroomBeacon), "On");
+
+        s.global.api_model = Some("claude-sonnet-5".into());
+        assert_eq!(s.value_label(SettingId::ApiModel), "claude-sonnet-5");
+    }
+
+    #[test]
+    fn helper_text_changes_with_value() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomTelemetry;
+        let off = s.helper(id);
+        s.toggle_bool(id);
+        let on = s.helper(id);
+        assert_ne!(off, on);
+        assert!(on.starts_with("On"));
+        assert!(off.starts_with("Off"));
+    }
+
+    #[test]
+    fn is_value_editable_only_text_controls() {
+        assert!(is_value_editable(SettingId::AnthropicApiUrl));
+        assert!(is_value_editable(SettingId::HeadroomTargetRatio));
+        assert!(is_value_editable(SettingId::HeadroomBudget));
+        assert!(!is_value_editable(SettingId::HeadroomLogMessages));
+        assert!(!is_value_editable(SettingId::HeadroomBeacon));
+        assert!(!is_value_editable(SettingId::HeadroomTelemetry));
+        assert!(!is_value_editable(SettingId::ApiModel));
+    }
+
+    // ---- persistence -----------------------------------------------------
 
     #[test]
     fn normalize_saved_drops_blank_urls() {
@@ -1222,134 +1587,6 @@ mod tests {
             saved.project.anthropic_api_url.as_deref(),
             Some("https://keep.example")
         );
-    }
-
-    fn index_of(id: SettingId) -> usize {
-        SETTINGS.iter().position(|&s| s == id).unwrap()
-    }
-
-    #[test]
-    fn target_ratio_cycle_through_scopes() {
-        let mut s = default_state();
-        let id = SettingId::HeadroomTargetRatio;
-        assert_eq!(s.scope(id), Scope::Off);
-
-        s.cycle_scope(id);
-        assert_eq!(s.scope(id), Scope::Global);
-        assert_eq!(
-            s.global
-                .headroom_env
-                .get("HEADROOM_TARGET_RATIO")
-                .map(String::as_str),
-            Some("")
-        );
-
-        s.cycle_scope(id);
-        assert_eq!(s.scope(id), Scope::Project);
-        assert!(s.project.headroom_env.contains_key("HEADROOM_TARGET_RATIO"));
-
-        s.cycle_scope(id);
-        assert_eq!(s.scope(id), Scope::Off);
-        assert!(!s.global.headroom_env.contains_key("HEADROOM_TARGET_RATIO"));
-        assert!(!s.project.headroom_env.contains_key("HEADROOM_TARGET_RATIO"));
-    }
-
-    #[test]
-    fn log_messages_toggle_cycle_writes_fixed_value() {
-        let mut s = default_state();
-        let id = SettingId::HeadroomLogMessages;
-
-        s.cycle_scope(id);
-        assert_eq!(s.scope(id), Scope::Global);
-        assert_eq!(
-            s.global
-                .headroom_env
-                .get("HEADROOM_LOG_MESSAGES")
-                .map(String::as_str),
-            Some("1")
-        );
-
-        s.cycle_scope(id);
-        assert_eq!(s.scope(id), Scope::Project);
-        assert_eq!(
-            s.project
-                .headroom_env
-                .get("HEADROOM_LOG_MESSAGES")
-                .map(String::as_str),
-            Some("1")
-        );
-
-        s.cycle_scope(id);
-        assert_eq!(s.scope(id), Scope::Off);
-        assert!(s.global.headroom_env.is_empty());
-        assert!(s.project.headroom_env.is_empty());
-    }
-
-    #[test]
-    fn beacon_toggle_cycle_writes_opt_out_value() {
-        let mut s = default_state();
-        let id = SettingId::HeadroomBeacon;
-        assert_eq!(s.scope(id), Scope::Off);
-
-        s.cycle_scope(id);
-        assert_eq!(s.scope(id), Scope::Global);
-        assert_eq!(
-            s.global
-                .headroom_env
-                .get("HEADROOM_BEACON")
-                .map(String::as_str),
-            Some("off")
-        );
-
-        s.cycle_scope(id);
-        assert_eq!(s.scope(id), Scope::Project);
-        assert_eq!(
-            s.project
-                .headroom_env
-                .get("HEADROOM_BEACON")
-                .map(String::as_str),
-            Some("off")
-        );
-
-        s.cycle_scope(id);
-        assert_eq!(s.scope(id), Scope::Off);
-        assert!(s.global.headroom_env.is_empty());
-        assert!(s.project.headroom_env.is_empty());
-    }
-
-    #[test]
-    fn beacon_is_not_free_text_editable() {
-        assert!(!is_value_editable(SettingId::HeadroomBeacon));
-    }
-
-    #[test]
-    fn commit_edit_writes_env_value_knob() {
-        let mut s = default_state();
-        s.selected = index_of(SettingId::HeadroomTargetRatio);
-        s.cycle_scope(SettingId::HeadroomTargetRatio); // -> Global, blank
-        s.editing = Some("0.6".into());
-        s.commit_edit();
-        assert!(s.editing.is_none());
-        assert_eq!(
-            s.global
-                .headroom_env
-                .get("HEADROOM_TARGET_RATIO")
-                .map(String::as_str),
-            Some("0.6")
-        );
-    }
-
-    #[test]
-    fn commit_edit_blank_clears_env_value_knob() {
-        let mut s = default_state();
-        s.selected = index_of(SettingId::HeadroomTargetRatio);
-        s.global
-            .headroom_env
-            .insert("HEADROOM_TARGET_RATIO".into(), "0.6".into());
-        s.editing = Some("   ".into());
-        s.commit_edit();
-        assert!(!s.global.headroom_env.contains_key("HEADROOM_TARGET_RATIO"));
-        assert_eq!(s.scope(SettingId::HeadroomTargetRatio), Scope::Off);
     }
 
     #[test]
@@ -1379,28 +1616,14 @@ mod tests {
     }
 
     #[test]
-    fn is_value_editable_covers_url_and_value_knobs() {
-        assert!(is_value_editable(SettingId::AnthropicApiUrl));
-        assert!(is_value_editable(SettingId::HeadroomTargetRatio));
-        assert!(is_value_editable(SettingId::HeadroomBudget));
-        assert!(!is_value_editable(SettingId::HeadroomLogMessages));
-        assert!(!is_value_editable(SettingId::HeadroomTelemetry));
-        assert!(!is_value_editable(SettingId::ApiModel));
+    fn dirty_detection() {
+        let mut s = default_state();
+        assert!(!s.dirty());
+        s.toggle_bool(SettingId::HeadroomTelemetry);
+        assert!(s.dirty());
     }
 
-    #[test]
-    fn edit_key_esc_cancels_without_writing() {
-        let mut s = default_state();
-        s.selected = url_index();
-        s.global.anthropic_api_url = Some("https://keep.example".into());
-        s.editing = Some("https://discard.example".into());
-        handle_edit_key(&mut s, KeyCode::Esc);
-        assert!(s.editing.is_none());
-        assert_eq!(
-            s.global.anthropic_api_url.as_deref(),
-            Some("https://keep.example")
-        );
-    }
+    // ---- model list helpers ---------------------------------------------
 
     #[test]
     fn newest_sonnet_picks_highest_version() {
@@ -1409,15 +1632,6 @@ mod tests {
             "claude-sonnet-4-6".to_string(),
             "claude-sonnet-5".to_string(),
             "claude-haiku-4-5".to_string(),
-        ];
-        assert_eq!(newest_sonnet(&models).as_deref(), Some("claude-sonnet-5"));
-    }
-
-    #[test]
-    fn newest_sonnet_ignores_input_order() {
-        let models = vec![
-            "claude-sonnet-5".to_string(),
-            "claude-sonnet-4-6".to_string(),
         ];
         assert_eq!(newest_sonnet(&models).as_deref(), Some("claude-sonnet-5"));
     }
@@ -1432,258 +1646,8 @@ mod tests {
     }
 
     #[test]
-    fn scope_cycle_order() {
-        assert_eq!(Scope::Off.cycle(), Scope::Global);
-        assert_eq!(Scope::Global.cycle(), Scope::Project);
-        assert_eq!(Scope::Project.cycle(), Scope::Off);
-    }
-
-    #[test]
-    fn telemetry_scope_from_project_override() {
-        let mut s = default_state();
-        s.project.headroom_telemetry = Some(true);
-        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Project);
-
-        s.project.headroom_telemetry = Some(false);
-        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Off);
-    }
-
-    #[test]
-    fn telemetry_scope_from_global() {
-        let mut s = default_state();
-        s.global.headroom_telemetry = true;
-        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Global);
-    }
-
-    #[test]
-    fn telemetry_cycle_through_all_scopes() {
-        let mut s = default_state();
-        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Off);
-
-        s.cycle_scope(SettingId::HeadroomTelemetry);
-        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Global);
-        assert!(s.global.headroom_telemetry);
-
-        s.cycle_scope(SettingId::HeadroomTelemetry);
-        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Project);
-        assert_eq!(s.project.headroom_telemetry, Some(true));
-
-        s.cycle_scope(SettingId::HeadroomTelemetry);
-        assert_eq!(s.scope(SettingId::HeadroomTelemetry), Scope::Off);
-    }
-
-    #[test]
-    fn memory_cycle_through_all_scopes() {
-        let mut s = default_state();
-        assert_eq!(s.scope(SettingId::HeadroomMemory), Scope::Off);
-
-        s.cycle_scope(SettingId::HeadroomMemory);
-        assert_eq!(s.scope(SettingId::HeadroomMemory), Scope::Global);
-        assert!(s.global.headroom_memory);
-
-        s.cycle_scope(SettingId::HeadroomMemory);
-        assert_eq!(s.scope(SettingId::HeadroomMemory), Scope::Project);
-        assert_eq!(s.project.headroom_memory, Some(true));
-
-        s.cycle_scope(SettingId::HeadroomMemory);
-        assert_eq!(s.scope(SettingId::HeadroomMemory), Scope::Off);
-        assert!(!s.global.headroom_memory);
-        assert!(s.project.headroom_memory.is_none());
-    }
-
-    #[test]
-    fn memory_scope_from_project_override() {
-        let mut s = default_state();
-        s.project.headroom_memory = Some(false);
-        assert_eq!(s.scope(SettingId::HeadroomMemory), Scope::Off);
-
-        s.project.headroom_memory = Some(true);
-        assert_eq!(s.scope(SettingId::HeadroomMemory), Scope::Project);
-    }
-
-    #[test]
-    fn model_scope_detection() {
-        let mut s = default_state();
-        assert_eq!(s.scope(SettingId::ApiModel), Scope::Off);
-
-        s.global.api_model = Some("claude-opus-4-6".into());
-        assert_eq!(s.scope(SettingId::ApiModel), Scope::Global);
-
-        s.project.api_model = Some("claude-sonnet-4-6".into());
-        assert_eq!(s.scope(SettingId::ApiModel), Scope::Project);
-    }
-
-    #[test]
-    fn model_cycle_through_scopes() {
-        let mut s = default_state();
-
-        s.cycle_scope(SettingId::ApiModel);
-        assert_eq!(s.scope(SettingId::ApiModel), Scope::Global);
-        assert_eq!(s.global.api_model.as_deref(), Some(FALLBACK_MODELS[0]));
-
-        s.cycle_scope(SettingId::ApiModel);
-        assert_eq!(s.scope(SettingId::ApiModel), Scope::Project);
-        assert_eq!(s.project.api_model.as_deref(), Some(FALLBACK_MODELS[0]));
-
-        s.cycle_scope(SettingId::ApiModel);
-        assert_eq!(s.scope(SettingId::ApiModel), Scope::Off);
-        assert!(s.global.api_model.is_none());
-        assert!(s.project.api_model.is_none());
-    }
-
-    #[test]
-    fn model_value_cycling() {
-        let mut s = default_state();
-        s.selected = index_of(SettingId::ApiModel);
-        s.global.api_model = Some(FALLBACK_MODELS[0].to_string());
-
-        s.cycle_model_value();
-        assert_eq!(s.global.api_model.as_deref(), Some(FALLBACK_MODELS[1]));
-
-        s.cycle_model_value();
-        assert_eq!(s.global.api_model.as_deref(), Some(FALLBACK_MODELS[2]));
-    }
-
-    #[test]
-    fn model_value_cycling_wraps() {
-        let mut s = default_state();
-        s.selected = index_of(SettingId::ApiModel);
-        s.global.api_model =
-            Some(FALLBACK_MODELS[FALLBACK_MODELS.len() - 1].to_string());
-
-        s.cycle_model_value();
-        assert_eq!(s.global.api_model.as_deref(), Some(FALLBACK_MODELS[0]));
-    }
-
-    #[test]
-    fn model_value_cycle_noop_when_off() {
-        let mut s = default_state();
-        s.selected = index_of(SettingId::ApiModel);
-        s.cycle_model_value();
-        assert!(s.global.api_model.is_none());
-        assert!(s.project.api_model.is_none());
-    }
-
-    #[test]
-    fn model_value_cycle_noop_for_non_model_setting() {
-        let mut s = default_state();
-        s.selected = 0;
-        s.cycle_model_value();
-        assert!(s.global.api_model.is_none());
-    }
-
-    #[test]
-    fn permission_mode_scope_detection() {
-        let mut s = default_state();
-        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Off);
-
-        s.global.permission_mode = Some("plan".into());
-        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Global);
-
-        s.project.permission_mode = Some("acceptEdits".into());
-        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Project);
-    }
-
-    #[test]
-    fn permission_mode_cycle_through_scopes() {
-        let mut s = default_state();
-
-        s.cycle_scope(SettingId::PermissionMode);
-        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Global);
-        assert_eq!(
-            s.global.permission_mode.as_deref(),
-            Some(PERMISSION_MODES[0])
-        );
-
-        s.cycle_scope(SettingId::PermissionMode);
-        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Project);
-        assert_eq!(
-            s.project.permission_mode.as_deref(),
-            Some(PERMISSION_MODES[0])
-        );
-
-        s.cycle_scope(SettingId::PermissionMode);
-        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Off);
-        assert!(s.global.permission_mode.is_none());
-        assert!(s.project.permission_mode.is_none());
-    }
-
-    #[test]
-    fn permission_mode_value_cycling_wraps() {
-        let mut s = default_state();
-        s.selected = index_of(SettingId::PermissionMode);
-        s.global.permission_mode =
-            Some(PERMISSION_MODES[PERMISSION_MODES.len() - 1].to_string());
-
-        s.cycle_permission_mode_value();
-        assert_eq!(
-            s.global.permission_mode.as_deref(),
-            Some(PERMISSION_MODES[0])
-        );
-    }
-
-    #[test]
-    fn permission_mode_value_cycles_forward() {
-        let mut s = default_state();
-        s.selected = index_of(SettingId::PermissionMode);
-        s.global.permission_mode = Some(PERMISSION_MODES[0].to_string());
-
-        s.cycle_permission_mode_value();
-        assert_eq!(
-            s.global.permission_mode.as_deref(),
-            Some(PERMISSION_MODES[1])
-        );
-    }
-
-    #[test]
-    fn permission_mode_value_cycle_noop_when_off() {
-        let mut s = default_state();
-        s.selected = index_of(SettingId::PermissionMode);
-        s.cycle_permission_mode_value();
-        assert!(s.global.permission_mode.is_none());
-        assert!(s.project.permission_mode.is_none());
-    }
-
-    #[test]
-    fn permission_mode_inherits_global_on_promote() {
-        let mut s = default_state();
-        s.cycle_scope(SettingId::PermissionMode);
-        s.global.permission_mode = Some("bypassPermissions".into());
-
-        s.cycle_scope(SettingId::PermissionMode);
-        assert_eq!(s.scope(SettingId::PermissionMode), Scope::Project);
-        assert_eq!(
-            s.project.permission_mode.as_deref(),
-            Some("bypassPermissions")
-        );
-    }
-
-    #[test]
-    fn dirty_detection() {
-        let mut s = default_state();
-        assert!(!s.dirty());
-        s.cycle_scope(SettingId::HeadroomTelemetry);
-        assert!(s.dirty());
-    }
-
-    #[test]
-    fn project_model_inherits_global_on_promote() {
-        let mut s = default_state();
-
-        s.cycle_scope(SettingId::ApiModel);
-        assert_eq!(s.scope(SettingId::ApiModel), Scope::Global);
-
-        s.global.api_model = Some("claude-sonnet-4-6".into());
-
-        s.cycle_scope(SettingId::ApiModel);
-        assert_eq!(s.scope(SettingId::ApiModel), Scope::Project);
-        assert_eq!(s.project.api_model.as_deref(), Some("claude-sonnet-4-6"));
-    }
-
-    #[test]
     fn is_current_gen_accepts_latest_families() {
         assert!(is_current_gen("claude-opus-4-8"));
-        assert!(is_current_gen("claude-opus-4-6"));
         assert!(is_current_gen("claude-sonnet-4-6"));
         assert!(is_current_gen("claude-haiku-4-5-20251001"));
         assert!(is_current_gen("claude-fable-5"));
@@ -1692,7 +1656,6 @@ mod tests {
     #[test]
     fn is_current_gen_rejects_older_families() {
         assert!(!is_current_gen("claude-3-5-sonnet-20241022"));
-        assert!(!is_current_gen("claude-3-opus-20240229"));
         assert!(!is_current_gen("gpt-4o"));
     }
 
@@ -1702,16 +1665,11 @@ mod tests {
             strip_date_suffix("claude-opus-4-8-20260501"),
             Some("claude-opus-4-8")
         );
-        assert_eq!(
-            strip_date_suffix("claude-sonnet-4-6-20250514"),
-            Some("claude-sonnet-4-6")
-        );
     }
 
     #[test]
     fn strip_date_suffix_returns_none_for_short_ids() {
         assert_eq!(strip_date_suffix("claude-opus-4-8"), None);
-        assert_eq!(strip_date_suffix("claude-fable-5"), None);
     }
 
     #[test]
@@ -1721,11 +1679,10 @@ mod tests {
         );
         assert!(
             family_order("claude-sonnet-4-6")
-                < family_order("claude-haiku-4-5-20251001")
+                < family_order("claude-haiku-4-5")
         );
         assert!(
-            family_order("claude-haiku-4-5-20251001")
-                < family_order("claude-fable-5")
+            family_order("claude-haiku-4-5") < family_order("claude-fable-5")
         );
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -241,41 +241,9 @@ pub(crate) fn current_icm_version() -> Option<String> {
 /// `integrations::run_all` after this returns.
 pub(crate) fn install_provider_binary(provider: MemoryProvider) -> Result<()> {
     match provider {
-        MemoryProvider::Icm => ensure_icm_installed(),
+        MemoryProvider::Icm => crate::icm::install(false),
         MemoryProvider::Skip => Ok(()),
     }
-}
-
-fn ensure_icm_installed() -> Result<()> {
-    if which::which("icm").is_ok() {
-        let output =
-            std::process::Command::new("icm").arg("--version").output();
-        if let Ok(o) = output {
-            if o.status.success() {
-                let ver = String::from_utf8_lossy(&o.stdout).trim().to_string();
-                ui::ok(&format!("icm already installed ({ver})"));
-                return Ok(());
-            }
-        }
-    }
-
-    ui::info("installing ICM...");
-    let status = std::process::Command::new("sh")
-        .arg("-c")
-        .arg("curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh")
-        .status()
-        .context("failed to run ICM install script")?;
-
-    if !status.success() {
-        bail!("ICM installation failed");
-    }
-
-    if which::which("icm").is_err() {
-        bail!("ICM binary not found after installation — check your PATH");
-    }
-
-    ui::ok("ICM installed");
-    Ok(())
 }
 
 fn write_manifest(provider: MemoryProvider) -> Result<()> {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,0 +1,707 @@
+//! Managed-dependency inventory: what whetstone installs, whether it is still
+//! there, and how to put it back.
+//!
+//! `whetstone setup` installs Headroom, RTK, Claude Code's memory provider
+//! (ICM) and wires their hooks. Nothing kept those installs honest afterwards:
+//! `uv tool uninstall headroom-ai`, a wiped `~/.local/bin`, or a Python
+//! upgrade that orphans a shim all left the project silently half-broken —
+//! `whetstone doctor` only ever looked at `~/.claude/settings.json`.
+//!
+//! This module is the missing half: a single place that knows the expected
+//! tool set, classifies each tool as present/broken/missing, and can reinstall
+//! and re-integrate the ones that went away. `whetstone doctor` consumes it
+//! (prompting before it touches anything) and `whetstone install-tools` drives
+//! it directly.
+
+use anyhow::{bail, Context, Result};
+use std::process::Command;
+
+use crate::config::{ToolVersions, WhetstoneManifest};
+use crate::memory::MemoryProvider;
+use crate::{claude_code, headroom, icm, integrations, rtk, ui};
+
+/// A dependency whetstone installs and is therefore responsible for repairing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tool {
+    Headroom,
+    Rtk,
+    ClaudeCode,
+    Icm,
+}
+
+impl Tool {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Headroom => "headroom",
+            Self::Rtk => "rtk",
+            Self::ClaudeCode => "claude code",
+            Self::Icm => "memory (ICM)",
+        }
+    }
+
+    /// Reverse of [`Tool::binary`] — used by the launch-time guard, which
+    /// only knows the program name whetstone is about to exec.
+    pub fn from_binary(binary: &str) -> Option<Self> {
+        [Self::Headroom, Self::Rtk, Self::ClaudeCode, Self::Icm]
+            .into_iter()
+            .find(|tool| tool.binary() == binary)
+    }
+
+    /// Executable whetstone expects to find on `PATH`.
+    pub fn binary(self) -> &'static str {
+        match self {
+            Self::Headroom => "headroom",
+            Self::Rtk => "rtk",
+            Self::ClaudeCode => "claude",
+            Self::Icm => "icm",
+        }
+    }
+
+    fn installed_version(self) -> Option<String> {
+        match self {
+            Self::Headroom => headroom::installed_version(),
+            Self::Rtk => rtk::installed_version(),
+            Self::ClaudeCode => claude_code::installed_version(),
+            Self::Icm => icm::installed_version(),
+        }
+    }
+
+    /// Classify the tool without changing anything. `extras` is the headroom
+    /// extras set the caller expects (`"all"` for every default path) — a
+    /// headroom whose uv receipt is missing one of them is `Incomplete`, not
+    /// `Present`, because `headroom proxy`/`mcp` won't exist at runtime.
+    pub fn presence(self, extras: &str) -> Presence {
+        if which::which(self.binary()).is_err() {
+            return Presence::Missing;
+        }
+        let Some(version) = self.installed_version() else {
+            return Presence::Broken;
+        };
+        if self == Self::Headroom {
+            let missing = headroom::missing_extras(extras);
+            if !missing.is_empty() {
+                return Presence::Incomplete { version, missing };
+            }
+        }
+        Presence::Present(version)
+    }
+
+    /// (Re)install the tool. `force` upgrades even when a good-enough version
+    /// is already present.
+    pub fn install(self, extras: &str, force: bool) -> Result<()> {
+        match self {
+            Self::Headroom => headroom::install(extras, force),
+            Self::Rtk => rtk::install(force),
+            Self::Icm => icm::install(force),
+            Self::ClaudeCode => claude_code::install(),
+        }
+    }
+
+    /// Re-run the tool's own `init` so its Claude Code hooks come back after a
+    /// reinstall. Tools that own no hooks are a no-op.
+    pub fn reintegrate(self) -> Result<()> {
+        match self {
+            Self::Rtk => integrations::rtk_init(),
+            Self::Icm => {
+                integrations::icm_init(integrations::IcmMode::Standard)
+            }
+            Self::Headroom | Self::ClaudeCode => Ok(()),
+        }
+    }
+}
+
+/// Result of looking for a tool on the system.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Presence {
+    /// Installed and reporting a version.
+    Present(String),
+    /// On `PATH` but `--version` failed — a dead shim, broken venv, or a
+    /// partially-removed install. Treated like missing for repair purposes.
+    Broken,
+    /// Runs, but was installed without extras whetstone depends on (headroom
+    /// installed as bare `headroom-ai` instead of `headroom-ai[proxy,code,mcp]`).
+    Incomplete {
+        version: String,
+        missing: Vec<String>,
+    },
+    /// Not on `PATH` at all.
+    Missing,
+}
+
+impl Presence {
+    /// Short human-readable state, e.g. "0.22.2" or "not installed".
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Present(ver) => ver.clone(),
+            Self::Broken => "installed but not runnable".into(),
+            Self::Incomplete { version, missing } => format!(
+                "{version}, installed without extras: {}",
+                missing.join(", "),
+            ),
+            Self::Missing => "not installed".into(),
+        }
+    }
+
+    /// Verb for the repair prompt — nothing to re-do when it was never there.
+    fn repair_verb(&self) -> &'static str {
+        match self {
+            Self::Missing => "install",
+            _ => "reinstall",
+        }
+    }
+}
+
+/// How aggressively a repair pass may act.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepairMode {
+    /// Report only — never install (used by `doctor` in non-interactive runs
+    /// and by the doctor pass at the end of `install-tools`).
+    Report,
+    /// Ask before installing each missing tool.
+    Prompt,
+    /// Install without asking.
+    Force,
+}
+
+impl RepairMode {
+    /// Prompting requires a TTY; degrade to reporting when there isn't one so
+    /// `whetstone doctor` stays usable in scripts and CI.
+    pub fn effective(self) -> Self {
+        match self {
+            Self::Prompt if !ui::is_interactive() => Self::Report,
+            other => other,
+        }
+    }
+}
+
+/// Outcome for one tool after a repair pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolOutcome {
+    /// Was already there.
+    Ok(String),
+    /// Was missing/broken and is now installed.
+    Repaired { from: Presence, version: String },
+    /// Was missing/broken; repair not attempted (report mode or user declined).
+    Unrepaired(Presence),
+    /// Repair was attempted and failed.
+    Failed { presence: Presence, error: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolReport {
+    pub tool: Tool,
+    pub outcome: ToolOutcome,
+}
+
+impl ToolReport {
+    pub fn is_healthy(&self) -> bool {
+        matches!(
+            self.outcome,
+            ToolOutcome::Ok(_) | ToolOutcome::Repaired { .. }
+        )
+    }
+}
+
+/// The tools whetstone expects on a machine, given the project's memory
+/// provider. `None` means "no project manifest here" — the global trio is
+/// still expected, but no provider is assumed.
+pub fn expected_tools(provider: Option<MemoryProvider>) -> Vec<Tool> {
+    let mut tools = vec![Tool::Headroom, Tool::Rtk, Tool::ClaudeCode];
+    if provider == Some(MemoryProvider::Icm) {
+        tools.push(Tool::Icm);
+    }
+    tools
+}
+
+/// Memory provider recorded in this directory's manifest, if any.
+pub fn project_provider() -> Option<MemoryProvider> {
+    let project_dir = std::env::current_dir().ok()?;
+    let manifest_path = WhetstoneManifest::path_for(&project_dir);
+    let manifest = WhetstoneManifest::load(&manifest_path).ok()??;
+    Some(manifest.provider.into())
+}
+
+/// Inspect every expected tool and, depending on `mode`, put back the ones
+/// that went away. Repaired hook-owning tools get their `init` re-run so
+/// `~/.claude/settings.json` is repopulated before the caller inspects it.
+pub fn repair(
+    provider: Option<MemoryProvider>,
+    mode: RepairMode,
+    extras: &str,
+) -> Vec<ToolReport> {
+    let mode = mode.effective();
+    expected_tools(provider)
+        .into_iter()
+        .map(|tool| ToolReport {
+            tool,
+            outcome: repair_one(tool, mode, extras),
+        })
+        .collect()
+}
+
+fn repair_one(tool: Tool, mode: RepairMode, extras: &str) -> ToolOutcome {
+    let presence = match tool.presence(extras) {
+        Presence::Present(ver) => return ToolOutcome::Ok(ver),
+        gone => gone,
+    };
+
+    match mode {
+        RepairMode::Report => return ToolOutcome::Unrepaired(presence),
+        RepairMode::Prompt => {
+            let prompt = format!(
+                "{} is {} — {} it now?",
+                tool.label(),
+                presence.describe(),
+                presence.repair_verb(),
+            );
+            if !ui::confirm(&prompt, true) {
+                return ToolOutcome::Unrepaired(presence);
+            }
+        }
+        RepairMode::Force => {
+            ui::info(&format!(
+                "{} is {} — {}ing",
+                tool.label(),
+                presence.describe(),
+                presence.repair_verb(),
+            ));
+        }
+    }
+
+    if let Err(e) = tool.install(extras, false) {
+        return ToolOutcome::Failed {
+            presence,
+            error: format!("{e:#}"),
+        };
+    }
+
+    let after = tool.presence(extras);
+    let Presence::Present(version) = after else {
+        return ToolOutcome::Failed {
+            presence,
+            error: format!(
+                "install completed but `{}` still {}",
+                tool.binary(),
+                after.describe(),
+            ),
+        };
+    };
+
+    // A reinstalled tool has no hooks in ~/.claude/settings.json until its own
+    // init runs again — that is the "fix whatever else broke" half.
+    if let Err(e) = tool.reintegrate() {
+        ui::warn(&format!(
+            "{} reinstalled but re-integration failed: {e:#}",
+            tool.label(),
+        ));
+    }
+
+    ToolOutcome::Repaired {
+        from: presence,
+        version,
+    }
+}
+
+/// Print a repair pass in the same shape as the rest of whetstone's output.
+pub fn print_reports(reports: &[ToolReport]) {
+    for report in reports {
+        let label = report.tool.label();
+        match &report.outcome {
+            ToolOutcome::Ok(ver) => ui::ok(&format!("{label} {ver}")),
+            ToolOutcome::Repaired { from, version } => ui::ok(&format!(
+                "{label}: reinstalled ({} → {version})",
+                from.describe(),
+            )),
+            ToolOutcome::Unrepaired(presence) => ui::warn(&format!(
+                "{label}: {} — run `whetstone install-tools` to reinstall",
+                presence.describe(),
+            )),
+            ToolOutcome::Failed { presence, error } => ui::warn(&format!(
+                "{label}: {} and reinstall failed: {error}",
+                presence.describe(),
+            )),
+        }
+    }
+}
+
+/// Guard the launch path: whetstone is about to `exec` a managed tool, so make
+/// sure it is actually there. Deliberately a `which` lookup rather than a
+/// `--version` spawn — this runs on every `whetstone claude` and must stay
+/// cheap. Exits the process (with a pointer to `install-tools`) when the tool
+/// is missing and could not be installed.
+pub fn ensure_available(binary: &str) {
+    let Some(tool) = Tool::from_binary(binary) else {
+        return;
+    };
+    if which::which(binary).is_ok() {
+        return;
+    }
+
+    ui::warn(&format!("{} is not installed", tool.label()));
+
+    let may_install = ui::is_interactive()
+        && ui::confirm(&format!("Install {} now?", tool.label()), true);
+
+    if may_install {
+        match tool.install("all", false) {
+            Ok(()) => {
+                if let Err(e) = tool.reintegrate() {
+                    ui::warn(&format!("re-integration failed: {e:#}"));
+                }
+                if which::which(binary).is_ok() {
+                    return;
+                }
+            }
+            Err(e) => ui::warn(&format!("install failed: {e:#}")),
+        }
+    }
+
+    ui::fail(&format!(
+        "`{binary}` not found — run `whetstone install-tools` to repair this install"
+    ));
+}
+
+/// Record the versions we ended up with in the project manifest, so
+/// `dashboard`/`update` don't keep reporting the pre-repair state. No-op when
+/// this directory has no manifest.
+pub fn sync_manifest_versions() -> Result<()> {
+    let project_dir = std::env::current_dir()?;
+    let manifest_path = WhetstoneManifest::path_for(&project_dir);
+    let Some(mut manifest) = WhetstoneManifest::load(&manifest_path)? else {
+        return Ok(());
+    };
+
+    let tools = ToolVersions {
+        rtk: rtk::installed_version(),
+        icm: icm::installed_version(),
+        headroom: headroom::installed_version(),
+    };
+    if manifest.tool_versions == tools {
+        return Ok(());
+    }
+
+    manifest.tool_versions = tools;
+    manifest
+        .touch_and_save(&manifest_path)
+        .with_context(|| format!("updating {}", manifest_path.display()))
+}
+
+/// A system dependency whetstone needs but does not own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Prereq {
+    pub name: &'static str,
+    pub hint: &'static str,
+    /// Whether whetstone knows a safe way to install it unattended.
+    pub installable: bool,
+}
+
+const PREREQS: &[Prereq] = &[
+    Prereq {
+        name: "uv",
+        hint: "https://docs.astral.sh/uv/ — required to install headroom",
+        installable: true,
+    },
+    Prereq {
+        name: "python3",
+        hint: "install Python 3.10+ — headroom runs on it",
+        installable: false,
+    },
+    Prereq {
+        name: "git",
+        hint: "install git — whetstone operates on git projects",
+        installable: false,
+    },
+    Prereq {
+        name: "curl",
+        hint: "install curl — used by the rtk and icm installers",
+        installable: false,
+    },
+];
+
+/// System dependencies that are currently absent.
+pub fn missing_prereqs() -> Vec<&'static Prereq> {
+    PREREQS
+        .iter()
+        .filter(|p| which::which(p.name).is_err())
+        .collect()
+}
+
+/// Install the system dependencies whetstone knows how to install (today:
+/// `uv`) and return the ones still missing. Callers report — this only prints
+/// progress for work it actually does.
+pub fn repair_prereqs(mode: RepairMode) -> Vec<&'static Prereq> {
+    let mode = mode.effective();
+    let mut still_missing = Vec::new();
+
+    for prereq in missing_prereqs() {
+        let attempt = prereq.installable
+            && match mode {
+                RepairMode::Report => false,
+                RepairMode::Force => true,
+                RepairMode::Prompt => ui::confirm(
+                    &format!("{} is missing — install it now?", prereq.name),
+                    true,
+                ),
+            };
+
+        if !attempt {
+            still_missing.push(prereq);
+            continue;
+        }
+
+        match install_prereq(prereq) {
+            Ok(()) => ui::ok(&format!("{} installed", prereq.name)),
+            Err(e) => {
+                ui::warn(&format!("{} install failed: {e:#}", prereq.name));
+                still_missing.push(prereq);
+            }
+        }
+    }
+
+    still_missing
+}
+
+fn install_prereq(prereq: &Prereq) -> Result<()> {
+    match prereq.name {
+        "uv" => install_uv(),
+        other => bail!("no unattended installer for {other}"),
+    }
+}
+
+fn install_uv() -> Result<()> {
+    ui::info("installing uv");
+    let status = Command::new("sh")
+        .arg("-c")
+        .arg("curl -LsSf https://astral.sh/uv/install.sh | sh")
+        .status()
+        .context("failed to run the uv install script")?;
+
+    if !status.success() {
+        bail!("uv install script failed");
+    }
+    if which::which("uv").is_err() {
+        bail!("uv not on PATH after install — restart your shell and retry");
+    }
+    Ok(())
+}
+
+/// `whetstone install-tools` — install or repair every managed dependency.
+pub fn run_install_tools(force: bool, extras: &str) -> Result<()> {
+    ui::section("whetstone install-tools");
+
+    let mode = if force {
+        RepairMode::Force
+    } else if ui::is_interactive() {
+        RepairMode::Prompt
+    } else {
+        RepairMode::Force
+    };
+
+    let blocked = repair_prereqs(mode);
+    for prereq in &blocked {
+        ui::warn(&format!("{} missing — {}", prereq.name, prereq.hint));
+    }
+    if blocked.iter().any(|p| p.name == "uv") {
+        ui::warn("headroom cannot be installed without uv");
+    }
+
+    let provider = project_provider();
+    let mut reports = repair(provider, mode, extras);
+
+    // `--force` means "reinstall everything", not just what disappeared.
+    if force {
+        for report in &mut reports {
+            if let ToolOutcome::Ok(ver) = &report.outcome {
+                let tool = report.tool;
+                ui::info(&format!("forcing reinstall of {}", tool.label()));
+                match tool.install(extras, true).and_then(|()| {
+                    tool.reintegrate().map(|()| tool.presence(extras))
+                }) {
+                    Ok(Presence::Present(new_ver)) if &new_ver != ver => {
+                        report.outcome = ToolOutcome::Repaired {
+                            from: Presence::Present(ver.clone()),
+                            version: new_ver,
+                        };
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        report.outcome = ToolOutcome::Failed {
+                            presence: Presence::Present(ver.clone()),
+                            error: format!("{e:#}"),
+                        };
+                    }
+                }
+            }
+        }
+    }
+
+    print_reports(&reports);
+
+    // Keep whetstone itself reachable — a wiped ~/.local/bin takes the
+    // symlink with it.
+    if let Err(e) = crate::setup::self_install() {
+        ui::warn(&format!("whetstone self-install failed: {e:#}"));
+    }
+
+    if let Err(e) = sync_manifest_versions() {
+        ui::warn(&format!("could not update project manifest: {e:#}"));
+    }
+
+    // Report-only doctor: repairs already happened above, and this confirms
+    // the hooks landed.
+    let doctor_report = crate::doctor::run_with(RepairMode::Report, extras)?;
+
+    let unhealthy: Vec<&ToolReport> =
+        reports.iter().filter(|r| !r.is_healthy()).collect();
+    if unhealthy.is_empty() && doctor_report.green() {
+        ui::summary_ok("All whetstone dependencies are installed");
+    } else {
+        ui::summary_info("Some dependencies still need attention — see above");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn icm_expected_only_for_icm_projects() {
+        assert_eq!(
+            expected_tools(Some(MemoryProvider::Icm)),
+            vec![Tool::Headroom, Tool::Rtk, Tool::ClaudeCode, Tool::Icm],
+        );
+        assert_eq!(
+            expected_tools(Some(MemoryProvider::Skip)),
+            vec![Tool::Headroom, Tool::Rtk, Tool::ClaudeCode],
+        );
+        assert_eq!(
+            expected_tools(None),
+            vec![Tool::Headroom, Tool::Rtk, Tool::ClaudeCode],
+        );
+    }
+
+    #[test]
+    fn presence_describes_each_state() {
+        assert_eq!(Presence::Present("1.2.3".into()).describe(), "1.2.3");
+        assert_eq!(Presence::Missing.describe(), "not installed");
+        assert_eq!(Presence::Broken.describe(), "installed but not runnable");
+        assert_eq!(
+            Presence::Incomplete {
+                version: "0.36.1".into(),
+                missing: vec!["mcp".into()],
+            }
+            .describe(),
+            "0.36.1, installed without extras: mcp",
+        );
+    }
+
+    #[test]
+    fn repair_verb_matches_what_actually_happens() {
+        assert_eq!(Presence::Missing.repair_verb(), "install");
+        assert_eq!(Presence::Broken.repair_verb(), "reinstall");
+        assert_eq!(
+            Presence::Incomplete {
+                version: "0.36.1".into(),
+                missing: vec!["proxy".into()],
+            }
+            .repair_verb(),
+            "reinstall",
+        );
+    }
+
+    #[test]
+    fn prompt_mode_degrades_to_report_without_a_tty() {
+        // Tests run without a TTY, so `Prompt` must never try to ask — an
+        // unattended `whetstone doctor` has to stay non-blocking.
+        assert_eq!(RepairMode::Prompt.effective(), RepairMode::Report);
+        assert_eq!(RepairMode::Force.effective(), RepairMode::Force);
+        assert_eq!(RepairMode::Report.effective(), RepairMode::Report);
+    }
+
+    #[test]
+    fn missing_tool_is_only_reported_in_report_mode() {
+        // `claude`/`rtk` may or may not exist on the machine running tests, so
+        // drive the pure branch with a tool binary that cannot exist.
+        let outcome = repair_one(Tool::Icm, RepairMode::Report, "all");
+        match Tool::Icm.presence("all") {
+            Presence::Present(ver) => {
+                assert_eq!(outcome, ToolOutcome::Ok(ver));
+            }
+            other => {
+                assert_eq!(outcome, ToolOutcome::Unrepaired(other));
+            }
+        }
+    }
+
+    #[test]
+    fn from_binary_round_trips_every_tool() {
+        for tool in [Tool::Headroom, Tool::Rtk, Tool::ClaudeCode, Tool::Icm] {
+            assert_eq!(Tool::from_binary(tool.binary()), Some(tool));
+        }
+        assert_eq!(Tool::from_binary("git"), None);
+    }
+
+    #[test]
+    fn tool_binaries_are_the_names_whetstone_shells_out_to() {
+        assert_eq!(Tool::Headroom.binary(), "headroom");
+        assert_eq!(Tool::Rtk.binary(), "rtk");
+        assert_eq!(Tool::ClaudeCode.binary(), "claude");
+        assert_eq!(Tool::Icm.binary(), "icm");
+    }
+
+    #[test]
+    fn healthy_covers_ok_and_repaired_only() {
+        let ok = ToolReport {
+            tool: Tool::Rtk,
+            outcome: ToolOutcome::Ok("0.42.3".into()),
+        };
+        let repaired = ToolReport {
+            tool: Tool::Rtk,
+            outcome: ToolOutcome::Repaired {
+                from: Presence::Missing,
+                version: "0.42.3".into(),
+            },
+        };
+        let unrepaired = ToolReport {
+            tool: Tool::Rtk,
+            outcome: ToolOutcome::Unrepaired(Presence::Missing),
+        };
+        let failed = ToolReport {
+            tool: Tool::Rtk,
+            outcome: ToolOutcome::Failed {
+                presence: Presence::Missing,
+                error: "boom".into(),
+            },
+        };
+        assert!(ok.is_healthy());
+        assert!(repaired.is_healthy());
+        assert!(!unrepaired.is_healthy());
+        assert!(!failed.is_healthy());
+    }
+
+    #[test]
+    fn prereq_list_covers_the_preflight_dependencies() {
+        // `install-tools` must not silently know about fewer dependencies
+        // than `whetstone setup`'s preflight checks.
+        let names: Vec<&str> = PREREQS.iter().map(|p| p.name).collect();
+        for expected in ["uv", "python3", "git", "curl"] {
+            assert!(
+                names.contains(&expected),
+                "prereq list is missing {expected}",
+            );
+        }
+    }
+
+    #[test]
+    fn only_uv_claims_an_unattended_installer() {
+        for prereq in PREREQS {
+            if prereq.installable {
+                assert_eq!(prereq.name, "uv");
+            } else {
+                assert!(install_prereq(prereq).is_err());
+            }
+        }
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -647,6 +647,27 @@ pub fn run(full: bool) -> Result<()> {
         timestamp: now_epoch(),
     });
 
+    // A component that vanished between runs is not an update problem —
+    // point at the command that puts it back rather than silently printing
+    // "not installed" forever.
+    let missing: Vec<&str> = [
+        ("rtk", &rtk_status),
+        ("headroom", &headroom_status),
+        ("claude code", &claude_code_status),
+        ("memory (ICM)", &memory_status),
+    ]
+    .into_iter()
+    .filter(|(_, status)| matches!(status, ui::ComponentStatus::NotInstalled))
+    .map(|(name, _)| name)
+    .collect();
+
+    if !missing.is_empty() {
+        ui::warn(&format!(
+            "{} not installed — run `whetstone install-tools` to reinstall",
+            missing.join(", "),
+        ));
+    }
+
     if updated_count > 0 {
         ui::summary_ok(&format!("Updated {updated_count} component(s)"));
         if matches!(&whetstone_status, ui::ComponentStatus::Updated(_, _)) {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 const DEFAULT_PROXY: &str = "http://127.0.0.1:8787";
+const PROXY_PORT: &str = "8787";
 const PROXY_HEALTH_URL: &str = "http://127.0.0.1:8787/health";
 const PROXY_READY_TIMEOUT: Duration = Duration::from_secs(15);
 const PROXY_KILL_TIMEOUT: Duration = Duration::from_secs(10);
@@ -330,6 +331,7 @@ fn spawn_proxy_detached(memory: bool) -> std::io::Result<()> {
     use std::process::Stdio;
     let telemetry_disabled = !headroom_telemetry_enabled();
     let args = build_proxy_args(
+        PROXY_PORT,
         headroom_proxy_supports_savings_profile(),
         telemetry_disabled,
         memory,
@@ -358,12 +360,163 @@ fn spawn_proxy_detached(memory: bool) -> std::io::Result<()> {
     cmd.spawn().map(|_| ())
 }
 
+/// Verdict from [`check_proxy_starts`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProxyStartCheck {
+    /// A proxy is already answering on the whetstone port — the strongest
+    /// possible evidence that headroom starts.
+    AlreadyRunning,
+    /// A throwaway proxy got past startup validation.
+    Starts,
+    /// The proxy exited during startup. `detail` is headroom's own complaint.
+    Failed { detail: String },
+}
+
+/// How long a smoke-test proxy gets to prove it survives startup. Startup
+/// *validation* failures (a rejected flag, a missing dependency, a bad config)
+/// are immediate; a healthy proxy takes longer than this to serve traffic, so
+/// "still running at the deadline" is the pass condition, not "/health said
+/// yes".
+const PROXY_SMOKE_TIMEOUT: Duration = Duration::from_secs(6);
+
+/// Actually try to start headroom.
+///
+/// Installed, right version, right extras — and still dead on arrival, because
+/// something in headroom's own `settings.json` asks for a flag the current
+/// rollout channel rejects. Nothing whetstone inspected could see that; only
+/// running the thing can. Uses the same args and env whetstone launches the
+/// real proxy with, on a throwaway port so a live proxy is never disturbed.
+pub(crate) fn check_proxy_starts() -> ProxyStartCheck {
+    if probe_proxy() {
+        return ProxyStartCheck::AlreadyRunning;
+    }
+    smoke_start_proxy("headroom", PROXY_SMOKE_TIMEOUT)
+}
+
+/// Spawn half of [`check_proxy_starts`], with the program and grace window
+/// passed in so the observe logic can be tested against a stub instead of a
+/// real headroom (and without depending on whether a proxy happens to be up).
+fn smoke_start_proxy(program: &str, grace: Duration) -> ProxyStartCheck {
+    use std::process::Stdio;
+
+    let port = match free_port() {
+        Some(port) => port.to_string(),
+        None => {
+            return ProxyStartCheck::Failed {
+                detail: "could not reserve a local port for the smoke test"
+                    .into(),
+            }
+        }
+    };
+
+    let telemetry_disabled = !headroom_telemetry_enabled();
+    let args = build_proxy_args(
+        &port,
+        headroom_proxy_supports_savings_profile(),
+        telemetry_disabled,
+        false,
+    );
+
+    let mut cmd = Command::new(program);
+    cmd.args(&args)
+        .env("HEADROOM_SAVINGS_PROFILE", required_savings_profile())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if telemetry_disabled {
+        cmd.env("HEADROOM_TELEMETRY", "off");
+    }
+    for (key, value) in &headroom_env_plan().apply {
+        cmd.env(key, value);
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            return ProxyStartCheck::Failed {
+                detail: format!("could not spawn `headroom proxy`: {e}"),
+            }
+        }
+    };
+
+    let deadline = Instant::now() + grace;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                let output = child.wait_with_output().ok();
+                let (stdout, stderr) = output
+                    .map(|o| {
+                        (
+                            String::from_utf8_lossy(&o.stdout).to_string(),
+                            String::from_utf8_lossy(&o.stderr).to_string(),
+                        )
+                    })
+                    .unwrap_or_default();
+                return ProxyStartCheck::Failed {
+                    detail: summarize_startup_failure(&stdout, &stderr),
+                };
+            }
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return ProxyStartCheck::Starts;
+            }
+            Ok(None) => std::thread::sleep(PROXY_POLL_INTERVAL),
+            Err(e) => {
+                let _ = child.kill();
+                return ProxyStartCheck::Failed {
+                    detail: format!("could not wait on `headroom proxy`: {e}"),
+                };
+            }
+        }
+    }
+}
+
+/// Ask the OS for an unused local port, then let go of it. The window between
+/// releasing and headroom binding is a theoretical race; losing it just makes
+/// one doctor run report a bind failure.
+fn free_port() -> Option<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").ok()?;
+    let port = listener.local_addr().ok()?.port();
+    drop(listener);
+    Some(port)
+}
+
+/// Boil headroom's startup output down to the line that explains the failure.
+/// Prefers an explicit error line; falls back to the last thing it said.
+/// Library chatter on stderr (the transformers/PyTorch notice) is dropped —
+/// it is present on healthy runs too and would bury the real message.
+fn summarize_startup_failure(stdout: &str, stderr: &str) -> String {
+    let lines: Vec<&str> = stderr
+        .lines()
+        .chain(stdout.lines())
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter(|line| !is_startup_noise(line))
+        .collect();
+
+    lines
+        .iter()
+        .find(|line| {
+            let lower = line.to_lowercase();
+            lower.starts_with("error") || lower.contains("error:")
+        })
+        .or_else(|| lines.last())
+        .map(|line| line.to_string())
+        .unwrap_or_else(|| "exited during startup with no output".into())
+}
+
+fn is_startup_noise(line: &str) -> bool {
+    line.starts_with("[transformers]") || line.contains("PyTorch was not found")
+}
+
 fn build_proxy_args(
+    port: &str,
     savings_profile: bool,
     no_telemetry: bool,
     memory: bool,
-) -> Vec<&'static str> {
-    let mut args = vec!["proxy", "--port", "8787"];
+) -> Vec<&str> {
+    let mut args = vec!["proxy", "--port", port];
     if savings_profile {
         args.push("--savings-profile");
     }
@@ -538,6 +691,7 @@ pub fn wrap_rtk(args: &[String]) -> ! {
 #[cfg(unix)]
 fn exec(program: &str, args: &[String]) -> ! {
     use std::os::unix::process::CommandExt;
+    crate::tools::ensure_available(program);
     let err = Command::new(program).args(args).exec();
     eprintln!("[FAIL] failed to exec {program}: {err}");
     std::process::exit(127);
@@ -545,6 +699,7 @@ fn exec(program: &str, args: &[String]) -> ! {
 
 #[cfg(not(unix))]
 fn exec(program: &str, args: &[String]) -> ! {
+    crate::tools::ensure_available(program);
     let status =
         Command::new(program)
             .args(args)
@@ -843,33 +998,153 @@ mod tests {
         assert!(!args.contains(&"acceptEdits".to_string()));
     }
 
+    /// Write an executable stub that stands in for `headroom proxy`.
+    #[cfg(unix)]
+    fn stub_binary(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join("fake-headroom");
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn smoke_reports_failure_when_the_proxy_exits_during_startup() {
+        // The read-maturation case: headroom rejects its own flag and dies
+        // before serving anything.
+        let dir = tempfile::tempdir().unwrap();
+        let stub = stub_binary(
+            dir.path(),
+            "echo '[transformers] PyTorch was not found.' >&2\n             echo 'error: --read-maturation is not available in the current              rollout channel (stable).' >&2\n             exit 1",
+        );
+
+        let result =
+            smoke_start_proxy(stub.to_str().unwrap(), Duration::from_secs(5));
+
+        match result {
+            ProxyStartCheck::Failed { detail } => {
+                assert!(
+                    detail.contains("--read-maturation"),
+                    "expected headroom's own error, got: {detail}"
+                );
+                assert!(
+                    !detail.contains("transformers"),
+                    "library chatter should be filtered, got: {detail}"
+                );
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn smoke_passes_when_the_proxy_survives_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        let stub = stub_binary(dir.path(), "sleep 30");
+
+        assert_eq!(
+            smoke_start_proxy(
+                stub.to_str().unwrap(),
+                Duration::from_millis(600)
+            ),
+            ProxyStartCheck::Starts,
+        );
+    }
+
+    #[test]
+    fn smoke_reports_failure_when_the_binary_cannot_be_spawned() {
+        let result = smoke_start_proxy(
+            "/nonexistent/definitely-not-headroom",
+            Duration::from_millis(200),
+        );
+        match result {
+            ProxyStartCheck::Failed { detail } => {
+                assert!(detail.contains("could not spawn"), "got: {detail}")
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn startup_failure_prefers_the_error_line() {
+        let stderr = "[transformers] PyTorch was not found. Models won't be \
+                      available.\nerror: --read-maturation is not available in \
+                      the current rollout channel (stable).\n";
+        assert_eq!(
+            summarize_startup_failure("", stderr),
+            "error: --read-maturation is not available in the current rollout \
+             channel (stable).",
+        );
+    }
+
+    #[test]
+    fn startup_failure_ignores_library_chatter() {
+        // The transformers notice appears on healthy runs too; reporting it as
+        // the failure would send the user chasing the wrong thing.
+        let stderr = "[transformers] PyTorch was not found.\n\
+                      Error: Proxy dependencies not installed. Run: pip \
+                      install headroom-ai[proxy]\n";
+        assert_eq!(
+            summarize_startup_failure("", stderr),
+            "Error: Proxy dependencies not installed. Run: pip install \
+             headroom-ai[proxy]",
+        );
+    }
+
+    #[test]
+    fn startup_failure_falls_back_to_the_last_line() {
+        assert_eq!(
+            summarize_startup_failure("starting up\nbind failed\n", ""),
+            "bind failed",
+        );
+    }
+
+    #[test]
+    fn startup_failure_with_no_output_still_says_something() {
+        assert_eq!(
+            summarize_startup_failure(
+                "",
+                "[transformers] PyTorch was not found.\n"
+            ),
+            "exited during startup with no output",
+        );
+    }
+
+    #[test]
+    fn free_port_returns_a_usable_port() {
+        let port = free_port().expect("OS should hand out an ephemeral port");
+        assert!(port > 0);
+    }
+
     #[test]
     fn build_proxy_args_without_savings_profile() {
-        let args = build_proxy_args(false, false, false);
+        let args = build_proxy_args("8787", false, false, false);
         assert_eq!(args, vec!["proxy", "--port", "8787"]);
     }
 
     #[test]
     fn build_proxy_args_with_savings_profile() {
-        let args = build_proxy_args(true, false, false);
+        let args = build_proxy_args("8787", true, false, false);
         assert_eq!(args, vec!["proxy", "--port", "8787", "--savings-profile"]);
     }
 
     #[test]
     fn build_proxy_args_with_no_telemetry() {
-        let args = build_proxy_args(false, true, false);
+        let args = build_proxy_args("8787", false, true, false);
         assert_eq!(args, vec!["proxy", "--port", "8787", "--no-telemetry"]);
     }
 
     #[test]
     fn build_proxy_args_with_memory() {
-        let args = build_proxy_args(false, false, true);
+        let args = build_proxy_args("8787", false, false, true);
         assert_eq!(args, vec!["proxy", "--port", "8787", "--memory"]);
     }
 
     #[test]
     fn build_proxy_args_with_savings_profile_and_memory() {
-        let args = build_proxy_args(true, false, true);
+        let args = build_proxy_args("8787", true, false, true);
         assert_eq!(
             args,
             vec!["proxy", "--port", "8787", "--savings-profile", "--memory"]
@@ -921,7 +1196,7 @@ mod tests {
 
     #[test]
     fn build_proxy_args_with_savings_profile_and_no_telemetry() {
-        let args = build_proxy_args(true, true, false);
+        let args = build_proxy_args("8787", true, true, false);
         assert_eq!(
             args,
             vec![


### PR DESCRIPTION
## Summary

- Add `whetstone install-tools` to install or repair every managed dependency (headroom, rtk, claude code, memory provider), re-run their `init` hooks, and resync the project manifest; `--force` reinstalls everything. New `src/tools.rs` holds the managed-dependency inventory.
- `whetstone doctor` now checks that managed dependencies still exist before inspecting `~/.claude/settings.json`, offers to reinstall missing ones (`--fix` skips the prompt), and reports missing system prerequisites.
- `whetstone doctor` now verifies headroom actually **starts**: it probes the running proxy or spawns a throwaway one on a free port with the same args/env whetstone launches with, and reports headroom's own startup error when it dies. A start blocked by a rollout-gated flag (e.g. `read_maturation` in `~/.headroom/settings.json`) is offered for removal — `--fix` removes it, with a backup, and re-checks.
- Launching a managed tool that was uninstalled now offers to reinstall it instead of failing with a bare `exec` error.
- Verify headroom's *extras*, not just its version: an install recorded by uv without `proxy`/`code`/`mcp` is reported by doctor and reinstalled as `headroom-ai[proxy,code,mcp]` instead of passing as healthy.

## Test plan

- `cargo build` — clean
- `cargo clippy --all-targets` — no issues
- `cargo test` — 278 passed