### PR TITLE
feat: per-config keyed proxy reuse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ whetstone memory consolidate [--dry-run]   # drain stray project-local .headroom
 
 `--headroom-extras` accepts: `all` (default = `proxy,code,mcp`), `none`, or comma-separated like `proxy,code`.
 
-`--memory` is a global flag (e.g. `whetstone --memory`, `whetstone --memory claude`). It enables Headroom persistent cross-session memory by passing `--memory` to the proxy whetstone spawns. If a proxy is already running *without* memory, whetstone prompts: restart it with memory (replaces the global proxy), start a memory proxy for this session only, or cancel. It can also be set persistently per-project or globally via `whetstone settings` (Headroom Memory).
+`--memory` is a global flag (e.g. `whetstone --memory`, `whetstone --memory claude`). It enables Headroom persistent cross-session memory by passing `--memory` to the proxy whetstone spawns. Memory on/off is part of the per-config fingerprint (see Architecture below), so a session that wants memory never fights one that doesn't — each gets its own proxy, and there is no restart/replace prompt to resolve the conflict. It can also be set persistently per-project or globally via `whetstone settings` (Headroom Memory).
 
 `whetstone doctor` checks the managed dependencies (headroom, rtk, claude
 code, and the project's memory provider) before it looks at hooks: a tool that
@@ -121,6 +121,8 @@ User → Claude Code
          ├── Context    → [Headroom Proxy :8787] → Anthropic API
          └── Memory     → [ICM, embedded SQLite] → persistent context
 ```
+
+Whetstone runs one Headroom proxy per distinct resolved config (savings profile, telemetry, memory, upstream URL, and the `HEADROOM_*` apply set — see the "Global Headroom memory root" bullet below), reusing a live proxy only when a session's config fingerprint matches exactly. There is no memory-conflict prompt: memory on/off is part of that fingerprint, so a session that wants memory and one that doesn't simply get separate proxies instead of racing to replace each other's.
 
 **Setup flow** (`whetstone setup`, orchestrated by `src/setup.rs`). Setup first self-updates and offers v2→v3 migration; if the terminal is interactive it runs `src/wizard.rs`, otherwise the headless sequence below:
 1. Resolve assets; preflight-check dependencies (python, git, curl, uv)
@@ -179,7 +181,8 @@ src/
 - **Idempotent**: setup skips already-installed components; safe to rerun
 - **Absolute paths in hooks**: avoids PATH/shell-state issues
 - **Global tools, per-project config**: RTK/Headroom installed globally; memory provider and version-pinned manifest are per-project
-- **Global Headroom memory root**: because the proxy is a single shared process, whetstone pins `HEADROOM_MEMORY_DB_PATH` to `~/.headroom/memory.db` so per-project memory DBs live under `~/.headroom/memories/projects/` instead of accumulating in whichever project launched the proxy. `wrap_claude` auto-consolidates any stray project-local `.headroom` store into that root (never overwriting global data; seed DBs migrate all-or-nothing), and `whetstone memory consolidate [--dry-run]` runs it explicitly (`src/memory_consolidate.rs`)
+- **Per-config proxy registry**: whetstone runs one proxy per distinct resolved config, keyed by a fingerprint (savings profile, telemetry, memory, upstream URL, and the non-memory-path `HEADROOM_*` apply set) over entries in `~/.whetstone/proxies.json` (`src/proxy_registry.rs`). Two sessions that would spawn a byte-identical proxy share it; anything that differs — including memory on vs. off — gets its own. Port `8787` is only a best-effort launch-order anchor so a bare `claude` launch and doctor's fast path still find a proxy there when nothing else has claimed it; it is not a fixed single-proxy port. The memory DB path itself stays out of the fingerprint (see below), so it can't fracture reuse on its own.
+- **Global Headroom memory root**: whetstone pins `HEADROOM_MEMORY_DB_PATH` to `~/.headroom/memory.db` so per-project memory DBs live under `~/.headroom/memories/projects/` instead of accumulating in whichever project launched the proxy — unaffected by per-config proxy reuse above. `wrap_claude` auto-consolidates any stray project-local `.headroom` store into that root (never overwriting global data; seed DBs migrate all-or-nothing), and `whetstone memory consolidate [--dry-run]` runs it explicitly (`src/memory_consolidate.rs`)
 - **Tool-managed hooks**: v3 delegates `~/.claude/settings.json` hook entries to `rtk init` / `icm init`; whetstone never hand-merges them (`doctor` reports drift, `migrate` archives before touching state)
 - **Layered settings**: `GlobalSettings` (`~/.whetstone/settings.json`) and per-project `ProjectSettings` (in `.claude/whetstone.json`) resolve with project-over-global precedence
 - **rusqlite bundled**: statically links SQLite, no system dependency

--- a/docs/superpowers/plans/2026-08-23-per-config-proxy.md
+++ b/docs/superpowers/plans/2026-08-23-per-config-proxy.md
@@ -1,0 +1,1115 @@
+# Per-Config Headroom Proxy Reuse Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Key Headroom proxy reuse on a config fingerprint so a project's per-project proxy settings (upstream URL, savings profile, telemetry, `headroom_env`, memory) stop bleeding across projects that share the single fixed-port proxy.
+
+**Architecture:** A new `src/proxy_registry.rs` computes a stable fingerprint over the exact config that would be spawned, keeps a lockfile-guarded registry (`~/.whetstone/proxies.json`) mapping fingerprint → `{port, pid}`, and resolves each launch to either a reused live proxy or a freshly-spawned one on its own port. `src/wrapper.rs` calls this instead of the old single-port `resolve_proxy`, points `ANTHROPIC_BASE_URL` at the selected port, and drops the now-dead memory-conflict prompt. Port 8787 is a best-effort launch-order anchor for backward compatibility.
+
+**Tech Stack:** Rust, `serde`/`serde_json`, `ureq` (health probe), std `TcpListener` (free-port + port-free checks), std `fs` (registry + lockfile). No new dependencies — FNV-1a fingerprint and an `O_EXCL` lockfile guard are hand-rolled.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-per-config-proxy-design.md`
+
+## Global Constraints
+
+- No new crate dependencies — fingerprint hashing and file locking are implemented in-repo.
+- `HEADROOM_MEMORY_DB_PATH` is excluded from the fingerprint (globally pinned; identical everywhere).
+- `HEADROOM_PORT` stays reserved/denied in `src/headroom_env.rs` `RESERVED_DENY` — unchanged.
+- Verify every task with `cargo build && cargo test && cargo clippy` (per CLAUDE.md). `just test` / `just lint` also work.
+- Existing external-env-wins precedence and the global `~/.headroom` memory root are unchanged.
+- Match the surrounding file style: `anyhow::Result` with `.context(...)`, `ui::` helpers for user output, module-level unit tests in a `#[cfg(test)] mod tests`.
+
+---
+
+### Task 1: Fingerprint (`ProxySpec` + `proxy_fingerprint`)
+
+**Files:**
+- Create: `src/proxy_registry.rs`
+- Modify: `src/main.rs` (add `mod proxy_registry;`)
+
+**Interfaces:**
+- Produces:
+  - `pub struct ProxySpec { pub savings_profile: String, pub telemetry: bool, pub memory: bool, pub anthropic_api_url: Option<String>, pub env: std::collections::BTreeMap<String, String> }`
+  - `pub fn proxy_fingerprint(spec: &ProxySpec) -> String` — 16-hex-char stable hash.
+
+- [ ] **Step 1: Register the module**
+
+In `src/main.rs`, add alongside the other `mod` declarations:
+
+```rust
+mod proxy_registry;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src/proxy_registry.rs` with only the type, a stub, and the tests:
+
+```rust
+//! Per-config Headroom proxy registry: fingerprint the exact proxy config a
+//! session would spawn, so two sessions share a proxy iff they would spawn a
+//! byte-identical one. Keyed reuse via `~/.whetstone/proxies.json`.
+
+use std::collections::BTreeMap;
+
+/// Everything that varies a spawned Headroom proxy's behavior. Two specs with
+/// the same fingerprint may share one proxy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxySpec {
+    /// Resolved `HEADROOM_SAVINGS_PROFILE`.
+    pub savings_profile: String,
+    /// Whether telemetry is enabled (drives `--no-telemetry` / env).
+    pub telemetry: bool,
+    /// Whether the proxy is started with `--memory`.
+    pub memory: bool,
+    /// Resolved `ANTHROPIC_TARGET_API_URL`, if any.
+    pub anthropic_api_url: Option<String>,
+    /// The `HEADROOM_*` apply set, EXCLUDING `HEADROOM_MEMORY_DB_PATH`.
+    pub env: BTreeMap<String, String>,
+}
+
+/// FNV-1a 64-bit over a canonical rendering of the spec.
+pub fn proxy_fingerprint(_spec: &ProxySpec) -> String {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> ProxySpec {
+        ProxySpec {
+            savings_profile: "agent-90".into(),
+            telemetry: false,
+            memory: false,
+            anthropic_api_url: None,
+            env: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_stable_and_16_hex() {
+        let fp = proxy_fingerprint(&base());
+        assert_eq!(fp.len(), 16);
+        assert!(fp.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(fp, proxy_fingerprint(&base()));
+    }
+
+    #[test]
+    fn fingerprint_is_order_independent_for_env() {
+        let mut a = base();
+        a.env.insert("HEADROOM_RPM".into(), "1".into());
+        a.env.insert("HEADROOM_CODE_AWARE_ENABLED".into(), "1".into());
+        // BTreeMap canonicalizes order; inserting in the other order matches.
+        let mut b = base();
+        b.env.insert("HEADROOM_CODE_AWARE_ENABLED".into(), "1".into());
+        b.env.insert("HEADROOM_RPM".into(), "1".into());
+        assert_eq!(proxy_fingerprint(&a), proxy_fingerprint(&b));
+    }
+
+    #[test]
+    fn each_field_changes_the_fingerprint() {
+        let f0 = proxy_fingerprint(&base());
+
+        let mut sp = base();
+        sp.savings_profile = "agent-50".into();
+        assert_ne!(f0, proxy_fingerprint(&sp));
+
+        let mut tel = base();
+        tel.telemetry = true;
+        assert_ne!(f0, proxy_fingerprint(&tel));
+
+        let mut mem = base();
+        mem.memory = true;
+        assert_ne!(f0, proxy_fingerprint(&mem));
+
+        let mut url = base();
+        url.anthropic_api_url = Some("https://example.test".into());
+        assert_ne!(f0, proxy_fingerprint(&url));
+
+        let mut env = base();
+        env.env.insert("HEADROOM_RPM".into(), "120".into());
+        assert_ne!(f0, proxy_fingerprint(&env));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test --lib proxy_registry`
+Expected: FAIL — `proxy_fingerprint` panics with `unimplemented!()`.
+
+- [ ] **Step 4: Implement the fingerprint**
+
+Replace the `proxy_fingerprint` stub:
+
+```rust
+fn canonical(spec: &ProxySpec) -> String {
+    let mut s = String::new();
+    s.push_str("sp=");
+    s.push_str(&spec.savings_profile);
+    s.push('\n');
+    s.push_str("tel=");
+    s.push(if spec.telemetry { '1' } else { '0' });
+    s.push('\n');
+    s.push_str("mem=");
+    s.push(if spec.memory { '1' } else { '0' });
+    s.push('\n');
+    s.push_str("url=");
+    s.push_str(spec.anthropic_api_url.as_deref().unwrap_or(""));
+    s.push('\n');
+    for (k, v) in &spec.env {
+        s.push_str("e:");
+        s.push_str(k);
+        s.push('=');
+        s.push_str(v);
+        s.push('\n');
+    }
+    s
+}
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+pub fn proxy_fingerprint(spec: &ProxySpec) -> String {
+    format!("{:016x}", fnv1a(canonical(spec).as_bytes()))
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --lib proxy_registry`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/proxy_registry.rs src/main.rs
+git commit -m "feat(proxy): add ProxySpec config fingerprint"
+```
+
+---
+
+### Task 2: Registry struct + load/save
+
+**Files:**
+- Modify: `src/proxy_registry.rs`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `pub struct ProxyEntry { pub fingerprint: String, pub port: u16, pub pid: u32 }` (derives `Clone, Debug, PartialEq, Eq, Serialize, Deserialize`).
+  - `pub struct Registry { pub entries: Vec<ProxyEntry> }` (derives `Default, Debug, Serialize, Deserialize`).
+  - `impl Registry`: `pub fn load(path: &std::path::Path) -> Self`, `pub fn save(&self, path: &std::path::Path) -> anyhow::Result<()>`, `pub fn find(&self, fingerprint: &str) -> Option<&ProxyEntry>`.
+  - `pub fn registry_path() -> Option<std::path::PathBuf>` → `~/.whetstone/proxies.json`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add imports at the top of `src/proxy_registry.rs` (merge with existing `use`):
+
+```rust
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+```
+
+Add these tests inside `mod tests`:
+
+```rust
+    #[test]
+    fn load_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("proxies.json");
+        let reg = Registry::load(&path);
+        assert!(reg.entries.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("proxies.json");
+        let reg = Registry {
+            entries: vec![ProxyEntry {
+                fingerprint: "abc123".into(),
+                port: 8801,
+                pid: 4242,
+            }],
+        };
+        reg.save(&path).unwrap();
+        let back = Registry::load(&path);
+        assert_eq!(back.entries, reg.entries);
+        assert_eq!(back.find("abc123").map(|e| e.port), Some(8801));
+        assert!(back.find("nope").is_none());
+    }
+
+    #[test]
+    fn load_corrupt_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("proxies.json");
+        std::fs::write(&path, "not json").unwrap();
+        assert!(Registry::load(&path).entries.is_empty());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib proxy_registry`
+Expected: FAIL — `Registry` / `ProxyEntry` undefined.
+
+- [ ] **Step 3: Implement the registry types**
+
+Add to `src/proxy_registry.rs` (outside `mod tests`):
+
+```rust
+const GLOBAL_DIR: &str = ".whetstone";
+const REGISTRY_FILENAME: &str = "proxies.json";
+
+/// One whetstone-spawned proxy: its config fingerprint, bound port, and pid.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProxyEntry {
+    pub fingerprint: String,
+    pub port: u16,
+    pub pid: u32,
+}
+
+/// The set of live whetstone-spawned proxies. Persisted to
+/// `~/.whetstone/proxies.json`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Registry {
+    #[serde(default)]
+    pub entries: Vec<ProxyEntry>,
+}
+
+/// `~/.whetstone/proxies.json`, or `None` if the home dir can't be found.
+pub fn registry_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(GLOBAL_DIR).join(REGISTRY_FILENAME))
+}
+
+impl Registry {
+    /// Load the registry, treating a missing or corrupt file as empty — a
+    /// stale registry must never block a launch.
+    pub fn load(path: &Path) -> Self {
+        let Ok(raw) = std::fs::read_to_string(path) else {
+            return Self::default();
+        };
+        serde_json::from_str(&raw).unwrap_or_default()
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let pretty = serde_json::to_string_pretty(self)
+            .context("serializing proxy registry")?;
+        std::fs::write(path, pretty)
+            .with_context(|| format!("writing {}", path.display()))
+    }
+
+    pub fn find(&self, fingerprint: &str) -> Option<&ProxyEntry> {
+        self.entries.iter().find(|e| e.fingerprint == fingerprint)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib proxy_registry`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy_registry.rs
+git commit -m "feat(proxy): add proxy registry load/save"
+```
+
+---
+
+### Task 3: Lockfile guard
+
+**Files:**
+- Modify: `src/proxy_registry.rs`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `pub struct LockGuard { path: PathBuf }` with `Drop` removing the file.
+  - `pub fn acquire_lock(path: &Path, timeout: std::time::Duration, stale_after: std::time::Duration) -> Result<LockGuard>` — spins on `O_EXCL` create; steals a lockfile older than `stale_after`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests` (add `use std::time::Duration;` to the test module or fully-qualify):
+
+```rust
+    #[test]
+    fn lock_is_exclusive_then_released_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("proxies.lock");
+        let short = std::time::Duration::from_millis(200);
+        let stale = std::time::Duration::from_secs(60);
+
+        let g = acquire_lock(&lock, short, stale).unwrap();
+        // Second acquisition times out while the first is held.
+        assert!(acquire_lock(&lock, short, stale).is_err());
+        drop(g);
+        // After release, it succeeds again.
+        assert!(acquire_lock(&lock, short, stale).is_ok());
+    }
+
+    #[test]
+    fn stale_lock_is_stolen() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("proxies.lock");
+        std::fs::write(&lock, "old").unwrap();
+        // stale_after = 0 → any existing lock is immediately stealable.
+        let g = acquire_lock(
+            &lock,
+            std::time::Duration::from_millis(200),
+            std::time::Duration::from_secs(0),
+        );
+        assert!(g.is_ok());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib proxy_registry`
+Expected: FAIL — `acquire_lock` / `LockGuard` undefined.
+
+- [ ] **Step 3: Implement the lock**
+
+Add to `src/proxy_registry.rs`:
+
+```rust
+use std::time::{Duration, Instant};
+
+/// Advisory lockfile guard. Holds an `O_EXCL`-created file for the duration of
+/// a registry critical section; removes it on drop.
+pub struct LockGuard {
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Acquire the registry lock, spinning until it's free or `timeout` elapses. A
+/// lockfile older than `stale_after` (a crashed holder) is stolen.
+pub fn acquire_lock(
+    path: &Path,
+    timeout: Duration,
+    stale_after: Duration,
+) -> Result<LockGuard> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let deadline = Instant::now() + timeout;
+    loop {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+        {
+            Ok(_) => return Ok(LockGuard { path: path.to_path_buf() }),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if lock_is_stale(path, stale_after) {
+                    let _ = std::fs::remove_file(path);
+                    continue;
+                }
+                if Instant::now() >= deadline {
+                    anyhow::bail!(
+                        "timed out acquiring proxy registry lock at {}",
+                        path.display()
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("opening lock {}", path.display())
+                })
+            }
+        }
+    }
+}
+
+fn lock_is_stale(path: &Path, stale_after: Duration) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    modified.elapsed().map(|age| age >= stale_after).unwrap_or(false)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib proxy_registry`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy_registry.rs
+git commit -m "feat(proxy): add lockfile guard for the registry"
+```
+
+---
+
+### Task 4: Port allocation (launch-order 8787 anchor)
+
+**Files:**
+- Modify: `src/proxy_registry.rs`
+
+**Interfaces:**
+- Consumes: `Registry`.
+- Produces:
+  - `pub const ANCHOR_PORT: u16 = 8787;`
+  - `pub fn choose_port(reg: &Registry, port_free: impl Fn(u16) -> bool, free_port: impl Fn() -> Option<u16>) -> Option<u16>` — returns 8787 when it's free and unclaimed, else a fresh free port.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests`:
+
+```rust
+    fn entry(fp: &str, port: u16) -> ProxyEntry {
+        ProxyEntry { fingerprint: fp.into(), port, pid: 1 }
+    }
+
+    #[test]
+    fn choose_port_prefers_anchor_when_free_and_unclaimed() {
+        let reg = Registry::default();
+        let port = choose_port(&reg, |_| true, || Some(9001));
+        assert_eq!(port, Some(ANCHOR_PORT));
+    }
+
+    #[test]
+    fn choose_port_skips_anchor_when_claimed_by_a_live_entry() {
+        let reg = Registry { entries: vec![entry("x", ANCHOR_PORT)] };
+        let port = choose_port(&reg, |_| true, || Some(9002));
+        assert_eq!(port, Some(9002));
+    }
+
+    #[test]
+    fn choose_port_skips_anchor_when_port_busy() {
+        let reg = Registry::default();
+        // Anchor reported busy by the OS even though no entry claims it.
+        let port = choose_port(&reg, |p| p != ANCHOR_PORT, || Some(9003));
+        assert_eq!(port, Some(9003));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib proxy_registry`
+Expected: FAIL — `choose_port` / `ANCHOR_PORT` undefined.
+
+- [ ] **Step 3: Implement**
+
+Add to `src/proxy_registry.rs`:
+
+```rust
+/// Backward-compat anchor port. Assigned best-effort to the first proxy
+/// whetstone spawns so a bare `claude` launch and doctor's fast-path still
+/// find a proxy at `127.0.0.1:8787`.
+pub const ANCHOR_PORT: u16 = 8787;
+
+/// Pick a port for a new proxy: the anchor when it's free and unclaimed,
+/// otherwise a fresh OS-assigned free port.
+pub fn choose_port(
+    reg: &Registry,
+    port_free: impl Fn(u16) -> bool,
+    free_port: impl Fn() -> Option<u16>,
+) -> Option<u16> {
+    let anchor_claimed = reg.entries.iter().any(|e| e.port == ANCHOR_PORT);
+    if !anchor_claimed && port_free(ANCHOR_PORT) {
+        return Some(ANCHOR_PORT);
+    }
+    free_port()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib proxy_registry`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy_registry.rs
+git commit -m "feat(proxy): launch-order 8787 port anchor"
+```
+
+---
+
+### Task 5: Prune + resolve orchestrator
+
+**Files:**
+- Modify: `src/proxy_registry.rs`
+
+**Interfaces:**
+- Consumes: `Registry`, `ProxySpec`, `proxy_fingerprint`, `choose_port`.
+- Produces:
+  - `pub enum ProxyOutcome { Reused(u16), Spawned(u16), Failed }`
+  - `pub struct ResolveDeps<'a> { pub probe: &'a dyn Fn(u16) -> bool, pub port_free: &'a dyn Fn(u16) -> bool, pub free_port: &'a dyn Fn() -> Option<u16>, pub spawn: &'a dyn Fn(u16, u32) -> Option<u32> }`
+    - `spawn(port, existing_pid_placeholder)`: spawn a proxy for the current spec on `port`, poll to readiness; return `Some(pid)` on success, `None` on failure. (The second arg is unused — see note; kept `u32` to avoid a lifetime-bearing closure type. **Correction:** use the simpler signature below.)
+  - `pub fn resolve(reg: &mut Registry, spec: &ProxySpec, deps: &ResolveDeps) -> ProxyOutcome` — mutates `reg` (prunes dead, records a spawn); caller persists it.
+
+> Interface correction (authoritative): `spawn` takes only the port:
+> `pub spawn: &'a dyn Fn(u16) -> Option<u32>` returning the new pid on success.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mod tests`:
+
+```rust
+    struct Stub {
+        alive: std::cell::RefCell<Vec<u16>>, // ports that answer /health
+        spawned: std::cell::RefCell<Vec<u16>>,
+        next_free: u16,
+    }
+
+    fn deps_from<'a>(
+        probe: &'a dyn Fn(u16) -> bool,
+        port_free: &'a dyn Fn(u16) -> bool,
+        free_port: &'a dyn Fn() -> Option<u16>,
+        spawn: &'a dyn Fn(u16) -> Option<u32>,
+    ) -> ResolveDeps<'a> {
+        ResolveDeps { probe, port_free, free_port, spawn }
+    }
+
+    #[test]
+    fn resolve_reuses_a_live_matching_proxy() {
+        let spec = base();
+        let fp = proxy_fingerprint(&spec);
+        let mut reg = Registry { entries: vec![ProxyEntry { fingerprint: fp, port: 8801, pid: 7 }] };
+
+        let probe = |_p: u16| true; // 8801 answers
+        let port_free = |_p: u16| true;
+        let free_port = || Some(9100u16);
+        let spawn = |_p: u16| -> Option<u32> { panic!("must not spawn on reuse") };
+        let deps = deps_from(&probe, &port_free, &free_port, &spawn);
+
+        let outcome = resolve(&mut reg, &spec, &deps);
+        assert_eq!(outcome, ProxyOutcome::Reused(8801));
+        assert_eq!(reg.entries.len(), 1);
+    }
+
+    #[test]
+    fn resolve_prunes_dead_entry_and_spawns() {
+        let spec = base();
+        let fp = proxy_fingerprint(&spec);
+        let mut reg = Registry { entries: vec![ProxyEntry { fingerprint: fp.clone(), port: 8801, pid: 7 }] };
+
+        let probe = |_p: u16| false; // nothing answers → 8801 is dead
+        let port_free = |_p: u16| true;
+        let free_port = || Some(9100u16);
+        let spawned: std::cell::Cell<Option<u16>> = std::cell::Cell::new(None);
+        let spawn = |p: u16| -> Option<u32> { spawned.set(Some(p)); Some(555) };
+        let deps = deps_from(&probe, &port_free, &free_port, &spawn);
+
+        let outcome = resolve(&mut reg, &spec, &deps);
+        // Dead 8801 pruned; anchor free & unclaimed → spawns on 8787.
+        assert_eq!(outcome, ProxyOutcome::Spawned(ANCHOR_PORT));
+        assert_eq!(spawned.get(), Some(ANCHOR_PORT));
+        assert_eq!(reg.find(&fp).map(|e| (e.port, e.pid)), Some((ANCHOR_PORT, 555)));
+    }
+
+    #[test]
+    fn resolve_spawns_new_port_when_anchor_taken() {
+        let spec = base();
+        let fp = proxy_fingerprint(&spec);
+        // A different fingerprint holds a live anchor.
+        let mut reg = Registry { entries: vec![ProxyEntry { fingerprint: "other".into(), port: ANCHOR_PORT, pid: 1 }] };
+
+        let probe = |_p: u16| true; // anchor's holder is alive
+        let port_free = |_p: u16| true;
+        let free_port = || Some(9100u16);
+        let spawn = |_p: u16| -> Option<u32> { Some(556) };
+        let deps = deps_from(&probe, &port_free, &free_port, &spawn);
+
+        let outcome = resolve(&mut reg, &spec, &deps);
+        assert_eq!(outcome, ProxyOutcome::Spawned(9100));
+        assert_eq!(reg.find(&fp).map(|e| e.port), Some(9100));
+    }
+
+    #[test]
+    fn resolve_reports_failed_when_spawn_fails() {
+        let spec = base();
+        let mut reg = Registry::default();
+        let probe = |_p: u16| false;
+        let port_free = |_p: u16| true;
+        let free_port = || Some(9100u16);
+        let spawn = |_p: u16| -> Option<u32> { None };
+        let deps = deps_from(&probe, &port_free, &free_port, &spawn);
+
+        assert_eq!(resolve(&mut reg, &spec, &deps), ProxyOutcome::Failed);
+        assert!(reg.find(&proxy_fingerprint(&spec)).is_none());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib proxy_registry`
+Expected: FAIL — `resolve` / `ProxyOutcome` / `ResolveDeps` undefined.
+
+- [ ] **Step 3: Implement**
+
+Add to `src/proxy_registry.rs`:
+
+```rust
+/// The result of resolving a launch to a proxy port.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ProxyOutcome {
+    /// An already-running proxy matched the fingerprint.
+    Reused(u16),
+    /// A fresh proxy was spawned on this port.
+    Spawned(u16),
+    /// No proxy could be brought up; caller should soft-fall-back.
+    Failed,
+}
+
+/// Injected side effects so `resolve` is unit-testable without a real proxy.
+pub struct ResolveDeps<'a> {
+    /// Does a proxy answer `/health` on this port?
+    pub probe: &'a dyn Fn(u16) -> bool,
+    /// Can we bind this port right now?
+    pub port_free: &'a dyn Fn(u16) -> bool,
+    /// Ask the OS for an unused port.
+    pub free_port: &'a dyn Fn() -> Option<u16>,
+    /// Spawn a proxy for the current spec on this port; return its pid when it
+    /// comes up ready, else `None`.
+    pub spawn: &'a dyn Fn(u16) -> Option<u32>,
+}
+
+/// Prune dead entries, reuse a live matching proxy, or spawn a new one.
+/// Mutates `reg`; the caller persists it under the lock.
+pub fn resolve(
+    reg: &mut Registry,
+    spec: &ProxySpec,
+    deps: &ResolveDeps,
+) -> ProxyOutcome {
+    reg.entries.retain(|e| (deps.probe)(e.port));
+
+    let fingerprint = proxy_fingerprint(spec);
+    if let Some(entry) = reg.find(&fingerprint) {
+        return ProxyOutcome::Reused(entry.port);
+    }
+
+    let Some(port) = choose_port(reg, deps.port_free, deps.free_port) else {
+        return ProxyOutcome::Failed;
+    };
+    match (deps.spawn)(port) {
+        Some(pid) => {
+            reg.entries.push(ProxyEntry { fingerprint, port, pid });
+            ProxyOutcome::Spawned(port)
+        }
+        None => ProxyOutcome::Failed,
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib proxy_registry`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy_registry.rs
+git commit -m "feat(proxy): prune + reuse/spawn resolve orchestrator"
+```
+
+---
+
+### Task 6: Wire the registry into `wrapper.rs` + docs
+
+This task replaces the single-port proxy logic with the registry, removes the memory-conflict prompt, and updates CLAUDE.md. It has no new pure unit under test of its own beyond a `build_proxy_spec` helper; the behavior is covered by the registry tests plus a `build_proxy_spec` test and the existing `build_claude_args` tests. Verification is a green `cargo test` for the whole crate with the four deleted `parse_proxy_health` tests gone.
+
+**Files:**
+- Modify: `src/wrapper.rs`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: `crate::proxy_registry::{ProxySpec, Registry, ResolveDeps, ProxyOutcome, registry_path, acquire_lock, ANCHOR_PORT, proxy_fingerprint}`.
+- Produces: internal helpers `build_proxy_spec`, `probe_port`, `select_proxy_port`; changed signatures `spawn_proxy_detached(port: &str, memory: bool)` and `spawn_proxy_ready(port: &str, memory: bool) -> Option<u32>`.
+
+- [ ] **Step 1: Add the `build_proxy_spec` failing test**
+
+In `src/wrapper.rs` `mod tests`, add:
+
+```rust
+    #[test]
+    fn build_proxy_spec_excludes_memory_db_path() {
+        use std::collections::BTreeMap;
+        let mut apply = vec![
+            ("HEADROOM_CODE_AWARE_ENABLED".to_string(), "1".to_string()),
+            (
+                "HEADROOM_MEMORY_DB_PATH".to_string(),
+                "/home/u/.headroom/memory.db".to_string(),
+            ),
+        ];
+        // Sorted apply set is fine; the helper filters by key.
+        apply.sort();
+        let spec = build_proxy_spec_from(
+            "agent-90".to_string(),
+            true,  // telemetry
+            true,  // memory
+            Some("https://up.test".to_string()),
+            &apply,
+        );
+        assert_eq!(spec.savings_profile, "agent-90");
+        assert!(spec.telemetry);
+        assert!(spec.memory);
+        assert_eq!(spec.anthropic_api_url.as_deref(), Some("https://up.test"));
+        assert!(spec.env.contains_key("HEADROOM_CODE_AWARE_ENABLED"));
+        assert!(!spec.env.contains_key("HEADROOM_MEMORY_DB_PATH"));
+        let _ = BTreeMap::<String, String>::new();
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib build_proxy_spec_excludes_memory_db_path`
+Expected: FAIL — `build_proxy_spec_from` undefined.
+
+- [ ] **Step 3: Add the pure spec-builder**
+
+In `src/wrapper.rs`, add (near `headroom_env_plan`):
+
+```rust
+/// Testable core: assemble a `ProxySpec` from resolved inputs + the apply set.
+fn build_proxy_spec_from(
+    savings_profile: String,
+    telemetry: bool,
+    memory: bool,
+    anthropic_api_url: Option<String>,
+    apply: &[(String, String)],
+) -> crate::proxy_registry::ProxySpec {
+    let env = apply
+        .iter()
+        .filter(|(k, _)| k != "HEADROOM_MEMORY_DB_PATH")
+        .cloned()
+        .collect();
+    crate::proxy_registry::ProxySpec {
+        savings_profile,
+        telemetry,
+        memory,
+        anthropic_api_url: anthropic_api_url
+            .filter(|s| !s.trim().is_empty()),
+        env,
+    }
+}
+
+/// Production wrapper: reads live settings, the applied env plan, and the
+/// effective upstream URL.
+fn build_proxy_spec(
+    resolved: &crate::config::ResolvedSettings,
+    hr_plan: &crate::headroom_env::HeadroomEnvPlan,
+    memory: bool,
+) -> crate::proxy_registry::ProxySpec {
+    build_proxy_spec_from(
+        required_savings_profile(),
+        resolved.headroom_telemetry,
+        memory,
+        env::var(ANTHROPIC_TARGET_API_URL).ok(),
+        &hr_plan.apply,
+    )
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `cargo test --lib build_proxy_spec_excludes_memory_db_path`
+Expected: PASS.
+
+- [ ] **Step 5: Generalize probe + spawn to a port, add the file-level selector**
+
+In `src/wrapper.rs`:
+
+Replace `fn probe_proxy() -> bool { ... }` with a port-parameterized probe plus a compat wrapper on the anchor:
+
+```rust
+fn probe_port(port: u16) -> bool {
+    let url = format!("http://127.0.0.1:{port}/health");
+    ureq::get(&url).timeout(PROXY_PROBE_TIMEOUT).call().is_ok()
+}
+
+fn probe_proxy() -> bool {
+    probe_port(crate::proxy_registry::ANCHOR_PORT)
+}
+```
+
+Change `spawn_proxy_detached` to take a port (replace its `PROXY_PORT` use):
+
+```rust
+fn spawn_proxy_detached(port: &str, memory: bool) -> std::io::Result<()> {
+```
+
+and inside it pass `port` to `build_proxy_args(port, ...)` instead of `PROXY_PORT`.
+
+Add a port-aware readiness spawn (generalizing the old `start_proxy_detached_ready`):
+
+```rust
+/// Spawn a proxy on `port` and poll until it answers or times out. Returns the
+/// child pid on success (read back from the port's own report is unnecessary —
+/// we return the spawned pid), else `None`.
+fn spawn_proxy_ready(port: u16, memory: bool) -> Option<u32> {
+    let pid = spawn_proxy_detached_pid(&port.to_string(), memory)?;
+    let deadline = Instant::now() + PROXY_READY_TIMEOUT;
+    while Instant::now() < deadline {
+        if probe_port(port) {
+            return Some(pid);
+        }
+        std::thread::sleep(PROXY_POLL_INTERVAL);
+    }
+    eprintln!(
+        "[WARN] whetstone: proxy on 127.0.0.1:{port} did not respond in time"
+    );
+    None
+}
+```
+
+Change `spawn_proxy_detached` to return the child pid so `spawn_proxy_ready` can record it — rename the spawning body to `spawn_proxy_detached_pid`:
+
+```rust
+fn spawn_proxy_detached_pid(port: &str, memory: bool) -> Option<u32> {
+    // ...existing body of spawn_proxy_detached, but:
+    //   let child = cmd.spawn().ok()?;
+    //   Some(child.id())
+}
+```
+
+(Delete the old `spawn_proxy_detached` returning `io::Result<()>`; nothing else calls it once Step 6 lands.)
+
+Add the file-level selector that locks, loads, resolves, saves:
+
+```rust
+/// Lock the registry, reconcile it against the running proxies, and return the
+/// port this session should use (spawning one if needed). Falls back to `None`
+/// so the caller can let `headroom wrap` try its own proxy.
+fn select_proxy_port(spec: &crate::proxy_registry::ProxySpec) -> Option<u16> {
+    use crate::proxy_registry as reg;
+    let path = reg::registry_path()?;
+    let lock_path = path.with_extension("lock");
+    // Lock window must outlast a full readiness wait.
+    let _guard = reg::acquire_lock(
+        &lock_path,
+        Duration::from_secs(25),
+        Duration::from_secs(45),
+    )
+    .ok()?;
+
+    let mut registry = reg::Registry::load(&path);
+    let probe = |p: u16| probe_port(p);
+    let port_free = |p: u16| free_port_is_bindable(p);
+    let free = || free_port();
+    let spawn = |p: u16| spawn_proxy_ready(p, spec.memory);
+    let deps = reg::ResolveDeps {
+        probe: &probe,
+        port_free: &port_free,
+        free_port: &free,
+        spawn: &spawn,
+    };
+
+    let outcome = reg::resolve(&mut registry, spec, &deps);
+    let _ = registry.save(&path);
+    match outcome {
+        reg::ProxyOutcome::Reused(p) | reg::ProxyOutcome::Spawned(p) => Some(p),
+        reg::ProxyOutcome::Failed => None,
+    }
+}
+
+/// Can we bind this specific port right now?
+fn free_port_is_bindable(port: u16) -> bool {
+    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+```
+
+- [ ] **Step 6: Replace `resolve_proxy` and delete the memory-conflict path**
+
+In `wrap_claude`, replace:
+
+```rust
+    let want_memory = memory_flag || resolved.headroom_memory;
+    let decision = resolve_proxy(want_memory);
+```
+
+with:
+
+```rust
+    let want_memory = memory_flag || resolved.headroom_memory;
+    let spec = build_proxy_spec(&resolved, &hr_plan, want_memory);
+    let selected = select_proxy_port(&spec);
+    if let Some(port) = selected {
+        env::set_var(
+            "ANTHROPIC_BASE_URL",
+            format!("http://127.0.0.1:{port}"),
+        );
+    }
+    let proxy_ready = selected.is_some();
+    let wrap_memory = if proxy_ready { false } else { want_memory };
+```
+
+Then update the `build_claude_args(...)` call to pass `proxy_ready` and `wrap_memory` (replacing `decision.proxy_ready` / `decision.wrap_memory`).
+
+Delete these items entirely (and their now-orphaned helpers):
+- `struct ProxyDecision`
+- `fn resolve_proxy`
+- `fn start_detached_decision`
+- `fn resolve_memory_conflict`
+- `fn kill_proxy` — **move** its SIGTERM-by-pid logic into Task 7's uninstall path; delete from `wrapper.rs`.
+- `struct ProxyHealth`, `fn probe_proxy_health`, `fn parse_proxy_health`
+- the four `#[cfg(test)]` fns: `parse_proxy_health_reads_memory_and_pid`, `parse_proxy_health_defaults_memory_false_when_absent`, `parse_proxy_health_handles_missing_config`, `parse_proxy_health_rejects_garbage`
+- the old `fn start_proxy_detached_ready` (superseded by `spawn_proxy_ready`)
+
+Keep `probe_proxy()` (now delegating to `probe_port(ANCHOR_PORT)`) — it's still used by `check_proxy_starts`. Keep `PROXY_PORT`/`DEFAULT_PROXY`/`PROXY_HEALTH_URL` **only if** still referenced after edits; otherwise delete the unused consts (clippy will flag them). Update `set_proxy_env`'s doc/behavior note: it still seeds a default `ANTHROPIC_BASE_URL`, but the per-session override in `wrap_claude` now wins.
+
+`check_proxy_starts` / `smoke_start_proxy` continue to call `build_proxy_args(&port, ...)` and `headroom_env_plan()` unchanged (doctor still smoke-tests on a free port).
+
+- [ ] **Step 7: Update CLAUDE.md**
+
+In `CLAUDE.md`, update the **"Global Headroom memory root"** key-design-decision bullet to describe per-config keyed reuse. Replace the parenthetical about "a single shared process" with wording that states: whetstone now runs *one proxy per distinct resolved config*, keyed by a fingerprint in `~/.whetstone/proxies.json`; identical configs still share a proxy; port 8787 is a best-effort launch-order anchor for bare-`claude`/doctor; the global memory root is unchanged. Add a one-line note under the CLI/Architecture prose that the memory-conflict prompt was removed (memory on/off is now part of the fingerprint, so conflicting sessions get separate proxies).
+
+- [ ] **Step 8: Build, lint, and run the full test suite**
+
+Run: `cargo build && cargo test && cargo clippy`
+Expected: PASS; no clippy warnings; the four `parse_proxy_health` tests are gone; all registry + `build_proxy_spec` + `build_claude_args` tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/wrapper.rs CLAUDE.md
+git commit -m "feat(proxy): per-config proxy selection; drop memory-conflict prompt"
+```
+
+---
+
+### Task 7: `global uninstall` teardown
+
+**Files:**
+- Modify: `src/uninstall.rs`
+- Modify: `src/proxy_registry.rs` (add `kill_all` helper + test)
+
+**Interfaces:**
+- Consumes: `Registry`, `registry_path`.
+- Produces: `pub fn kill_all(reg: &Registry, kill: impl Fn(u32))` in `proxy_registry.rs`; `run_global` calls a new `remove_proxies()` in `uninstall.rs`.
+
+- [ ] **Step 1: Write the failing test (pure kill_all)**
+
+Add to `proxy_registry.rs` `mod tests`:
+
+```rust
+    #[test]
+    fn kill_all_signals_every_recorded_pid() {
+        let reg = Registry {
+            entries: vec![
+                ProxyEntry { fingerprint: "a".into(), port: 8787, pid: 11 },
+                ProxyEntry { fingerprint: "b".into(), port: 8801, pid: 22 },
+            ],
+        };
+        let killed = std::cell::RefCell::new(Vec::new());
+        kill_all(&reg, |pid| killed.borrow_mut().push(pid));
+        assert_eq!(*killed.borrow(), vec![11, 22]);
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test --lib kill_all_signals_every_recorded_pid`
+Expected: FAIL — `kill_all` undefined.
+
+- [ ] **Step 3: Implement `kill_all`**
+
+Add to `proxy_registry.rs`:
+
+```rust
+/// Signal every recorded proxy pid via the injected killer.
+pub fn kill_all(reg: &Registry, kill: impl Fn(u32)) {
+    for entry in &reg.entries {
+        kill(entry.pid);
+    }
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `cargo test --lib kill_all_signals_every_recorded_pid`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into `run_global`**
+
+In `src/uninstall.rs`, add a helper and call it from `run_global` (before the closing `ui::ok`):
+
+```rust
+fn remove_proxies() {
+    use crate::proxy_registry as reg;
+    let Some(path) = reg::registry_path() else { return };
+    let registry = reg::Registry::load(&path);
+    if registry.entries.is_empty() {
+        return;
+    }
+    ui::info("stopping whetstone-spawned Headroom proxies...");
+    reg::kill_all(&registry, |pid| {
+        let _ = std::process::Command::new("kill")
+            .arg(pid.to_string())
+            .status();
+    });
+    let _ = fs::remove_file(&path);
+    let _ = fs::remove_file(path.with_extension("lock"));
+    ui::ok("stopped registered proxies and removed the registry");
+}
+```
+
+Call `remove_proxies();` inside `run_global()` (e.g. right after `remove_bins();`). Confirm `fs` and `crate::proxy_registry` are in scope (add `use` if needed).
+
+- [ ] **Step 6: Build, lint, test**
+
+Run: `cargo build && cargo test && cargo clippy`
+Expected: PASS, no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/proxy_registry.rs src/uninstall.rs
+git commit -m "feat(proxy): kill registered proxies on global uninstall"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Fingerprint over exact spawn config, memory in fingerprint, MEMORY_DB_PATH excluded → Task 1 (+ `build_proxy_spec` Task 6).
+- Registry `~/.whetstone/proxies.json` → Task 2.
+- Lockfile-guarded critical section → Task 3, applied in Task 6 `select_proxy_port`.
+- Launch-order 8787 anchor → Task 4.
+- Prune-dead + reuse-or-spawn resolve → Task 5.
+- `resolve_proxy` rewrite, `ANTHROPIC_BASE_URL` override, `spawn_proxy_detached` port arg, delete memory-conflict prompt + `probe_proxy_health` parsing → Task 6.
+- CLAUDE.md design-decision update → Task 6 Step 7.
+- `global uninstall` kills registered proxies + removes registry → Task 7.
+- Known-limitation (orphaned live proxies not reaped): documented in spec, no task — intentional YAGNI.
+- doctor `:8787` fast-path unchanged: `probe_proxy()` retained delegating to `ANCHOR_PORT` (Task 6 Step 5); `HEADROOM_PORT` reserved key untouched (Global Constraints).
+
+**2. Placeholder scan:** No "TBD"/"add error handling"/"similar to Task N". One in-plan interface *correction* is called out explicitly (Task 5 `spawn` signature is `Fn(u16) -> Option<u32>`, authoritative over the struct-comment draft). All code steps carry real code.
+
+**3. Type consistency:**
+- `ProxySpec` fields identical in Tasks 1, 5, 6.
+- `spawn` closure is `Fn(u16) -> Option<u32>` in Task 5 impl, its tests, and Task 6's `select_proxy_port` (`spawn_proxy_ready(p, spec.memory) -> Option<u32>`). ✓
+- `ResolveDeps` fields (`probe`, `port_free`, `free_port`, `spawn`) match between Task 5 definition and Task 6 construction. ✓
+- `ProxyOutcome::{Reused, Spawned, Failed}` used identically in Tasks 5 and 6. ✓
+- `registry_path()`/`acquire_lock`/`ANCHOR_PORT`/`kill_all` signatures consistent across Tasks 2–7. ✓
+- `probe_port(u16) -> bool` and `free_port_is_bindable(u16) -> bool` introduced in Task 6 and used only there. ✓

--- a/docs/superpowers/specs/2026-08-23-per-config-proxy-design.md
+++ b/docs/superpowers/specs/2026-08-23-per-config-proxy-design.md
@@ -1,0 +1,261 @@
+# Per-Config Headroom Proxy Reuse — Design
+
+**Date:** 2026-08-23
+**Status:** Approved for planning
+
+## Goal
+
+Make the Headroom proxy whetstone selects for a session match *this
+project's* resolved Headroom config, instead of silently inheriting
+whatever config the first project to launch a proxy baked in. Projects
+whose proxy config is identical keep sharing one proxy; a project whose
+config diverges gets its own.
+
+## Background: the bug
+
+whetstone runs a Headroom proxy as a **persistent daemon**.
+`spawn_proxy_detached` (`src/wrapper.rs`) spawns `headroom proxy` with
+null stdio and forgets it; nothing kills it when Claude exits (only the
+memory-conflict path ever calls `kill_proxy`). Everything is pinned to a
+fixed port `8787` — `DEFAULT_PROXY`, `PROXY_PORT`, `PROXY_HEALTH_URL`,
+`build_proxy_args`, and every probe assume it.
+
+`resolve_proxy` probes `127.0.0.1:8787/health`. If *any* proxy answers
+(and its memory flag matches what this session wants), it reuses it by
+passing `--no-proxy` to `headroom wrap claude`. Only if nothing answers
+does it spawn one.
+
+Consequence: the **first project to ever launch headroom owns the proxy
+config**, and every subsequent project — sequential *or* concurrent —
+reuses it until the proxy dies or the box reboots. It is not a
+concurrency race; it is "first launcher wins, indefinitely."
+
+Everything the *proxy* reads is baked in by that first launcher and
+bleeds into later projects:
+
+- `ANTHROPIC_TARGET_API_URL` — a custom upstream. Project B's requests
+  flow through A's proxy → **A's upstream**.
+- `HEADROOM_SAVINGS_PROFILE` — compression aggressiveness.
+- `HEADROOM_CODE_AWARE_ENABLED` and any `headroom_env` passthrough key
+  (`HEADROOM_RPM`, `HEADROOM_LOG_MESSAGES`, …).
+- `HEADROOM_NO_MEMORY_TOOLS` / `HEADROOM_NO_MEMORY_CONTEXT` — if project A
+  is ICM and B is Skip, the wrong gating sticks.
+
+What does **not** bleed today: the memory on/off flag (the one thing
+`/health` reconciles, via `probe_proxy_health` + `resolve_memory_conflict`)
+and `HEADROOM_MEMORY_DB_PATH` (deliberately pinned to a global root, so it
+never diverges).
+
+The per-project settings machinery in `src/settings.rs` /
+`src/headroom_env.rs` exists precisely so projects *can* diverge (custom
+upstream, custom savings profile, raw `headroom_env`). The shared proxy
+quietly defeats that half of the feature. The gap is invisible until a
+project actually sets a divergent proxy-level config — then it is wrong,
+persistently.
+
+## Approach: per-config keyed reuse
+
+Two sessions share a proxy **iff they would spawn a byte-identical
+proxy.** whetstone computes a *fingerprint* over exactly the inputs that
+determine a spawned proxy's behavior, keeps a registry of the proxies it
+has spawned keyed by that fingerprint, reuses a live matching proxy when
+one exists, and otherwise spawns a new proxy on its own port and points
+this session at it.
+
+This was chosen over strict "one proxy per project directory" because
+per-project spawns N daemons even when 10 projects are identical, and
+collides head-on with the deliberately-global memory root. Per-config
+gives correctness with the minimum number of proxies.
+
+## The fingerprint
+
+`proxy_fingerprint` is a stable hash over the exact `(args, env)`
+whetstone would launch the proxy with:
+
+- `build_proxy_args` output — the `--savings-profile`, `--no-telemetry`,
+  `--memory` flags.
+- `HEADROOM_SAVINGS_PROFILE` (the resolved `required_savings_profile()`).
+- `HEADROOM_TELEMETRY` (on/off).
+- `ANTHROPIC_TARGET_API_URL` (resolved, if any).
+- The resolved `headroom_env_plan().apply` set, **excluding**
+  `HEADROOM_MEMORY_DB_PATH` (globally pinned; identical everywhere).
+
+Properties:
+
+- Deterministic: same resolved config → same fingerprint, independent of
+  launch order or which project spawned first.
+- Sensitive: any change to a proxy-affecting field yields a different
+  fingerprint; the memory flag flips it.
+- Future-proof: because it hashes the *would-be spawn command*, any new
+  proxy knob added later feeds the fingerprint automatically, so this
+  class of bug cannot silently reappear.
+
+Fold the memory flag into the fingerprint — it stops being a special case
+reconciled via `/health` and becomes just another input.
+
+## The registry
+
+A small JSON file `~/.whetstone/proxies.json`:
+
+```json
+[ { "fingerprint": "…", "port": 8801, "pid": 12345 } ]
+```
+
+- Guarded by a file lock (advisory `flock` on a sibling lockfile) around
+  the whole read → decide → spawn → write critical section, so two
+  concurrent launches of the same *new* fingerprint don't both allocate a
+  port and spawn.
+- Entries are pruned when found dead (see lifecycle).
+- Lives beside `~/.whetstone/settings.json`; created lazily.
+
+## Launch flow (replaces `resolve_proxy`)
+
+`resolve_proxy` / `start_detached_decision` / `resolve_memory_conflict`
+are replaced by:
+
+1. Compute the fingerprint from resolved settings (memory flag included).
+2. Acquire the registry lock.
+3. **Prune** dead entries: probe each registered port's `/health`; drop
+   any that don't answer.
+4. Live entry for this fingerprint?
+   - **Yes** → reuse: set `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`,
+     release the lock, and pass `--no-proxy` to `headroom wrap claude`.
+   - **No** → allocate a port (see below), spawn `headroom proxy` with
+     *this* config's args + env, wait for `/health` to answer within
+     `PROXY_READY_TIMEOUT`, record `{fingerprint, port, pid}` in the
+     registry, set `ANTHROPIC_BASE_URL` to that port.
+5. Release the lock.
+
+The `ProxyDecision` returned to `build_claude_args` collapses to a single
+`proxy_ready` bit: whetstone always owns the proxy (reused or freshly
+spawned) and always passes `--no-proxy`. The `wrap_memory` fallback path
+(letting `headroom wrap` bring up its own session-bound proxy) is only
+reached when a spawn fails to come up — same soft-fallback semantics as
+today.
+
+### Port allocation
+
+- The **default** fingerprint — what a project with no divergent
+  proxy-affecting settings resolves to — is pinned to port **8787**.
+- Any other fingerprint gets a port from `free_port()`.
+
+This preserves backward compatibility for the common case:
+
+- The shell-profile `export ANTHROPIC_BASE_URL=…:8787` (written by
+  `src/shell.rs` at setup) still points a bare, non-whetstone `claude`
+  launch at a live default-config proxy.
+- doctor's `:8787` fast-path (`check_proxy_starts` →
+  `ProxyStartCheck::AlreadyRunning`) still recognizes a running default
+  proxy as proof headroom starts.
+
+whetstone computes the default fingerprint deterministically (global
+settings only, empty project overrides) so "is this the default config?"
+is a pure comparison, not a launch-order heuristic.
+
+## `ANTHROPIC_BASE_URL` ownership change
+
+Today `set_proxy_env` sets `ANTHROPIC_BASE_URL` only when it is unset,
+deferring to the shell-profile export. Under this design whetstone
+**overrides** it to the port it selected for the session, because
+whetstone now owns proxy selection.
+
+This is safe: a user's deliberate custom *upstream* is expressed through
+`ANTHROPIC_TARGET_API_URL` (which feeds the fingerprint and is honored by
+the spawned proxy), **not** through `ANTHROPIC_BASE_URL`.
+`ANTHROPIC_BASE_URL` only ever names the local proxy endpoint, which is
+whetstone's to assign. The override applies to the `headroom wrap claude`
+exec env; whetstone does not rewrite the shell profile.
+
+## What this removes
+
+- **The memory-conflict prompt.** `resolve_memory_conflict` and its 3-way
+  "restart the proxy with memory / session-only / cancel" prompt, plus the
+  `kill_proxy` path it drives, exist *only* because there was one shared
+  proxy that might lack memory. With the memory flag in the fingerprint,
+  memory-on and memory-off are different fingerprints → different proxies.
+  A memory session that finds no memory-proxy simply spawns one; it never
+  kills or replaces a proxy other sessions may share. Delete the prompt,
+  the kill path, and the non-interactive memory-conflict warning.
+- **`probe_proxy_health` memory parsing.** Reuse is keyed on the registry,
+  not on parsing `config.memory` out of `/health`. A plain liveness probe
+  (`probe_proxy` against a specific port) is all the prune/reuse checks
+  need. `kill_proxy` may still be retained for `global uninstall` (below).
+
+## Lifecycle / reaping
+
+- **Prune-dead-on-launch:** every launch, while holding the lock, probes
+  each registry entry and drops dead ones. Keeps the file from
+  accumulating stale entries across reboots.
+- **Live proxies persist** (as today) so a divergent-config proxy stays
+  available for reuse across sessions.
+- **`global uninstall`** kills every registered proxy (by pid) and removes
+  the registry file, so teardown doesn't leave orphaned daemons.
+
+**Known limitation (deliberate YAGNI cut):** changing a project's config
+strands its old-fingerprint proxy — still alive, now unused — until the
+box reboots or `global uninstall` runs. Idle-reaping of live-but-orphaned
+proxies is out of scope for v1. Documented, not built.
+
+## doctor and reserved keys
+
+- doctor's `:8787` fast-path and its `free_port()` smoke test are
+  unchanged for v1: 8787 remains the default-config port, and the smoke
+  test already uses a throwaway free port. A future refinement could check
+  the current project's fingerprint-specific proxy; out of scope here.
+- `HEADROOM_PORT` stays reserved/denied in `headroom_env.rs`
+  (`RESERVED_DENY`). whetstone now allocates ports dynamically, so the
+  rationale ("whetstone owns the proxy port") is only more true. No change
+  beyond possibly refreshing the warning text.
+
+## Files touched
+
+- **new `src/proxy_registry.rs`** — `proxy_fingerprint`, the registry
+  struct, load/save, file lock, prune, and port allocation. Keeps the new
+  surface out of `wrapper.rs`.
+- **`src/wrapper.rs`** — rewrite `resolve_proxy` and the decision helpers
+  around the registry; delete `resolve_memory_conflict` and the memory
+  branch of `probe_proxy_health`; make `set_proxy_env` / launch set
+  `ANTHROPIC_BASE_URL` to the selected port; `spawn_proxy_detached` takes a
+  port argument.
+- **`src/headroom_env.rs`** — expose the resolved `apply` set (and the
+  proxy-arg/profile/telemetry inputs) in a form the fingerprint can hash.
+- **`src/uninstall.rs`** (or wherever `global uninstall` lives) — kill
+  registered proxies and remove the registry file.
+- **CLAUDE.md** — update the "Global Headroom memory root / single shared
+  proxy" design-decision note to describe per-config keyed reuse and the
+  8787 default anchor.
+
+## Testing approach
+
+Mostly pure, in `proxy_registry.rs`:
+
+- **Fingerprint stability:** identical resolved config → identical
+  fingerprint, regardless of ordering of the `apply` map.
+- **Fingerprint sensitivity:** changing the savings profile, the upstream
+  URL, a `headroom_env` key, or the memory flag each changes the
+  fingerprint; changing only `HEADROOM_MEMORY_DB_PATH` does not.
+- **Registry reuse:** a live matching entry is reused (no spawn); a stale
+  (dead-port) entry is pruned and a fresh proxy is allocated.
+- **Port pinning:** the default fingerprint maps to 8787; a divergent
+  fingerprint gets a distinct free port.
+- **Concurrency:** two allocations of the same new fingerprint serialize
+  on the lock — the second observes the first's registry entry and reuses
+  rather than double-spawning. (Tested at the registry API level with a
+  stubbed spawn.)
+- **Memory prompt gone:** a memory-wanting session with only a
+  non-memory proxy live spawns a *second* proxy instead of prompting.
+- **`ANTHROPIC_BASE_URL` override:** a non-default fingerprint sets
+  `ANTHROPIC_BASE_URL` to the allocated port even when the inherited env
+  already had `:8787`.
+
+Health-probe/spawn are injected behind a trait or fn pointer so the
+registry logic tests without a real headroom.
+
+## Out of scope
+
+- Strict one-proxy-per-directory isolation (rejected in favor of
+  per-config).
+- Idle-reaping of orphaned live proxies.
+- Per-project memory roots — the global `~/.headroom` memory root and its
+  consolidation behavior are unchanged.
+- Rewriting the shell-profile `ANTHROPIC_BASE_URL` export.

--- a/docs/superpowers/specs/2026-08-23-per-config-proxy-design.md
+++ b/docs/superpowers/specs/2026-08-23-per-config-proxy-design.md
@@ -133,24 +133,30 @@ spawned) and always passes `--no-proxy`. The `wrap_memory` fallback path
 reached when a spawn fails to come up — same soft-fallback semantics as
 today.
 
-### Port allocation
+### Port allocation (launch-order anchor)
 
-- The **default** fingerprint — what a project with no divergent
-  proxy-affecting settings resolves to — is pinned to port **8787**.
-- Any other fingerprint gets a port from `free_port()`.
+Port **8787** is the *anchor* port, assigned best-effort to whichever
+proxy whetstone spawns first:
 
-This preserves backward compatibility for the common case:
+- Spawning a new proxy: if 8787 is free and unclaimed by a live registry
+  entry, use 8787; otherwise take a port from `free_port()`.
+- Every fingerprint records its actual assigned port in the registry.
+
+Correctness never depends on which fingerprint holds 8787 — reuse is
+always fingerprint → recorded port. 8787's only job is the backward-compat
+conveniences, and they only need *a* live proxy there:
 
 - The shell-profile `export ANTHROPIC_BASE_URL=…:8787` (written by
   `src/shell.rs` at setup) still points a bare, non-whetstone `claude`
-  launch at a live default-config proxy.
+  launch at a live proxy.
 - doctor's `:8787` fast-path (`check_proxy_starts` →
-  `ProxyStartCheck::AlreadyRunning`) still recognizes a running default
-  proxy as proof headroom starts.
+  `ProxyStartCheck::AlreadyRunning`) still recognizes a running proxy as
+  proof headroom starts.
 
-whetstone computes the default fingerprint deterministically (global
-settings only, empty project overrides) so "is this the default config?"
-is a pure comparison, not a launch-order heuristic.
+(Planning refinement: an earlier draft pinned 8787 to "the default-config
+fingerprint," but the ICM-vs-Skip provider gating makes a single canonical
+"default config" ill-defined. The launch-order anchor reaches the same
+compat goals without computing one.)
 
 ## `ANTHROPIC_BASE_URL` ownership change
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod memory_consolidate;
 mod migrate;
 mod model_update;
 mod preflight;
+mod proxy_registry;
 mod release;
 mod rtk;
 mod settings;

--- a/src/proxy_registry.rs
+++ b/src/proxy_registry.rs
@@ -5,6 +5,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -123,18 +124,37 @@ impl Registry {
 
 /// Advisory lockfile guard. Holds an `O_EXCL`-created file for the duration of
 /// a registry critical section; removes it on drop.
+#[allow(dead_code)]
 pub struct LockGuard {
     path: PathBuf,
+    pid: u32,
 }
 
 impl Drop for LockGuard {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
+        // Only delete if the file contents match our PID (confirms we still own it).
+        let should_delete = std::fs::read_to_string(&self.path)
+            .ok()
+            .and_then(|contents| {
+                contents.trim().parse::<u32>().ok().and_then(|file_pid| {
+                    if file_pid == self.pid {
+                        Some(true)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .unwrap_or(false);
+
+        if should_delete {
+            let _ = std::fs::remove_file(&self.path);
+        }
     }
 }
 
 /// Acquire the registry lock, spinning until it's free or `timeout` elapses. A
 /// lockfile older than `stale_after` (a crashed holder) is stolen.
+#[allow(dead_code)]
 pub fn acquire_lock(
     path: &Path,
     timeout: Duration,
@@ -145,23 +165,35 @@ pub fn acquire_lock(
             .with_context(|| format!("creating {}", parent.display()))?;
     }
     let deadline = Instant::now() + timeout;
+    let pid = std::process::id();
     loop {
+        // Check deadline at the top of each iteration to honor timeout in all paths.
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out acquiring proxy registry lock at {}",
+                path.display()
+            );
+        }
+
         match std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .open(path)
         {
-            Ok(_) => return Ok(LockGuard { path: path.to_path_buf() }),
+            Ok(mut file) => {
+                // Write our PID to the lockfile for ownership verification.
+                let pid_str = pid.to_string();
+                file.write_all(pid_str.as_bytes())
+                    .with_context(|| format!("writing pid to lock {}", path.display()))?;
+                return Ok(LockGuard {
+                    path: path.to_path_buf(),
+                    pid,
+                });
+            }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 if lock_is_stale(path, stale_after) {
                     let _ = std::fs::remove_file(path);
                     continue;
-                }
-                if Instant::now() >= deadline {
-                    anyhow::bail!(
-                        "timed out acquiring proxy registry lock at {}",
-                        path.display()
-                    );
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
@@ -187,7 +219,6 @@ fn lock_is_stale(path: &Path, stale_after: Duration) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     #[test]
     fn load_missing_file_is_empty() {
@@ -305,5 +336,30 @@ mod tests {
             std::time::Duration::from_secs(0),
         );
         assert!(g.is_ok());
+    }
+
+    #[test]
+    fn guard_does_not_delete_foreign_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("proxies.lock");
+        let short = std::time::Duration::from_millis(200);
+        let stale = std::time::Duration::from_secs(60);
+
+        // Acquire a lock and get the guard.
+        let g = acquire_lock(&lock, short, stale).unwrap();
+        let our_pid = g.pid;
+
+        // Simulate another process stealing and recreating the lock with a different PID.
+        let other_pid = our_pid.wrapping_add(1);
+        std::fs::write(&lock, other_pid.to_string()).unwrap();
+
+        // Drop our guard; it should NOT delete the foreign lock.
+        drop(g);
+
+        // Verify the lockfile still exists.
+        assert!(lock.exists());
+        // Verify it contains the other PID, not our guard's.
+        let contents = std::fs::read_to_string(&lock).unwrap();
+        assert_eq!(contents, other_pid.to_string());
     }
 }

--- a/src/proxy_registry.rs
+++ b/src/proxy_registry.rs
@@ -12,7 +12,6 @@ use std::time::{Duration, Instant};
 /// Everything that varies a spawned Headroom proxy's behavior. Two specs with
 /// the same fingerprint may share one proxy.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub struct ProxySpec {
     /// Resolved `HEADROOM_SAVINGS_PROFILE`.
     pub savings_profile: String,
@@ -26,7 +25,6 @@ pub struct ProxySpec {
     pub env: BTreeMap<String, String>,
 }
 
-#[allow(dead_code)]
 fn canonical(spec: &ProxySpec) -> String {
     let mut s = String::new();
     s.push_str("sp=");
@@ -51,7 +49,6 @@ fn canonical(spec: &ProxySpec) -> String {
     s
 }
 
-#[allow(dead_code)]
 fn fnv1a(bytes: &[u8]) -> u64 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for b in bytes {
@@ -62,7 +59,6 @@ fn fnv1a(bytes: &[u8]) -> u64 {
 }
 
 /// FNV-1a 64-bit over a canonical rendering of the spec.
-#[allow(dead_code)]
 pub fn proxy_fingerprint(spec: &ProxySpec) -> String {
     format!("{:016x}", fnv1a(canonical(spec).as_bytes()))
 }
@@ -81,14 +77,12 @@ pub struct ProxyEntry {
 /// The set of live whetstone-spawned proxies. Persisted to
 /// `~/.whetstone/proxies.json`.
 #[derive(Debug, Default, Serialize, Deserialize)]
-#[allow(dead_code)]
 pub struct Registry {
     #[serde(default)]
     pub entries: Vec<ProxyEntry>,
 }
 
 /// `~/.whetstone/proxies.json`, or `None` if the home dir can't be found.
-#[allow(dead_code)]
 pub fn registry_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(GLOBAL_DIR).join(REGISTRY_FILENAME))
 }
@@ -96,7 +90,6 @@ pub fn registry_path() -> Option<PathBuf> {
 impl Registry {
     /// Load the registry, treating a missing or corrupt file as empty — a
     /// stale registry must never block a launch.
-    #[allow(dead_code)]
     pub fn load(path: &Path) -> Self {
         let Ok(raw) = std::fs::read_to_string(path) else {
             return Self::default();
@@ -104,7 +97,6 @@ impl Registry {
         serde_json::from_str(&raw).unwrap_or_default()
     }
 
-    #[allow(dead_code)]
     pub fn save(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
@@ -116,7 +108,6 @@ impl Registry {
             .with_context(|| format!("writing {}", path.display()))
     }
 
-    #[allow(dead_code)]
     pub fn find(&self, fingerprint: &str) -> Option<&ProxyEntry> {
         self.entries.iter().find(|e| e.fingerprint == fingerprint)
     }
@@ -124,7 +115,6 @@ impl Registry {
 
 /// Advisory lockfile guard. Holds an `O_EXCL`-created file for the duration of
 /// a registry critical section; removes it on drop.
-#[allow(dead_code)]
 pub struct LockGuard {
     path: PathBuf,
     pid: u32,
@@ -154,7 +144,6 @@ impl Drop for LockGuard {
 
 /// Acquire the registry lock, spinning until it's free or `timeout` elapses. A
 /// lockfile older than `stale_after` (a crashed holder) is stolen.
-#[allow(dead_code)]
 pub fn acquire_lock(
     path: &Path,
     timeout: Duration,
@@ -223,12 +212,10 @@ fn lock_is_stale(path: &Path, stale_after: Duration) -> bool {
 /// Backward-compat anchor port. Assigned best-effort to the first proxy
 /// whetstone spawns so a bare `claude` launch and doctor's fast-path still
 /// find a proxy at `127.0.0.1:8787`.
-#[allow(dead_code)]
 pub const ANCHOR_PORT: u16 = 8787;
 
 /// Pick a port for a new proxy: the anchor when it's free and unclaimed,
 /// otherwise a fresh OS-assigned free port.
-#[allow(dead_code)]
 pub fn choose_port(
     reg: &Registry,
     port_free: impl Fn(u16) -> bool,
@@ -267,15 +254,23 @@ pub struct ResolveDeps<'a> {
 
 /// Prune dead entries, reuse a live matching proxy, or spawn a new one.
 /// Mutates `reg`; the caller persists it under the lock.
-#[allow(dead_code)]
 pub fn resolve(
     reg: &mut Registry,
     spec: &ProxySpec,
     deps: &ResolveDeps,
 ) -> ProxyOutcome {
-    reg.entries.retain(|e| (deps.probe)(e.port));
-
     let fingerprint = proxy_fingerprint(spec);
+    // Give the entry matching our config a second-chance probe before pruning:
+    // a live-but-transiently-busy proxy must not be dropped and duplicate-spawned.
+    let matched_port = reg.find(&fingerprint).map(|e| e.port);
+    reg.entries.retain(|e| {
+        if Some(e.port) == matched_port {
+            (deps.probe)(e.port) || (deps.probe)(e.port)
+        } else {
+            (deps.probe)(e.port)
+        }
+    });
+
     if let Some(entry) = reg.find(&fingerprint) {
         return ProxyOutcome::Reused(entry.port);
     }
@@ -520,6 +515,39 @@ mod tests {
         let outcome = resolve(&mut reg, &spec, &deps);
         assert_eq!(outcome, ProxyOutcome::Reused(8801));
         assert_eq!(reg.entries.len(), 1);
+    }
+
+    #[test]
+    fn resolve_reuses_transiently_busy_matching_proxy() {
+        let spec = base();
+        let fp = proxy_fingerprint(&spec);
+        let mut reg = Registry {
+            entries: vec![ProxyEntry {
+                fingerprint: fp,
+                port: 8801,
+                pid: 7,
+            }],
+        };
+
+        // First probe of the matching port says dead; second says alive.
+        // Must still be reused, not pruned + duplicate-spawned.
+        let call_count = std::cell::Cell::new(0u32);
+        let probe = |_p: u16| {
+            let n = call_count.get();
+            call_count.set(n + 1);
+            n >= 1 // false on the first call, true from then on
+        };
+        let port_free = |_p: u16| true;
+        let free_port = || Some(9100u16);
+        let spawn = |_p: u16| -> Option<u32> {
+            panic!("must not spawn a duplicate for a transiently-busy match")
+        };
+        let deps = deps_from(&probe, &port_free, &free_port, &spawn);
+
+        let outcome = resolve(&mut reg, &spec, &deps);
+        assert_eq!(outcome, ProxyOutcome::Reused(8801));
+        assert_eq!(reg.entries.len(), 1);
+        assert_eq!(call_count.get(), 2);
     }
 
     #[test]

--- a/src/proxy_registry.rs
+++ b/src/proxy_registry.rs
@@ -1,0 +1,123 @@
+//! Per-config Headroom proxy registry: fingerprint the exact proxy config a
+//! session would spawn, so two sessions share a proxy iff they would spawn a
+//! byte-identical one. Keyed reuse via `~/.whetstone/proxies.json`.
+
+use std::collections::BTreeMap;
+
+/// Everything that varies a spawned Headroom proxy's behavior. Two specs with
+/// the same fingerprint may share one proxy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct ProxySpec {
+    /// Resolved `HEADROOM_SAVINGS_PROFILE`.
+    pub savings_profile: String,
+    /// Whether telemetry is enabled (drives `--no-telemetry` / env).
+    pub telemetry: bool,
+    /// Whether the proxy is started with `--memory`.
+    pub memory: bool,
+    /// Resolved `ANTHROPIC_TARGET_API_URL`, if any.
+    pub anthropic_api_url: Option<String>,
+    /// The `HEADROOM_*` apply set, EXCLUDING `HEADROOM_MEMORY_DB_PATH`.
+    pub env: BTreeMap<String, String>,
+}
+
+#[allow(dead_code)]
+fn canonical(spec: &ProxySpec) -> String {
+    let mut s = String::new();
+    s.push_str("sp=");
+    s.push_str(&spec.savings_profile);
+    s.push('\n');
+    s.push_str("tel=");
+    s.push(if spec.telemetry { '1' } else { '0' });
+    s.push('\n');
+    s.push_str("mem=");
+    s.push(if spec.memory { '1' } else { '0' });
+    s.push('\n');
+    s.push_str("url=");
+    s.push_str(spec.anthropic_api_url.as_deref().unwrap_or(""));
+    s.push('\n');
+    for (k, v) in &spec.env {
+        s.push_str("e:");
+        s.push_str(k);
+        s.push('=');
+        s.push_str(v);
+        s.push('\n');
+    }
+    s
+}
+
+#[allow(dead_code)]
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// FNV-1a 64-bit over a canonical rendering of the spec.
+#[allow(dead_code)]
+pub fn proxy_fingerprint(spec: &ProxySpec) -> String {
+    format!("{:016x}", fnv1a(canonical(spec).as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> ProxySpec {
+        ProxySpec {
+            savings_profile: "agent-90".into(),
+            telemetry: false,
+            memory: false,
+            anthropic_api_url: None,
+            env: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_stable_and_16_hex() {
+        let fp = proxy_fingerprint(&base());
+        assert_eq!(fp.len(), 16);
+        assert!(fp.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(fp, proxy_fingerprint(&base()));
+    }
+
+    #[test]
+    fn fingerprint_is_order_independent_for_env() {
+        let mut a = base();
+        a.env.insert("HEADROOM_RPM".into(), "1".into());
+        a.env.insert("HEADROOM_CODE_AWARE_ENABLED".into(), "1".into());
+        // BTreeMap canonicalizes order; inserting in the other order matches.
+        let mut b = base();
+        b.env.insert("HEADROOM_CODE_AWARE_ENABLED".into(), "1".into());
+        b.env.insert("HEADROOM_RPM".into(), "1".into());
+        assert_eq!(proxy_fingerprint(&a), proxy_fingerprint(&b));
+    }
+
+    #[test]
+    fn each_field_changes_the_fingerprint() {
+        let f0 = proxy_fingerprint(&base());
+
+        let mut sp = base();
+        sp.savings_profile = "agent-50".into();
+        assert_ne!(f0, proxy_fingerprint(&sp));
+
+        let mut tel = base();
+        tel.telemetry = true;
+        assert_ne!(f0, proxy_fingerprint(&tel));
+
+        let mut mem = base();
+        mem.memory = true;
+        assert_ne!(f0, proxy_fingerprint(&mem));
+
+        let mut url = base();
+        url.anthropic_api_url = Some("https://example.test".into());
+        assert_ne!(f0, proxy_fingerprint(&url));
+
+        let mut env = base();
+        env.env.insert("HEADROOM_RPM".into(), "120".into());
+        assert_ne!(f0, proxy_fingerprint(&env));
+    }
+}

--- a/src/proxy_registry.rs
+++ b/src/proxy_registry.rs
@@ -216,6 +216,27 @@ fn lock_is_stale(path: &Path, stale_after: Duration) -> bool {
     modified.elapsed().map(|age| age >= stale_after).unwrap_or(false)
 }
 
+/// Backward-compat anchor port. Assigned best-effort to the first proxy
+/// whetstone spawns so a bare `claude` launch and doctor's fast-path still
+/// find a proxy at `127.0.0.1:8787`.
+#[allow(dead_code)]
+pub const ANCHOR_PORT: u16 = 8787;
+
+/// Pick a port for a new proxy: the anchor when it's free and unclaimed,
+/// otherwise a fresh OS-assigned free port.
+#[allow(dead_code)]
+pub fn choose_port(
+    reg: &Registry,
+    port_free: impl Fn(u16) -> bool,
+    free_port: impl Fn() -> Option<u16>,
+) -> Option<u16> {
+    let anchor_claimed = reg.entries.iter().any(|e| e.port == ANCHOR_PORT);
+    if !anchor_claimed && port_free(ANCHOR_PORT) {
+        return Some(ANCHOR_PORT);
+    }
+    free_port()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -361,5 +382,31 @@ mod tests {
         // Verify it contains the other PID, not our guard's.
         let contents = std::fs::read_to_string(&lock).unwrap();
         assert_eq!(contents, other_pid.to_string());
+    }
+
+    fn entry(fp: &str, port: u16) -> ProxyEntry {
+        ProxyEntry { fingerprint: fp.into(), port, pid: 1 }
+    }
+
+    #[test]
+    fn choose_port_prefers_anchor_when_free_and_unclaimed() {
+        let reg = Registry::default();
+        let port = choose_port(&reg, |_| true, || Some(9001));
+        assert_eq!(port, Some(ANCHOR_PORT));
+    }
+
+    #[test]
+    fn choose_port_skips_anchor_when_claimed_by_a_live_entry() {
+        let reg = Registry { entries: vec![entry("x", ANCHOR_PORT)] };
+        let port = choose_port(&reg, |_| true, || Some(9002));
+        assert_eq!(port, Some(9002));
+    }
+
+    #[test]
+    fn choose_port_skips_anchor_when_port_busy() {
+        let reg = Registry::default();
+        // Anchor reported busy by the OS even though no entry claims it.
+        let port = choose_port(&reg, |p| p != ANCHOR_PORT, || Some(9003));
+        assert_eq!(port, Some(9003));
     }
 }

--- a/src/proxy_registry.rs
+++ b/src/proxy_registry.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 /// Everything that varies a spawned Headroom proxy's behavior. Two specs with
 /// the same fingerprint may share one proxy.
@@ -120,9 +121,73 @@ impl Registry {
     }
 }
 
+/// Advisory lockfile guard. Holds an `O_EXCL`-created file for the duration of
+/// a registry critical section; removes it on drop.
+pub struct LockGuard {
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Acquire the registry lock, spinning until it's free or `timeout` elapses. A
+/// lockfile older than `stale_after` (a crashed holder) is stolen.
+pub fn acquire_lock(
+    path: &Path,
+    timeout: Duration,
+    stale_after: Duration,
+) -> Result<LockGuard> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let deadline = Instant::now() + timeout;
+    loop {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+        {
+            Ok(_) => return Ok(LockGuard { path: path.to_path_buf() }),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if lock_is_stale(path, stale_after) {
+                    let _ = std::fs::remove_file(path);
+                    continue;
+                }
+                if Instant::now() >= deadline {
+                    anyhow::bail!(
+                        "timed out acquiring proxy registry lock at {}",
+                        path.display()
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("opening lock {}", path.display())
+                })
+            }
+        }
+    }
+}
+
+fn lock_is_stale(path: &Path, stale_after: Duration) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    modified.elapsed().map(|age| age >= stale_after).unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn load_missing_file_is_empty() {
@@ -211,5 +276,34 @@ mod tests {
         let mut env = base();
         env.env.insert("HEADROOM_RPM".into(), "120".into());
         assert_ne!(f0, proxy_fingerprint(&env));
+    }
+
+    #[test]
+    fn lock_is_exclusive_then_released_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("proxies.lock");
+        let short = std::time::Duration::from_millis(200);
+        let stale = std::time::Duration::from_secs(60);
+
+        let g = acquire_lock(&lock, short, stale).unwrap();
+        // Second acquisition times out while the first is held.
+        assert!(acquire_lock(&lock, short, stale).is_err());
+        drop(g);
+        // After release, it succeeds again.
+        assert!(acquire_lock(&lock, short, stale).is_ok());
+    }
+
+    #[test]
+    fn stale_lock_is_stolen() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("proxies.lock");
+        std::fs::write(&lock, "old").unwrap();
+        // stale_after = 0 → any existing lock is immediately stealable.
+        let g = acquire_lock(
+            &lock,
+            std::time::Duration::from_millis(200),
+            std::time::Duration::from_secs(0),
+        );
+        assert!(g.is_ok());
     }
 }

--- a/src/proxy_registry.rs
+++ b/src/proxy_registry.rs
@@ -296,6 +296,13 @@ pub fn resolve(
     }
 }
 
+/// Signal every recorded proxy pid via the injected killer.
+pub fn kill_all(reg: &Registry, kill: impl Fn(u32)) {
+    for entry in &reg.entries {
+        kill(entry.pid);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -583,5 +590,26 @@ mod tests {
 
         assert_eq!(resolve(&mut reg, &spec, &deps), ProxyOutcome::Failed);
         assert!(reg.find(&proxy_fingerprint(&spec)).is_none());
+    }
+
+    #[test]
+    fn kill_all_signals_every_recorded_pid() {
+        let reg = Registry {
+            entries: vec![
+                ProxyEntry {
+                    fingerprint: "a".into(),
+                    port: 8787,
+                    pid: 11,
+                },
+                ProxyEntry {
+                    fingerprint: "b".into(),
+                    port: 8801,
+                    pid: 22,
+                },
+            ],
+        };
+        let killed = std::cell::RefCell::new(Vec::new());
+        kill_all(&reg, |pid| killed.borrow_mut().push(pid));
+        assert_eq!(*killed.borrow(), vec![11, 22]);
     }
 }

--- a/src/proxy_registry.rs
+++ b/src/proxy_registry.rs
@@ -183,8 +183,9 @@ pub fn acquire_lock(
             Ok(mut file) => {
                 // Write our PID to the lockfile for ownership verification.
                 let pid_str = pid.to_string();
-                file.write_all(pid_str.as_bytes())
-                    .with_context(|| format!("writing pid to lock {}", path.display()))?;
+                file.write_all(pid_str.as_bytes()).with_context(|| {
+                    format!("writing pid to lock {}", path.display())
+                })?;
                 return Ok(LockGuard {
                     path: path.to_path_buf(),
                     pid,
@@ -213,7 +214,10 @@ fn lock_is_stale(path: &Path, stale_after: Duration) -> bool {
     let Ok(modified) = meta.modified() else {
         return false;
     };
-    modified.elapsed().map(|age| age >= stale_after).unwrap_or(false)
+    modified
+        .elapsed()
+        .map(|age| age >= stale_after)
+        .unwrap_or(false)
 }
 
 /// Backward-compat anchor port. Assigned best-effort to the first proxy
@@ -281,7 +285,11 @@ pub fn resolve(
     };
     match (deps.spawn)(port) {
         Some(pid) => {
-            reg.entries.push(ProxyEntry { fingerprint, port, pid });
+            reg.entries.push(ProxyEntry {
+                fingerprint,
+                port,
+                pid,
+            });
             ProxyOutcome::Spawned(port)
         }
         None => ProxyOutcome::Failed,
@@ -348,10 +356,12 @@ mod tests {
     fn fingerprint_is_order_independent_for_env() {
         let mut a = base();
         a.env.insert("HEADROOM_RPM".into(), "1".into());
-        a.env.insert("HEADROOM_CODE_AWARE_ENABLED".into(), "1".into());
+        a.env
+            .insert("HEADROOM_CODE_AWARE_ENABLED".into(), "1".into());
         // BTreeMap canonicalizes order; inserting in the other order matches.
         let mut b = base();
-        b.env.insert("HEADROOM_CODE_AWARE_ENABLED".into(), "1".into());
+        b.env
+            .insert("HEADROOM_CODE_AWARE_ENABLED".into(), "1".into());
         b.env.insert("HEADROOM_RPM".into(), "1".into());
         assert_eq!(proxy_fingerprint(&a), proxy_fingerprint(&b));
     }
@@ -436,7 +446,11 @@ mod tests {
     }
 
     fn entry(fp: &str, port: u16) -> ProxyEntry {
-        ProxyEntry { fingerprint: fp.into(), port, pid: 1 }
+        ProxyEntry {
+            fingerprint: fp.into(),
+            port,
+            pid: 1,
+        }
     }
 
     #[test]
@@ -448,7 +462,9 @@ mod tests {
 
     #[test]
     fn choose_port_skips_anchor_when_claimed_by_a_live_entry() {
-        let reg = Registry { entries: vec![entry("x", ANCHOR_PORT)] };
+        let reg = Registry {
+            entries: vec![entry("x", ANCHOR_PORT)],
+        };
         let port = choose_port(&reg, |_| true, || Some(9002));
         assert_eq!(port, Some(9002));
     }
@@ -461,31 +477,37 @@ mod tests {
         assert_eq!(port, Some(9003));
     }
 
-    struct Stub {
-        alive: std::cell::RefCell<Vec<u16>>, // ports that answer /health
-        spawned: std::cell::RefCell<Vec<u16>>,
-        next_free: u16,
-    }
-
     fn deps_from<'a>(
         probe: &'a dyn Fn(u16) -> bool,
         port_free: &'a dyn Fn(u16) -> bool,
         free_port: &'a dyn Fn() -> Option<u16>,
         spawn: &'a dyn Fn(u16) -> Option<u32>,
     ) -> ResolveDeps<'a> {
-        ResolveDeps { probe, port_free, free_port, spawn }
+        ResolveDeps {
+            probe,
+            port_free,
+            free_port,
+            spawn,
+        }
     }
 
     #[test]
     fn resolve_reuses_a_live_matching_proxy() {
         let spec = base();
         let fp = proxy_fingerprint(&spec);
-        let mut reg = Registry { entries: vec![ProxyEntry { fingerprint: fp, port: 8801, pid: 7 }] };
+        let mut reg = Registry {
+            entries: vec![ProxyEntry {
+                fingerprint: fp,
+                port: 8801,
+                pid: 7,
+            }],
+        };
 
         let probe = |_p: u16| true; // 8801 answers
         let port_free = |_p: u16| true;
         let free_port = || Some(9100u16);
-        let spawn = |_p: u16| -> Option<u32> { panic!("must not spawn on reuse") };
+        let spawn =
+            |_p: u16| -> Option<u32> { panic!("must not spawn on reuse") };
         let deps = deps_from(&probe, &port_free, &free_port, &spawn);
 
         let outcome = resolve(&mut reg, &spec, &deps);
@@ -497,20 +519,32 @@ mod tests {
     fn resolve_prunes_dead_entry_and_spawns() {
         let spec = base();
         let fp = proxy_fingerprint(&spec);
-        let mut reg = Registry { entries: vec![ProxyEntry { fingerprint: fp.clone(), port: 8801, pid: 7 }] };
+        let mut reg = Registry {
+            entries: vec![ProxyEntry {
+                fingerprint: fp.clone(),
+                port: 8801,
+                pid: 7,
+            }],
+        };
 
         let probe = |_p: u16| false; // nothing answers → 8801 is dead
         let port_free = |_p: u16| true;
         let free_port = || Some(9100u16);
         let spawned: std::cell::Cell<Option<u16>> = std::cell::Cell::new(None);
-        let spawn = |p: u16| -> Option<u32> { spawned.set(Some(p)); Some(555) };
+        let spawn = |p: u16| -> Option<u32> {
+            spawned.set(Some(p));
+            Some(555)
+        };
         let deps = deps_from(&probe, &port_free, &free_port, &spawn);
 
         let outcome = resolve(&mut reg, &spec, &deps);
         // Dead 8801 pruned; anchor free & unclaimed → spawns on 8787.
         assert_eq!(outcome, ProxyOutcome::Spawned(ANCHOR_PORT));
         assert_eq!(spawned.get(), Some(ANCHOR_PORT));
-        assert_eq!(reg.find(&fp).map(|e| (e.port, e.pid)), Some((ANCHOR_PORT, 555)));
+        assert_eq!(
+            reg.find(&fp).map(|e| (e.port, e.pid)),
+            Some((ANCHOR_PORT, 555))
+        );
     }
 
     #[test]
@@ -518,7 +552,13 @@ mod tests {
         let spec = base();
         let fp = proxy_fingerprint(&spec);
         // A different fingerprint holds a live anchor.
-        let mut reg = Registry { entries: vec![ProxyEntry { fingerprint: "other".into(), port: ANCHOR_PORT, pid: 1 }] };
+        let mut reg = Registry {
+            entries: vec![ProxyEntry {
+                fingerprint: "other".into(),
+                port: ANCHOR_PORT,
+                pid: 1,
+            }],
+        };
 
         let probe = |_p: u16| true; // anchor's holder is alive
         let port_free = |_p: u16| true;

--- a/src/proxy_registry.rs
+++ b/src/proxy_registry.rs
@@ -2,7 +2,10 @@
 //! session would spawn, so two sessions share a proxy iff they would spawn a
 //! byte-identical one. Keyed reuse via `~/.whetstone/proxies.json`.
 
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 /// Everything that varies a spawned Headroom proxy's behavior. Two specs with
 /// the same fingerprint may share one proxy.
@@ -62,9 +65,98 @@ pub fn proxy_fingerprint(spec: &ProxySpec) -> String {
     format!("{:016x}", fnv1a(canonical(spec).as_bytes()))
 }
 
+const GLOBAL_DIR: &str = ".whetstone";
+const REGISTRY_FILENAME: &str = "proxies.json";
+
+/// One whetstone-spawned proxy: its config fingerprint, bound port, and pid.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProxyEntry {
+    pub fingerprint: String,
+    pub port: u16,
+    pub pid: u32,
+}
+
+/// The set of live whetstone-spawned proxies. Persisted to
+/// `~/.whetstone/proxies.json`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct Registry {
+    #[serde(default)]
+    pub entries: Vec<ProxyEntry>,
+}
+
+/// `~/.whetstone/proxies.json`, or `None` if the home dir can't be found.
+#[allow(dead_code)]
+pub fn registry_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(GLOBAL_DIR).join(REGISTRY_FILENAME))
+}
+
+impl Registry {
+    /// Load the registry, treating a missing or corrupt file as empty — a
+    /// stale registry must never block a launch.
+    #[allow(dead_code)]
+    pub fn load(path: &Path) -> Self {
+        let Ok(raw) = std::fs::read_to_string(path) else {
+            return Self::default();
+        };
+        serde_json::from_str(&raw).unwrap_or_default()
+    }
+
+    #[allow(dead_code)]
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let pretty = serde_json::to_string_pretty(self)
+            .context("serializing proxy registry")?;
+        std::fs::write(path, pretty)
+            .with_context(|| format!("writing {}", path.display()))
+    }
+
+    #[allow(dead_code)]
+    pub fn find(&self, fingerprint: &str) -> Option<&ProxyEntry> {
+        self.entries.iter().find(|e| e.fingerprint == fingerprint)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn load_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("proxies.json");
+        let reg = Registry::load(&path);
+        assert!(reg.entries.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("proxies.json");
+        let reg = Registry {
+            entries: vec![ProxyEntry {
+                fingerprint: "abc123".into(),
+                port: 8801,
+                pid: 4242,
+            }],
+        };
+        reg.save(&path).unwrap();
+        let back = Registry::load(&path);
+        assert_eq!(back.entries, reg.entries);
+        assert_eq!(back.find("abc123").map(|e| e.port), Some(8801));
+        assert!(back.find("nope").is_none());
+    }
+
+    #[test]
+    fn load_corrupt_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("proxies.json");
+        std::fs::write(&path, "not json").unwrap();
+        assert!(Registry::load(&path).entries.is_empty());
+    }
 
     fn base() -> ProxySpec {
         ProxySpec {

--- a/src/proxy_registry.rs
+++ b/src/proxy_registry.rs
@@ -237,6 +237,57 @@ pub fn choose_port(
     free_port()
 }
 
+/// The result of resolving a launch to a proxy port.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ProxyOutcome {
+    /// An already-running proxy matched the fingerprint.
+    Reused(u16),
+    /// A fresh proxy was spawned on this port.
+    Spawned(u16),
+    /// No proxy could be brought up; caller should soft-fall-back.
+    Failed,
+}
+
+/// Injected side effects so `resolve` is unit-testable without a real proxy.
+pub struct ResolveDeps<'a> {
+    /// Does a proxy answer `/health` on this port?
+    pub probe: &'a dyn Fn(u16) -> bool,
+    /// Can we bind this port right now?
+    pub port_free: &'a dyn Fn(u16) -> bool,
+    /// Ask the OS for an unused port.
+    pub free_port: &'a dyn Fn() -> Option<u16>,
+    /// Spawn a proxy for the current spec on this port; return its pid when it
+    /// comes up ready, else `None`.
+    pub spawn: &'a dyn Fn(u16) -> Option<u32>,
+}
+
+/// Prune dead entries, reuse a live matching proxy, or spawn a new one.
+/// Mutates `reg`; the caller persists it under the lock.
+#[allow(dead_code)]
+pub fn resolve(
+    reg: &mut Registry,
+    spec: &ProxySpec,
+    deps: &ResolveDeps,
+) -> ProxyOutcome {
+    reg.entries.retain(|e| (deps.probe)(e.port));
+
+    let fingerprint = proxy_fingerprint(spec);
+    if let Some(entry) = reg.find(&fingerprint) {
+        return ProxyOutcome::Reused(entry.port);
+    }
+
+    let Some(port) = choose_port(reg, deps.port_free, deps.free_port) else {
+        return ProxyOutcome::Failed;
+    };
+    match (deps.spawn)(port) {
+        Some(pid) => {
+            reg.entries.push(ProxyEntry { fingerprint, port, pid });
+            ProxyOutcome::Spawned(port)
+        }
+        None => ProxyOutcome::Failed,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -408,5 +459,89 @@ mod tests {
         // Anchor reported busy by the OS even though no entry claims it.
         let port = choose_port(&reg, |p| p != ANCHOR_PORT, || Some(9003));
         assert_eq!(port, Some(9003));
+    }
+
+    struct Stub {
+        alive: std::cell::RefCell<Vec<u16>>, // ports that answer /health
+        spawned: std::cell::RefCell<Vec<u16>>,
+        next_free: u16,
+    }
+
+    fn deps_from<'a>(
+        probe: &'a dyn Fn(u16) -> bool,
+        port_free: &'a dyn Fn(u16) -> bool,
+        free_port: &'a dyn Fn() -> Option<u16>,
+        spawn: &'a dyn Fn(u16) -> Option<u32>,
+    ) -> ResolveDeps<'a> {
+        ResolveDeps { probe, port_free, free_port, spawn }
+    }
+
+    #[test]
+    fn resolve_reuses_a_live_matching_proxy() {
+        let spec = base();
+        let fp = proxy_fingerprint(&spec);
+        let mut reg = Registry { entries: vec![ProxyEntry { fingerprint: fp, port: 8801, pid: 7 }] };
+
+        let probe = |_p: u16| true; // 8801 answers
+        let port_free = |_p: u16| true;
+        let free_port = || Some(9100u16);
+        let spawn = |_p: u16| -> Option<u32> { panic!("must not spawn on reuse") };
+        let deps = deps_from(&probe, &port_free, &free_port, &spawn);
+
+        let outcome = resolve(&mut reg, &spec, &deps);
+        assert_eq!(outcome, ProxyOutcome::Reused(8801));
+        assert_eq!(reg.entries.len(), 1);
+    }
+
+    #[test]
+    fn resolve_prunes_dead_entry_and_spawns() {
+        let spec = base();
+        let fp = proxy_fingerprint(&spec);
+        let mut reg = Registry { entries: vec![ProxyEntry { fingerprint: fp.clone(), port: 8801, pid: 7 }] };
+
+        let probe = |_p: u16| false; // nothing answers → 8801 is dead
+        let port_free = |_p: u16| true;
+        let free_port = || Some(9100u16);
+        let spawned: std::cell::Cell<Option<u16>> = std::cell::Cell::new(None);
+        let spawn = |p: u16| -> Option<u32> { spawned.set(Some(p)); Some(555) };
+        let deps = deps_from(&probe, &port_free, &free_port, &spawn);
+
+        let outcome = resolve(&mut reg, &spec, &deps);
+        // Dead 8801 pruned; anchor free & unclaimed → spawns on 8787.
+        assert_eq!(outcome, ProxyOutcome::Spawned(ANCHOR_PORT));
+        assert_eq!(spawned.get(), Some(ANCHOR_PORT));
+        assert_eq!(reg.find(&fp).map(|e| (e.port, e.pid)), Some((ANCHOR_PORT, 555)));
+    }
+
+    #[test]
+    fn resolve_spawns_new_port_when_anchor_taken() {
+        let spec = base();
+        let fp = proxy_fingerprint(&spec);
+        // A different fingerprint holds a live anchor.
+        let mut reg = Registry { entries: vec![ProxyEntry { fingerprint: "other".into(), port: ANCHOR_PORT, pid: 1 }] };
+
+        let probe = |_p: u16| true; // anchor's holder is alive
+        let port_free = |_p: u16| true;
+        let free_port = || Some(9100u16);
+        let spawn = |_p: u16| -> Option<u32> { Some(556) };
+        let deps = deps_from(&probe, &port_free, &free_port, &spawn);
+
+        let outcome = resolve(&mut reg, &spec, &deps);
+        assert_eq!(outcome, ProxyOutcome::Spawned(9100));
+        assert_eq!(reg.find(&fp).map(|e| e.port), Some(9100));
+    }
+
+    #[test]
+    fn resolve_reports_failed_when_spawn_fails() {
+        let spec = base();
+        let mut reg = Registry::default();
+        let probe = |_p: u16| false;
+        let port_free = |_p: u16| true;
+        let free_port = || Some(9100u16);
+        let spawn = |_p: u16| -> Option<u32> { None };
+        let deps = deps_from(&probe, &port_free, &free_port, &spawn);
+
+        assert_eq!(resolve(&mut reg, &spec, &deps), ProxyOutcome::Failed);
+        assert!(reg.find(&proxy_fingerprint(&spec)).is_none());
     }
 }

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -43,6 +43,7 @@ pub fn run_global() -> Result<()> {
     ui::info("whetstone global uninstall");
 
     remove_bins();
+    remove_proxies();
 
     if ui::confirm("Remove RTK (global)?", false) {
         remove_rtk();
@@ -123,4 +124,24 @@ fn remove_project_files(project_dir: &Path) {
     let _ = fs::remove_file(project_dir.join("STACK-SETUP.md"));
 
     ui::ok("project whetstone files removed");
+}
+
+fn remove_proxies() {
+    use crate::proxy_registry as reg;
+    let Some(path) = reg::registry_path() else {
+        return;
+    };
+    let registry = reg::Registry::load(&path);
+    if registry.entries.is_empty() {
+        return;
+    }
+    ui::info("stopping whetstone-spawned Headroom proxies...");
+    reg::kill_all(&registry, |pid| {
+        let _ = std::process::Command::new("kill")
+            .arg(pid.to_string())
+            .status();
+    });
+    let _ = fs::remove_file(&path);
+    let _ = fs::remove_file(path.with_extension("lock"));
+    ui::ok("stopped registered proxies and removed the registry");
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -163,7 +163,11 @@ fn select_proxy_port(spec: &crate::proxy_registry::ProxySpec) -> Option<u16> {
     };
 
     let outcome = reg::resolve(&mut registry, spec, &deps);
-    let _ = registry.save(&path);
+    if let Err(e) = registry.save(&path) {
+        crate::ui::warn(&format!(
+            "could not persist proxy registry ({e}); a spawned proxy may be untracked"
+        ));
+    }
     match outcome {
         reg::ProxyOutcome::Reused(p) | reg::ProxyOutcome::Spawned(p) => Some(p),
         reg::ProxyOutcome::Failed => None,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,16 +1,17 @@
-use serde_json::Value;
 use std::env;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
 const DEFAULT_PROXY: &str = "http://127.0.0.1:8787";
-const PROXY_PORT: &str = "8787";
-const PROXY_HEALTH_URL: &str = "http://127.0.0.1:8787/health";
 const PROXY_READY_TIMEOUT: Duration = Duration::from_secs(15);
-const PROXY_KILL_TIMEOUT: Duration = Duration::from_secs(10);
 const PROXY_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const PROXY_PROBE_TIMEOUT: Duration = Duration::from_millis(800);
 
+/// Seed a default `ANTHROPIC_BASE_URL` pointing at the anchor port, so a bare
+/// `whetstone proxy` / `whetstone rtk` launch (which never calls
+/// `select_proxy_port`) still has something sane to inherit. `wrap_claude`
+/// overrides this per-session once it knows the actual port the registry
+/// resolved to.
 fn set_proxy_env() {
     if std::env::var("ANTHROPIC_BASE_URL").is_err() {
         std::env::set_var("ANTHROPIC_BASE_URL", DEFAULT_PROXY);
@@ -67,7 +68,13 @@ pub fn wrap_claude(args: &[String], memory_flag: bool) -> ! {
     }
 
     let want_memory = memory_flag || resolved.headroom_memory;
-    let decision = resolve_proxy(want_memory);
+    let spec = build_proxy_spec(&resolved, &hr_plan, want_memory);
+    let selected = select_proxy_port(&spec);
+    if let Some(port) = selected {
+        env::set_var("ANTHROPIC_BASE_URL", format!("http://127.0.0.1:{port}"));
+    }
+    let proxy_ready = selected.is_some();
+    let wrap_memory = if proxy_ready { false } else { want_memory };
 
     // An explicit `--model` suppresses the launch-time update prompt entirely;
     // otherwise offer any newer/new-family model and honor the user's choice.
@@ -81,8 +88,8 @@ pub fn wrap_claude(args: &[String], memory_flag: bool) -> ! {
     let model = choose_model(user_set, model_decision, &fallback);
     let cmd_args = build_claude_args(
         args,
-        decision.proxy_ready,
-        decision.wrap_memory,
+        proxy_ready,
+        wrap_memory,
         &model,
         resolved.permission_mode.as_deref(),
     );
@@ -90,112 +97,82 @@ pub fn wrap_claude(args: &[String], memory_flag: bool) -> ! {
     exec("headroom", &cmd_args);
 }
 
-/// How whetstone should hand the proxy off to `headroom wrap claude`.
-struct ProxyDecision {
-    /// A live proxy already serves :8787 — pass `--no-proxy` so wrap reuses it.
-    proxy_ready: bool,
-    /// Let `headroom wrap` own a session-bound proxy started with `--memory`.
-    wrap_memory: bool,
-}
-
-/// Reconcile the running proxy (if any) with whether this session wants
-/// persistent memory. When a proxy is already up *without* memory but memory
-/// is wanted, prompt the user before replacing it.
-fn resolve_proxy(want_memory: bool) -> ProxyDecision {
-    match probe_proxy_health() {
-        Some(health) => {
-            if want_memory && !health.memory {
-                resolve_memory_conflict(want_memory, health.pid)
-            } else {
-                // A live proxy already satisfies this session.
-                ProxyDecision {
-                    proxy_ready: true,
-                    wrap_memory: false,
-                }
-            }
-        }
-        None => start_detached_decision(want_memory),
+/// Testable core: assemble a `ProxySpec` from resolved inputs + the apply set.
+fn build_proxy_spec_from(
+    savings_profile: String,
+    telemetry: bool,
+    memory: bool,
+    anthropic_api_url: Option<String>,
+    apply: &[(String, String)],
+) -> crate::proxy_registry::ProxySpec {
+    let env = apply
+        .iter()
+        .filter(|(k, _)| k != "HEADROOM_MEMORY_DB_PATH")
+        .cloned()
+        .collect();
+    crate::proxy_registry::ProxySpec {
+        savings_profile,
+        telemetry,
+        memory,
+        anthropic_api_url: anthropic_api_url.filter(|s| !s.trim().is_empty()),
+        env,
     }
 }
 
-/// Spawn a detached proxy (optionally with memory) and wait for it to answer.
-/// If it never comes up, fall back to letting `headroom wrap` start its own
-/// session-bound proxy — carrying the memory preference across.
-fn start_detached_decision(want_memory: bool) -> ProxyDecision {
-    let ready = start_proxy_detached_ready(want_memory);
-    ProxyDecision {
-        proxy_ready: ready,
-        wrap_memory: if ready { false } else { want_memory },
+/// Production wrapper: reads live settings, the applied env plan, and the
+/// effective upstream URL.
+fn build_proxy_spec(
+    resolved: &crate::config::ResolvedSettings,
+    hr_plan: &crate::headroom_env::HeadroomEnvPlan,
+    memory: bool,
+) -> crate::proxy_registry::ProxySpec {
+    build_proxy_spec_from(
+        required_savings_profile(),
+        resolved.headroom_telemetry,
+        memory,
+        env::var(ANTHROPIC_TARGET_API_URL).ok(),
+        &hr_plan.apply,
+    )
+}
+
+/// Lock the registry, reconcile it against the running proxies, and return the
+/// port this session should use (spawning one if needed). Falls back to `None`
+/// so the caller can let `headroom wrap` try its own proxy.
+fn select_proxy_port(spec: &crate::proxy_registry::ProxySpec) -> Option<u16> {
+    use crate::proxy_registry as reg;
+    let path = reg::registry_path()?;
+    let lock_path = path.with_extension("lock");
+    // Lock window must outlast a full readiness wait.
+    let _guard = reg::acquire_lock(
+        &lock_path,
+        Duration::from_secs(25),
+        Duration::from_secs(45),
+    )
+    .ok()?;
+
+    let mut registry = reg::Registry::load(&path);
+    let probe = |p: u16| probe_port(p);
+    let port_free = |p: u16| free_port_is_bindable(p);
+    let free = || free_port();
+    let spawn = |p: u16| spawn_proxy_ready(p, spec.memory);
+    let deps = reg::ResolveDeps {
+        probe: &probe,
+        port_free: &port_free,
+        free_port: &free,
+        spawn: &spawn,
+    };
+
+    let outcome = reg::resolve(&mut registry, spec, &deps);
+    let _ = registry.save(&path);
+    match outcome {
+        reg::ProxyOutcome::Reused(p) | reg::ProxyOutcome::Spawned(p) => Some(p),
+        reg::ProxyOutcome::Failed => None,
     }
 }
 
-/// The running proxy lacks memory but this session wants it. Ask what to do.
-fn resolve_memory_conflict(
-    want_memory: bool,
-    pid: Option<u32>,
-) -> ProxyDecision {
-    // Non-interactive: never kill a proxy other sessions may be sharing.
-    if !crate::ui::is_interactive() {
-        eprintln!(
-            "[WARN] whetstone: a proxy is already running without --memory; \
-             continuing without memory (run interactively to replace it)"
-        );
-        return ProxyDecision {
-            proxy_ready: true,
-            wrap_memory: false,
-        };
-    }
-
-    let choices = [
-        "Restart the proxy with memory (replaces it for all sessions)",
-        "Start a memory proxy for this session only",
-        "Cancel and abort launch",
-    ];
-    let prompt =
-        "A Headroom proxy is already running without --memory. What now?";
-    match crate::ui::select(prompt, &choices, 0) {
-        0 => {
-            kill_proxy(pid);
-            start_detached_decision(want_memory)
-        }
-        1 => {
-            kill_proxy(pid);
-            // `headroom wrap claude --memory` brings up its own session proxy.
-            ProxyDecision {
-                proxy_ready: false,
-                wrap_memory: true,
-            }
-        }
-        _ => {
-            crate::ui::info("aborted; proxy left untouched");
-            std::process::exit(0);
-        }
-    }
-}
-
-/// SIGTERM the running proxy by PID and wait for the port to free up, so a
-/// replacement can bind :8787 without an [Errno 98] address-in-use race.
-fn kill_proxy(pid: Option<u32>) {
-    match pid {
-        Some(pid) => {
-            let _ = Command::new("kill").arg(pid.to_string()).status();
-        }
-        None => {
-            eprintln!("[WARN] whetstone: running proxy did not report a pid; cannot kill it");
-            return;
-        }
-    }
-
-    let deadline = Instant::now() + PROXY_KILL_TIMEOUT;
-    while Instant::now() < deadline {
-        if !probe_proxy() {
-            return;
-        }
-        std::thread::sleep(PROXY_POLL_INTERVAL);
-    }
-    eprintln!(
-        "[WARN] whetstone: proxy at {DEFAULT_PROXY} did not shut down in time"
-    );
+/// Can we bind this specific port right now?
+fn free_port_is_bindable(port: u16) -> bool {
+    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
 }
 
 fn resolved_settings() -> crate::config::ResolvedSettings {
@@ -256,82 +233,38 @@ fn warn_ignored_headroom_env(ignored: &[String]) {
     }
 }
 
-/// Phase 6.3: claude's first API call must hit a live proxy. The SessionStart
-/// hook auto-starts headroom, but it fires after claude has already launched —
-/// so the proxy may still be down by the time claude makes its first request.
-/// Spawn `headroom proxy` (optionally with `--memory`) detached and poll until
-/// it answers or we hit `PROXY_READY_TIMEOUT`. Returns whether a proxy is up,
-/// so the caller can pass `--no-proxy` to `headroom wrap` — whetstone owns the
-/// proxy lifecycle, and letting wrap manage it risks a hot-restart crash. On
-/// failure we soft-warn and return false so wrap may still try its own proxy
-/// startup as a last-resort fallback (e.g. a custom upstream).
-fn start_proxy_detached_ready(memory: bool) -> bool {
-    let spawned = spawn_proxy_detached(memory).is_ok();
-
-    let deadline = Instant::now() + PROXY_READY_TIMEOUT;
-    while Instant::now() < deadline {
-        if probe_proxy() {
-            return true;
-        }
-        std::thread::sleep(PROXY_POLL_INTERVAL);
-    }
-
-    let tail = if spawned {
-        "(spawned a background headroom proxy, but it did not respond in time)"
-    } else {
-        "(could not spawn `headroom proxy` — is headroom installed?)"
-    };
-    eprintln!(
-        "[WARN] whetstone: proxy at {DEFAULT_PROXY} is not responding {tail}"
-    );
-    false
+fn probe_port(port: u16) -> bool {
+    let url = format!("http://127.0.0.1:{port}/health");
+    ureq::get(&url).timeout(PROXY_PROBE_TIMEOUT).call().is_ok()
 }
 
 fn probe_proxy() -> bool {
-    ureq::get(PROXY_HEALTH_URL)
-        .timeout(PROXY_PROBE_TIMEOUT)
-        .call()
-        .is_ok()
+    probe_port(crate::proxy_registry::ANCHOR_PORT)
 }
 
-/// A live proxy's relevant state, read from `/health` `config`.
-struct ProxyHealth {
-    /// Whether the running proxy was started with persistent memory enabled.
-    memory: bool,
-    /// The proxy's process id, used to replace it cleanly. `None` if absent.
-    pid: Option<u32>,
+/// Spawn a proxy on `port` and poll until it answers or times out. Returns the
+/// child pid on success (read back from the port's own report is unnecessary —
+/// we return the spawned pid), else `None`.
+fn spawn_proxy_ready(port: u16, memory: bool) -> Option<u32> {
+    let pid = spawn_proxy_detached_pid(&port.to_string(), memory)?;
+    let deadline = Instant::now() + PROXY_READY_TIMEOUT;
+    while Instant::now() < deadline {
+        if probe_port(port) {
+            return Some(pid);
+        }
+        std::thread::sleep(PROXY_POLL_INTERVAL);
+    }
+    eprintln!(
+        "[WARN] whetstone: proxy on 127.0.0.1:{port} did not respond in time"
+    );
+    None
 }
 
-/// Probe `/health` and parse memory state + pid. `None` when no proxy answers.
-fn probe_proxy_health() -> Option<ProxyHealth> {
-    let body = ureq::get(PROXY_HEALTH_URL)
-        .timeout(PROXY_PROBE_TIMEOUT)
-        .call()
-        .ok()?
-        .into_string()
-        .ok()?;
-    parse_proxy_health(&body)
-}
-
-fn parse_proxy_health(body: &str) -> Option<ProxyHealth> {
-    let json: Value = serde_json::from_str(body).ok()?;
-    let config = json.get("config");
-    let memory = config
-        .and_then(|c| c.get("memory"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let pid = config
-        .and_then(|c| c.get("pid"))
-        .and_then(Value::as_u64)
-        .map(|p| p as u32);
-    Some(ProxyHealth { memory, pid })
-}
-
-fn spawn_proxy_detached(memory: bool) -> std::io::Result<()> {
+fn spawn_proxy_detached_pid(port: &str, memory: bool) -> Option<u32> {
     use std::process::Stdio;
     let telemetry_disabled = !headroom_telemetry_enabled();
     let args = build_proxy_args(
-        PROXY_PORT,
+        port,
         headroom_proxy_supports_savings_profile(),
         telemetry_disabled,
         memory,
@@ -357,7 +290,8 @@ fn spawn_proxy_detached(memory: bool) -> std::io::Result<()> {
         cmd.env(key, value);
     }
 
-    cmd.spawn().map(|_| ())
+    let child = cmd.spawn().ok()?;
+    Some(child.id())
 }
 
 /// Verdict from [`check_proxy_starts`].
@@ -763,6 +697,34 @@ mod tests {
     }
 
     #[test]
+    fn build_proxy_spec_excludes_memory_db_path() {
+        use std::collections::BTreeMap;
+        let mut apply = vec![
+            ("HEADROOM_CODE_AWARE_ENABLED".to_string(), "1".to_string()),
+            (
+                "HEADROOM_MEMORY_DB_PATH".to_string(),
+                "/home/u/.headroom/memory.db".to_string(),
+            ),
+        ];
+        // Sorted apply set is fine; the helper filters by key.
+        apply.sort();
+        let spec = build_proxy_spec_from(
+            "agent-90".to_string(),
+            true, // telemetry
+            true, // memory
+            Some("https://up.test".to_string()),
+            &apply,
+        );
+        assert_eq!(spec.savings_profile, "agent-90");
+        assert!(spec.telemetry);
+        assert!(spec.memory);
+        assert_eq!(spec.anthropic_api_url.as_deref(), Some("https://up.test"));
+        assert!(spec.env.contains_key("HEADROOM_CODE_AWARE_ENABLED"));
+        assert!(!spec.env.contains_key("HEADROOM_MEMORY_DB_PATH"));
+        let _ = BTreeMap::<String, String>::new();
+    }
+
+    #[test]
     fn resolve_api_url_uses_setting_when_env_unset() {
         assert_eq!(
             resolve_anthropic_api_url(Some("https://proxy.example"), None),
@@ -1163,35 +1125,6 @@ mod tests {
     fn build_claude_args_omits_memory_by_default() {
         let args = build_claude_args(&[], true, false, DEFAULT_MODEL, None);
         assert!(!args.contains(&"--memory".to_string()));
-    }
-
-    #[test]
-    fn parse_proxy_health_reads_memory_and_pid() {
-        let body = r#"{"config":{"memory":true,"pid":4242}}"#;
-        let health = parse_proxy_health(body).unwrap();
-        assert!(health.memory);
-        assert_eq!(health.pid, Some(4242));
-    }
-
-    #[test]
-    fn parse_proxy_health_defaults_memory_false_when_absent() {
-        let body = r#"{"config":{"pid":7}}"#;
-        let health = parse_proxy_health(body).unwrap();
-        assert!(!health.memory);
-        assert_eq!(health.pid, Some(7));
-    }
-
-    #[test]
-    fn parse_proxy_health_handles_missing_config() {
-        let body = r#"{"status":"healthy"}"#;
-        let health = parse_proxy_health(body).unwrap();
-        assert!(!health.memory);
-        assert_eq!(health.pid, None);
-    }
-
-    #[test]
-    fn parse_proxy_health_rejects_garbage() {
-        assert!(parse_proxy_health("not json").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Per-config keyed proxy reuse

Whetstone previously ran a single shared Headroom proxy on fixed port 8787, so per-project Headroom config bled across projects. This branch fingerprints the exact `(args + env)` config a session would spawn a proxy with; two sessions share a proxy **iff** their config is byte-identical, and each distinct config gets its own proxy.

### How it works

- **Fingerprint** — a hand-rolled FNV-1a hash over the canonical `(args, env)` spec a session would launch with. Memory on/off is *part* of the fingerprint, so a memory session and a non-memory session get separate proxies instead of racing to replace each other. `HEADROOM_MEMORY_DB_PATH` is deliberately *excluded* so the global memory-root pin can't fracture reuse on its own.
- **Registry** — running proxies are tracked in `~/.whetstone/proxies.json`, keyed by fingerprint. A live entry is reused only on an exact match.
- **Launch-order 8787 anchor** — the first spawned proxy takes port 8787 if it's free and unclaimed (so a bare `claude` launch and doctor's fast path still find one there); every entry records its actual port.
- **Concurrency** — an `O_EXCL` lockfile with pid-token ownership guards the registry read-modify-write, released before the long-running exec. A transiently-busy matching proxy gets a second-chance probe so it's reused rather than duplicated.
- **Teardown** — `whetstone global uninstall` reaps every registered proxy via `kill_all`.

### Changes

- `src/proxy_registry.rs` (new) — fingerprint, registry, lock, resolve orchestrator, teardown. Zero new crate dependencies.
- `src/wrapper.rs` — `select_proxy_port` integration on the launch path; surfaces registry-save errors.
- `src/uninstall.rs` — `remove_proxies` on global uninstall.

### Testing

- 290 unit + 3 integration tests pass.
- `just lint` clean (fmt + clippy `-D warnings`).
