### PR TITLE
feat(settings): add Headroom Savings Profile setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@ reports unknown extras and is left alone.
 
 `whetstone settings` also exposes **Edit Mode** — the Claude Code `--permission-mode` (`acceptEdits`, `default`, `plan`, `bypassPermissions`) whetstone injects into `headroom wrap claude`. Stored per-project (`permission_mode` in `.claude/whetstone.json`) or globally, project-over-global. When unset (**Off**), whetstone injects no flag and Claude Code uses its own default; an explicit `--permission-mode` on the command line always wins.
 
+`whetstone settings` also exposes **Headroom Savings Profile** — the Headroom compression profile (`coding`, `agent-90`, `balanced`, `general`) whetstone exports as `HEADROOM_SAVINGS_PROFILE` before launching Headroom, so the spawned proxy and the exec'd `headroom wrap claude` read the same profile (keeping them in agreement and part of the per-config proxy fingerprint). Stored per-project (`savings_profile` in `.claude/whetstone.json`) or globally, project-over-global. When unset (**Off**/None), whetstone exports nothing and Headroom falls back to its own default (`agent-90`); an externally-set `HEADROOM_SAVINGS_PROFILE` env var takes precedence over the stored setting.
+
 On launch, whetstone (`src/model_update.rs`) checks the 12h-cached Anthropic models list for a model newer than the one this project runs — or a brand-new model family — and shows a full-screen modal offering to pin it as the project default (`api_model`), use it for one session, or dismiss it permanently (recorded in the manifest's top-level `dismissed_models`). The prompt is skipped when non-interactive, offline, not a v3 project, or when `--model` was passed explicitly.
 
 whetstone also supports `headroom_env` — a map of any Headroom launch knobs in

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,11 @@ pub struct ProjectSettings {
     /// Claude Code uses its own default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub permission_mode: Option<String>,
+    /// Headroom savings profile exported as `HEADROOM_SAVINGS_PROFILE` when set
+    /// (see [`SAVINGS_PROFILES`]). `None` means whetstone exports nothing and
+    /// Headroom uses its own default (`agent-90`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub savings_profile: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub headroom_env: BTreeMap<String, String>,
 }
@@ -87,6 +92,12 @@ pub struct ProjectSettings {
 /// setting seeds).
 pub const PERMISSION_MODES: &[&str] =
     &["acceptEdits", "default", "plan", "bypassPermissions"];
+
+/// Selectable Headroom savings profiles for the settings TUI's cycle order.
+/// The TUI's leading "Off" slot is the "None" option (no override; Headroom
+/// falls back to its own default, `agent-90`).
+pub const SAVINGS_PROFILES: &[&str] =
+    &["coding", "agent-90", "balanced", "general"];
 
 const GLOBAL_DIR: &str = ".whetstone";
 const GLOBAL_SETTINGS_FILENAME: &str = "settings.json";
@@ -103,6 +114,8 @@ pub struct GlobalSettings {
     pub anthropic_api_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub permission_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub savings_profile: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub headroom_env: BTreeMap<String, String>,
 }
@@ -147,6 +160,7 @@ pub struct ResolvedSettings {
     pub api_model: Option<String>,
     pub anthropic_api_url: Option<String>,
     pub permission_mode: Option<String>,
+    pub savings_profile: Option<String>,
     pub headroom_env: BTreeMap<String, String>,
 }
 
@@ -174,6 +188,10 @@ impl ResolvedSettings {
                 .permission_mode
                 .clone()
                 .or_else(|| global.permission_mode.clone()),
+            savings_profile: project
+                .savings_profile
+                .clone()
+                .or_else(|| global.savings_profile.clone()),
             headroom_env,
         }
     }
@@ -359,6 +377,47 @@ mod tests {
         let s = ProjectSettings::default();
         let raw = serde_json::to_string(&s).unwrap();
         assert!(!raw.contains("permission_mode"));
+    }
+
+    #[test]
+    fn resolve_prefers_project_savings_profile() {
+        let global = GlobalSettings {
+            savings_profile: Some("balanced".into()),
+            ..Default::default()
+        };
+        let project = ProjectSettings {
+            savings_profile: Some("coding".into()),
+            ..Default::default()
+        };
+        let resolved = ResolvedSettings::resolve(&global, &project);
+        assert_eq!(resolved.savings_profile.as_deref(), Some("coding"));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_global_savings_profile() {
+        let global = GlobalSettings {
+            savings_profile: Some("general".into()),
+            ..Default::default()
+        };
+        let resolved =
+            ResolvedSettings::resolve(&global, &ProjectSettings::default());
+        assert_eq!(resolved.savings_profile.as_deref(), Some("general"));
+    }
+
+    #[test]
+    fn resolve_savings_profile_none_when_unset() {
+        let resolved = ResolvedSettings::resolve(
+            &GlobalSettings::default(),
+            &ProjectSettings::default(),
+        );
+        assert!(resolved.savings_profile.is_none());
+    }
+
+    #[test]
+    fn empty_savings_profile_omitted_from_project_json() {
+        let s = ProjectSettings::default();
+        let raw = serde_json::to_string(&s).unwrap();
+        assert!(!raw.contains("savings_profile"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,14 +90,14 @@ pub struct ProjectSettings {
 /// Valid Claude Code `--permission-mode` values, most-permissive-first for the
 /// settings TUI's cycle order (the first entry is the value a freshly-enabled
 /// setting seeds).
-pub const PERMISSION_MODES: &[&str] =
-    &["acceptEdits", "default", "plan", "bypassPermissions"];
+pub const PERMISSION_MODES: [&str; 4] =
+    ["acceptEdits", "default", "plan", "bypassPermissions"];
 
 /// Selectable Headroom savings profiles for the settings TUI's cycle order.
 /// The TUI's leading "Off" slot is the "None" option (no override; Headroom
 /// falls back to its own default, `agent-90`).
-pub const SAVINGS_PROFILES: &[&str] =
-    &["coding", "agent-90", "balanced", "general"];
+pub const SAVINGS_PROFILES: [&str; 4] =
+    ["coding", "agent-90", "balanced", "general"];
 
 const GLOBAL_DIR: &str = ".whetstone";
 const GLOBAL_SETTINGS_FILENAME: &str = "settings.json";

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::config::{
     GlobalSettings, ProjectSettings, WhetstoneManifest, PERMISSION_MODES,
+    SAVINGS_PROFILES,
 };
 use crate::memory::MemoryProvider;
 use crate::ui;
@@ -231,6 +232,7 @@ enum SettingId {
     HeadroomLogMessages,
     ApiModel,
     PermissionMode,
+    HeadroomSavingsProfile,
     AnthropicApiUrl,
 }
 
@@ -243,6 +245,7 @@ const SETTINGS: &[SettingId] = &[
     SettingId::HeadroomLogMessages,
     SettingId::ApiModel,
     SettingId::PermissionMode,
+    SettingId::HeadroomSavingsProfile,
     SettingId::AnthropicApiUrl,
 ];
 
@@ -263,7 +266,9 @@ fn control_kind(id: SettingId) -> Control {
         | SettingId::HeadroomBeacon
         | SettingId::HeadroomMemory
         | SettingId::HeadroomLogMessages => Control::Bool,
-        SettingId::ApiModel | SettingId::PermissionMode => Control::Choice,
+        SettingId::ApiModel
+        | SettingId::PermissionMode
+        | SettingId::HeadroomSavingsProfile => Control::Choice,
         SettingId::HeadroomTargetRatio
         | SettingId::HeadroomBudget
         | SettingId::AnthropicApiUrl => Control::Text,
@@ -281,6 +286,7 @@ fn label(id: SettingId) -> &'static str {
         SettingId::HeadroomLogMessages => "Headroom Log Messages",
         SettingId::ApiModel => "API Model",
         SettingId::PermissionMode => "Edit Mode",
+        SettingId::HeadroomSavingsProfile => "Headroom Savings Profile",
         SettingId::AnthropicApiUrl => "Anthropic API URL",
     }
 }
@@ -363,6 +369,15 @@ impl SettingsState {
                 if self.project.permission_mode.is_some() {
                     Scope::Project
                 } else if self.global.permission_mode.is_some() {
+                    Scope::Global
+                } else {
+                    Scope::Off
+                }
+            }
+            SettingId::HeadroomSavingsProfile => {
+                if self.project.savings_profile.is_some() {
+                    Scope::Project
+                } else if self.global.savings_profile.is_some() {
                     Scope::Global
                 } else {
                     Scope::Off
@@ -463,6 +478,27 @@ impl SettingsState {
                         .clone()
                         .unwrap_or_else(|| PERMISSION_MODES[0].to_string());
                     self.project.permission_mode = Some(base);
+                }
+            },
+            SettingId::HeadroomSavingsProfile => match target {
+                Scope::Off => {
+                    self.global.savings_profile = None;
+                    self.project.savings_profile = None;
+                }
+                Scope::Global => {
+                    if self.global.savings_profile.is_none() {
+                        self.global.savings_profile =
+                            Some(SAVINGS_PROFILES[0].to_string());
+                    }
+                    self.project.savings_profile = None;
+                }
+                Scope::Project => {
+                    let base = self
+                        .global
+                        .savings_profile
+                        .clone()
+                        .unwrap_or_else(|| SAVINGS_PROFILES[0].to_string());
+                    self.project.savings_profile = Some(base);
                 }
             },
             SettingId::AnthropicApiUrl => match target {
@@ -577,6 +613,9 @@ impl SettingsState {
             SettingId::PermissionMode => {
                 PERMISSION_MODES.iter().map(|s| s.to_string()).collect()
             }
+            SettingId::HeadroomSavingsProfile => {
+                SAVINGS_PROFILES.iter().map(|s| s.to_string()).collect()
+            }
             _ => Vec::new(),
         }
     }
@@ -625,6 +664,12 @@ impl SettingsState {
             (SettingId::PermissionMode, Scope::Project) => {
                 self.project.permission_mode = Some(value)
             }
+            (SettingId::HeadroomSavingsProfile, Scope::Global) => {
+                self.global.savings_profile = Some(value)
+            }
+            (SettingId::HeadroomSavingsProfile, Scope::Project) => {
+                self.project.savings_profile = Some(value)
+            }
             _ => {}
         }
     }
@@ -656,6 +701,11 @@ impl SettingsState {
                 Scope::Off => None,
                 Scope::Global => self.global.permission_mode.as_deref(),
                 Scope::Project => self.project.permission_mode.as_deref(),
+            },
+            SettingId::HeadroomSavingsProfile => match self.scope(id) {
+                Scope::Off => None,
+                Scope::Global => self.global.savings_profile.as_deref(),
+                Scope::Project => self.project.savings_profile.as_deref(),
             },
             SettingId::AnthropicApiUrl => match self.scope(id) {
                 Scope::Off => None,
@@ -724,6 +774,15 @@ impl SettingsState {
                 None => "Off — Claude Code uses its own default permission mode."
                     .to_string(),
             },
+            SettingId::HeadroomSavingsProfile => {
+                match self.current_value_display(id) {
+                    Some(p) => format!(
+                        "Headroom compresses with the {p} savings profile (HEADROOM_SAVINGS_PROFILE)."
+                    ),
+                    None => "Off — Headroom uses its default savings profile (agent-90)."
+                        .to_string(),
+                }
+            }
             SettingId::AnthropicApiUrl => match self.current_value_display(id) {
                 Some(u) if !u.trim().is_empty() => {
                     format!("Headroom proxies to {u} instead of the default Anthropic API.")
@@ -1399,6 +1458,42 @@ mod tests {
         );
         s.cycle_choice(id, Dir::Next);
         assert_eq!(s.scope(id), Scope::Off);
+    }
+
+    #[test]
+    fn savings_profile_cycles_off_through_profiles() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomSavingsProfile;
+        assert_eq!(s.scope(id), Scope::Off);
+
+        s.cycle_choice(id, Dir::Next);
+        assert_eq!(s.scope(id), Scope::Global);
+        assert_eq!(
+            s.global.savings_profile.as_deref(),
+            Some(SAVINGS_PROFILES[0])
+        );
+
+        for _ in 1..SAVINGS_PROFILES.len() {
+            s.cycle_choice(id, Dir::Next);
+        }
+        assert_eq!(
+            s.global.savings_profile.as_deref(),
+            Some(SAVINGS_PROFILES[SAVINGS_PROFILES.len() - 1])
+        );
+        s.cycle_choice(id, Dir::Next);
+        assert_eq!(s.scope(id), Scope::Off);
+        assert!(s.global.savings_profile.is_none());
+    }
+
+    #[test]
+    fn savings_profile_scope_toggle_preserves_value() {
+        let mut s = default_state();
+        let id = SettingId::HeadroomSavingsProfile;
+        s.cycle_choice(id, Dir::Next); // Global, SAVINGS_PROFILES[0]
+        s.set_choice_value(id, "balanced".to_string());
+        s.toggle_scope(id);
+        assert_eq!(s.scope(id), Scope::Project);
+        assert_eq!(s.project.savings_profile.as_deref(), Some("balanced"));
     }
 
     // ---- text value + scope ---------------------------------------------

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -51,11 +51,43 @@ fn resolve_anthropic_api_url(
         .map(str::to_string)
 }
 
+/// Export the configured Headroom savings profile so a whetstone-spawned proxy
+/// *and* the exec'd `headroom wrap claude` read the same profile from the
+/// environment (they both source it from `HEADROOM_SAVINGS_PROFILE`, so this
+/// keeps them in agreement and avoids wrap's "missing --savings-profile"
+/// hot-restart). An externally-set env var wins over the stored setting, and
+/// blank/whitespace settings are ignored.
+fn apply_savings_profile(setting: Option<&str>) {
+    if let Some(profile) = resolve_savings_profile_env(
+        setting,
+        env::var(HEADROOM_SAVINGS_PROFILE_ENV).ok(),
+    ) {
+        env::set_var(HEADROOM_SAVINGS_PROFILE_ENV, profile);
+    }
+}
+
+/// Pure resolution for [`apply_savings_profile`]: an existing non-empty env
+/// override takes precedence; otherwise a non-blank setting is used. `None`
+/// means "leave the environment untouched" (so Headroom's own default applies).
+fn resolve_savings_profile_env(
+    setting: Option<&str>,
+    existing_env: Option<String>,
+) -> Option<String> {
+    if existing_env.is_some_and(|v| !v.trim().is_empty()) {
+        return None;
+    }
+    setting
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 pub fn wrap_claude(args: &[String], memory_flag: bool) -> ! {
     set_proxy_env();
 
     let resolved = resolved_settings();
     apply_anthropic_api_url(resolved.anthropic_api_url.as_deref());
+    apply_savings_profile(resolved.savings_profile.as_deref());
 
     // Drain any stray `.headroom` store this project accumulated before memory
     // was pinned to the global root. Idempotent no-op once clean.
@@ -479,8 +511,13 @@ fn headroom_telemetry_enabled() -> bool {
 // the `HEADROOM_SAVINGS_PROFILE` env var, not a CLI flag, in current headroom.
 const DEFAULT_SAVINGS_PROFILE: &str = "agent-90";
 
+// The env var headroom reads for the savings profile. Whetstone owns this key
+// (see `headroom_env::RESERVED_OWNED`): `apply_savings_profile` exports the
+// configured setting here, and both the spawned proxy and exec'd wrap read it.
+const HEADROOM_SAVINGS_PROFILE_ENV: &str = "HEADROOM_SAVINGS_PROFILE";
+
 fn required_savings_profile() -> String {
-    resolve_savings_profile(env::var("HEADROOM_SAVINGS_PROFILE").ok())
+    resolve_savings_profile(env::var(HEADROOM_SAVINGS_PROFILE_ENV).ok())
 }
 
 // Honor an existing override (matching what `headroom wrap claude` will read),
@@ -665,6 +702,7 @@ mod tests {
             api_model: None,
             anthropic_api_url: None,
             permission_mode: None,
+            savings_profile: None,
             headroom_env: std::collections::BTreeMap::new(),
         };
         let plan = headroom_env_plan_for(
@@ -686,6 +724,7 @@ mod tests {
             api_model: None,
             anthropic_api_url: None,
             permission_mode: None,
+            savings_profile: None,
             headroom_env: std::collections::BTreeMap::new(),
         };
         let plan = headroom_env_plan_for(
@@ -761,6 +800,39 @@ mod tests {
                 Some("  ".to_string())
             ),
             Some("https://setting.example".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_savings_profile_env_uses_setting_when_env_unset() {
+        assert_eq!(
+            resolve_savings_profile_env(Some("coding"), None),
+            Some("coding".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_savings_profile_env_override_wins() {
+        assert_eq!(
+            resolve_savings_profile_env(
+                Some("coding"),
+                Some("balanced".to_string())
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_savings_profile_env_ignores_blank_setting() {
+        assert_eq!(resolve_savings_profile_env(Some("   "), None), None);
+        assert_eq!(resolve_savings_profile_env(None, None), None);
+    }
+
+    #[test]
+    fn resolve_savings_profile_env_ignores_blank_override() {
+        assert_eq!(
+            resolve_savings_profile_env(Some("coding"), Some("  ".to_string())),
+            Some("coding".to_string())
         );
     }
 


### PR DESCRIPTION
## What

Adds a **Headroom Savings Profile** setting to `whetstone settings`, exposing `HEADROOM_SAVINGS_PROFILE` with choices `coding`, `agent-90`, `balanced`, `general`. Follows the existing **Edit Mode** (`permission_mode`) `Control::Choice` pattern end-to-end.

## How

- **`config.rs`**: `savings_profile: Option<String>` on `ProjectSettings`, `GlobalSettings`, and `ResolvedSettings`, with project-over-global resolution. New `SAVINGS_PROFILES` const.
- **`wrapper.rs`**: `apply_savings_profile()` exports `HEADROOM_SAVINGS_PROFILE` during `wrap_claude`, before the proxy spec is built — so the spawned proxy, the exec'd `headroom wrap claude`, and the per-config proxy fingerprint all read the same profile (avoiding wrap's "missing --savings-profile" hot-restart). An externally-set env var wins over the stored setting; blank settings are ignored.
- **`settings.rs`**: `HeadroomSavingsProfile` choice control. The leading **Off** slot is the **None** option — unset exports nothing and Headroom falls back to its own default (`agent-90`).
- **`CLAUDE.md`**: documented the new setting.

The env key was already listed in `headroom_env::RESERVED_OWNED`, so there is no collision with the `headroom_env` passthrough map — this setting is that dedicated path.

## Testing

- Added config resolve tests, env-resolution tests, and TUI cycle/scope tests.
- `cargo test`: 304 passed. `cargo clippy` clean. `cargo fmt --check` clean.