### PR TITLE
feat(settings): add Tool Search toggle and Headroom rollout/shaper knobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,12 +108,20 @@ reports unknown extras and is left alone.
 
 `whetstone settings` also exposes **Headroom Savings Profile** — the Headroom compression profile (`coding`, `agent-90`, `balanced`, `general`) whetstone exports as `HEADROOM_SAVINGS_PROFILE` before launching Headroom, so the spawned proxy and the exec'd `headroom wrap claude` read the same profile (keeping them in agreement and part of the per-config proxy fingerprint). Stored per-project (`savings_profile` in `.claude/whetstone.json`) or globally, project-over-global. When unset (**Off**/None), whetstone exports nothing and Headroom falls back to its own default (`agent-90`); an externally-set `HEADROOM_SAVINGS_PROFILE` env var takes precedence over the stored setting.
 
+`whetstone settings` also exposes **Tool Search** — a boolean that, when **On**, exports `ENABLE_TOOL_SEARCH=1` before launching so Claude Code turns on deferred-tool search. This is a Claude Code concern (exported into the environment the exec'd `headroom wrap claude` passes to Claude Code), *not* a Headroom one, so it is not part of the per-config proxy fingerprint. Stored per-project (`enable_tool_search` in `.claude/whetstone.json`) or globally, project-over-global (a project value of `false` overrides a global `true`). When **Off**, whetstone exports nothing, so any externally-set `ENABLE_TOOL_SEARCH` passes through untouched.
+
 On launch, whetstone (`src/model_update.rs`) checks the 12h-cached Anthropic models list for a model newer than the one this project runs — or a brand-new model family — and shows a full-screen modal offering to pin it as the project default (`api_model`), use it for one session, or dismiss it permanently (recorded in the manifest's top-level `dismissed_models`). The prompt is skipped when non-interactive, offline, not a v3 project, or when `--model` was passed explicitly.
 
 whetstone also supports `headroom_env` — a map of any Headroom launch knobs in
 `.claude/whetstone.json` (project) or `~/.whetstone/settings.json` (global),
 with precedence: external `HEADROOM_*` env vars > project map > global map >
-whetstone defaults (`HEADROOM_PORT` reserved, wins always).
+whetstone defaults (`HEADROOM_PORT` reserved, wins always). `whetstone settings`
+surfaces several of these map keys as named free-text knobs — **Headroom Target
+Ratio** (`HEADROOM_TARGET_RATIO`), **Headroom Budget** (`HEADROOM_BUDGET`),
+**Headroom Rollout Channel** (`HEADROOM_ROLLOUT_CHANNEL`), and **Headroom Output
+Shaper** (`HEADROOM_OUTPUT_SHAPER`) — each stored as an ordinary `headroom_env`
+entry, so they follow the same precedence and become part of the per-config
+proxy fingerprint like any other applied `HEADROOM_*` var.
 
 ## Architecture
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,11 @@ pub struct ProjectSettings {
     /// Headroom uses its own default (`agent-90`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub savings_profile: Option<String>,
+    /// When on, whetstone exports `ENABLE_TOOL_SEARCH=1` so Claude Code turns on
+    /// deferred-tool search. `None` means whetstone exports nothing and any
+    /// externally-set `ENABLE_TOOL_SEARCH` passes through untouched.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enable_tool_search: Option<bool>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub headroom_env: BTreeMap<String, String>,
 }
@@ -116,6 +121,8 @@ pub struct GlobalSettings {
     pub permission_mode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub savings_profile: Option<String>,
+    #[serde(default)]
+    pub enable_tool_search: bool,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub headroom_env: BTreeMap<String, String>,
 }
@@ -161,6 +168,7 @@ pub struct ResolvedSettings {
     pub anthropic_api_url: Option<String>,
     pub permission_mode: Option<String>,
     pub savings_profile: Option<String>,
+    pub enable_tool_search: bool,
     pub headroom_env: BTreeMap<String, String>,
 }
 
@@ -192,6 +200,9 @@ impl ResolvedSettings {
                 .savings_profile
                 .clone()
                 .or_else(|| global.savings_profile.clone()),
+            enable_tool_search: project
+                .enable_tool_search
+                .unwrap_or(global.enable_tool_search),
             headroom_env,
         }
     }
@@ -418,6 +429,61 @@ mod tests {
         let s = ProjectSettings::default();
         let raw = serde_json::to_string(&s).unwrap();
         assert!(!raw.contains("savings_profile"));
+    }
+
+    #[test]
+    fn resolve_prefers_project_enable_tool_search() {
+        let global = GlobalSettings {
+            enable_tool_search: false,
+            ..Default::default()
+        };
+        let project = ProjectSettings {
+            enable_tool_search: Some(true),
+            ..Default::default()
+        };
+        let resolved = ResolvedSettings::resolve(&global, &project);
+        assert!(resolved.enable_tool_search);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_global_enable_tool_search() {
+        let global = GlobalSettings {
+            enable_tool_search: true,
+            ..Default::default()
+        };
+        let resolved =
+            ResolvedSettings::resolve(&global, &ProjectSettings::default());
+        assert!(resolved.enable_tool_search);
+    }
+
+    #[test]
+    fn resolve_enable_tool_search_off_when_unset() {
+        let resolved = ResolvedSettings::resolve(
+            &GlobalSettings::default(),
+            &ProjectSettings::default(),
+        );
+        assert!(!resolved.enable_tool_search);
+    }
+
+    #[test]
+    fn resolve_project_false_overrides_global_enable_tool_search() {
+        let global = GlobalSettings {
+            enable_tool_search: true,
+            ..Default::default()
+        };
+        let project = ProjectSettings {
+            enable_tool_search: Some(false),
+            ..Default::default()
+        };
+        let resolved = ResolvedSettings::resolve(&global, &project);
+        assert!(!resolved.enable_tool_search);
+    }
+
+    #[test]
+    fn empty_enable_tool_search_omitted_from_project_json() {
+        let s = ProjectSettings::default();
+        let raw = serde_json::to_string(&s).unwrap();
+        assert!(!raw.contains("enable_tool_search"));
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -230,9 +230,12 @@ enum SettingId {
     HeadroomTargetRatio,
     HeadroomBudget,
     HeadroomLogMessages,
+    HeadroomRolloutChannel,
+    HeadroomOutputShaper,
     ApiModel,
     PermissionMode,
     HeadroomSavingsProfile,
+    EnableToolSearch,
     AnthropicApiUrl,
 }
 
@@ -243,9 +246,12 @@ const SETTINGS: &[SettingId] = &[
     SettingId::HeadroomTargetRatio,
     SettingId::HeadroomBudget,
     SettingId::HeadroomLogMessages,
+    SettingId::HeadroomRolloutChannel,
+    SettingId::HeadroomOutputShaper,
     SettingId::ApiModel,
     SettingId::PermissionMode,
     SettingId::HeadroomSavingsProfile,
+    SettingId::EnableToolSearch,
     SettingId::AnthropicApiUrl,
 ];
 
@@ -265,12 +271,15 @@ fn control_kind(id: SettingId) -> Control {
         SettingId::HeadroomTelemetry
         | SettingId::HeadroomBeacon
         | SettingId::HeadroomMemory
-        | SettingId::HeadroomLogMessages => Control::Bool,
+        | SettingId::HeadroomLogMessages
+        | SettingId::EnableToolSearch => Control::Bool,
         SettingId::ApiModel
         | SettingId::PermissionMode
         | SettingId::HeadroomSavingsProfile => Control::Choice,
         SettingId::HeadroomTargetRatio
         | SettingId::HeadroomBudget
+        | SettingId::HeadroomRolloutChannel
+        | SettingId::HeadroomOutputShaper
         | SettingId::AnthropicApiUrl => Control::Text,
     }
 }
@@ -284,9 +293,12 @@ fn label(id: SettingId) -> &'static str {
         SettingId::HeadroomTargetRatio => "Headroom Target Ratio",
         SettingId::HeadroomBudget => "Headroom Budget",
         SettingId::HeadroomLogMessages => "Headroom Log Messages",
+        SettingId::HeadroomRolloutChannel => "Headroom Rollout Channel",
+        SettingId::HeadroomOutputShaper => "Headroom Output Shaper",
         SettingId::ApiModel => "API Model",
         SettingId::PermissionMode => "Edit Mode",
         SettingId::HeadroomSavingsProfile => "Headroom Savings Profile",
+        SettingId::EnableToolSearch => "Tool Search",
         SettingId::AnthropicApiUrl => "Anthropic API URL",
     }
 }
@@ -308,6 +320,12 @@ fn env_knob(id: SettingId) -> Option<(&'static str, EnvKind)> {
             Some(("HEADROOM_TARGET_RATIO", EnvKind::Value))
         }
         SettingId::HeadroomBudget => Some(("HEADROOM_BUDGET", EnvKind::Value)),
+        SettingId::HeadroomRolloutChannel => {
+            Some(("HEADROOM_ROLLOUT_CHANNEL", EnvKind::Value))
+        }
+        SettingId::HeadroomOutputShaper => {
+            Some(("HEADROOM_OUTPUT_SHAPER", EnvKind::Value))
+        }
         SettingId::HeadroomLogMessages => {
             Some(("HEADROOM_LOG_MESSAGES", EnvKind::Toggle("1")))
         }
@@ -356,6 +374,14 @@ impl SettingsState {
                 None if self.global.headroom_memory => Scope::Global,
                 None => Scope::Off,
             },
+            SettingId::EnableToolSearch => {
+                match self.project.enable_tool_search {
+                    Some(true) => Scope::Project,
+                    Some(false) => Scope::Off,
+                    None if self.global.enable_tool_search => Scope::Global,
+                    None => Scope::Off,
+                }
+            }
             SettingId::ApiModel => {
                 if self.project.api_model.is_some() {
                     Scope::Project
@@ -396,6 +422,8 @@ impl SettingsState {
             SettingId::HeadroomTargetRatio
             | SettingId::HeadroomBudget
             | SettingId::HeadroomLogMessages
+            | SettingId::HeadroomRolloutChannel
+            | SettingId::HeadroomOutputShaper
             | SettingId::HeadroomBeacon => unreachable!(),
         }
     }
@@ -437,6 +465,19 @@ impl SettingsState {
                 }
                 Scope::Project => {
                     self.project.headroom_memory = Some(true);
+                }
+            },
+            SettingId::EnableToolSearch => match target {
+                Scope::Off => {
+                    self.global.enable_tool_search = false;
+                    self.project.enable_tool_search = None;
+                }
+                Scope::Global => {
+                    self.global.enable_tool_search = true;
+                    self.project.enable_tool_search = None;
+                }
+                Scope::Project => {
+                    self.project.enable_tool_search = Some(true);
                 }
             },
             SettingId::ApiModel => match target {
@@ -524,6 +565,8 @@ impl SettingsState {
             SettingId::HeadroomTargetRatio
             | SettingId::HeadroomBudget
             | SettingId::HeadroomLogMessages
+            | SettingId::HeadroomRolloutChannel
+            | SettingId::HeadroomOutputShaper
             | SettingId::HeadroomBeacon => unreachable!(),
         }
     }
@@ -761,6 +804,12 @@ impl SettingsState {
                 "Off — message content is not logged."
             }
             .to_string(),
+            SettingId::EnableToolSearch => if self.value_on(id) {
+                "On — Claude Code turns on deferred-tool search (ENABLE_TOOL_SEARCH=1)."
+            } else {
+                "Off — Claude Code uses its own default; any external ENABLE_TOOL_SEARCH passes through."
+            }
+            .to_string(),
             SettingId::ApiModel => match self.current_value_display(id) {
                 Some(m) => format!("Claude Code sessions use {m}."),
                 None => {
@@ -805,6 +854,24 @@ impl SettingsState {
                 }
                 _ => "Off — no spend cap on the Headroom proxy.".to_string(),
             },
+            SettingId::HeadroomRolloutChannel => {
+                match self.current_value_display(id) {
+                    Some(v) if !v.trim().is_empty() => format!(
+                        "Headroom uses the {v} rollout channel (HEADROOM_ROLLOUT_CHANNEL)."
+                    ),
+                    _ => "Off — Headroom uses its default rollout channel."
+                        .to_string(),
+                }
+            }
+            SettingId::HeadroomOutputShaper => {
+                match self.current_value_display(id) {
+                    Some(v) if !v.trim().is_empty() => format!(
+                        "Headroom shapes output with {v} (HEADROOM_OUTPUT_SHAPER)."
+                    ),
+                    _ => "Off — Headroom uses its default output shaper."
+                        .to_string(),
+                }
+            }
         }
     }
 
@@ -1325,6 +1392,34 @@ mod tests {
     }
 
     #[test]
+    fn tool_search_toggle_on_off() {
+        let mut s = default_state();
+        let id = SettingId::EnableToolSearch;
+        assert!(!s.value_on(id));
+        s.toggle_bool(id);
+        assert!(s.value_on(id));
+        assert!(s.global.enable_tool_search);
+        assert_eq!(s.scope(id), Scope::Global);
+        s.toggle_bool(id);
+        assert!(!s.value_on(id));
+        assert!(!s.global.enable_tool_search);
+    }
+
+    #[test]
+    fn tool_search_scope_toggle_moves_global_project() {
+        let mut s = default_state();
+        let id = SettingId::EnableToolSearch;
+        s.toggle_bool(id); // On @ Global
+        s.toggle_scope(id);
+        assert_eq!(s.scope(id), Scope::Project);
+        assert_eq!(s.project.enable_tool_search, Some(true));
+
+        s.toggle_scope(id);
+        assert_eq!(s.scope(id), Scope::Global);
+        assert!(s.global.enable_tool_search);
+    }
+
+    #[test]
     fn beacon_is_inverted_opt_out() {
         let mut s = default_state();
         let id = SettingId::HeadroomBeacon;
@@ -1577,6 +1672,33 @@ mod tests {
                 .get("HEADROOM_TARGET_RATIO")
                 .map(String::as_str),
             Some("0.6")
+        );
+    }
+
+    #[test]
+    fn rollout_channel_and_output_shaper_write_env_value_knobs() {
+        let mut s = default_state();
+
+        s.selected = index_of(SettingId::HeadroomRolloutChannel);
+        s.editing = Some("beta".into());
+        s.commit_edit();
+        assert_eq!(
+            s.global
+                .headroom_env
+                .get("HEADROOM_ROLLOUT_CHANNEL")
+                .map(String::as_str),
+            Some("beta")
+        );
+
+        s.selected = index_of(SettingId::HeadroomOutputShaper);
+        s.editing = Some("markdown".into());
+        s.commit_edit();
+        assert_eq!(
+            s.global
+                .headroom_env
+                .get("HEADROOM_OUTPUT_SHAPER")
+                .map(String::as_str),
+            Some("markdown")
         );
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -82,12 +82,24 @@ fn resolve_savings_profile_env(
         .map(str::to_string)
 }
 
+/// Export `ENABLE_TOOL_SEARCH=1` when the setting is on so Claude Code (launched
+/// by the exec'd `headroom wrap claude`) turns on deferred-tool search. When
+/// off, whetstone touches nothing, so any externally-set `ENABLE_TOOL_SEARCH`
+/// passes through untouched. Not part of the proxy fingerprint — this is a
+/// Claude Code concern, not a Headroom one.
+fn apply_enable_tool_search(on: bool) {
+    if on {
+        env::set_var(ENABLE_TOOL_SEARCH_ENV, "1");
+    }
+}
+
 pub fn wrap_claude(args: &[String], memory_flag: bool) -> ! {
     set_proxy_env();
 
     let resolved = resolved_settings();
     apply_anthropic_api_url(resolved.anthropic_api_url.as_deref());
     apply_savings_profile(resolved.savings_profile.as_deref());
+    apply_enable_tool_search(resolved.enable_tool_search);
 
     // Drain any stray `.headroom` store this project accumulated before memory
     // was pinned to the global root. Idempotent no-op once clean.
@@ -516,6 +528,9 @@ const DEFAULT_SAVINGS_PROFILE: &str = "agent-90";
 // configured setting here, and both the spawned proxy and exec'd wrap read it.
 const HEADROOM_SAVINGS_PROFILE_ENV: &str = "HEADROOM_SAVINGS_PROFILE";
 
+// The env var Claude Code reads to turn on deferred-tool search.
+const ENABLE_TOOL_SEARCH_ENV: &str = "ENABLE_TOOL_SEARCH";
+
 fn required_savings_profile() -> String {
     resolve_savings_profile(env::var(HEADROOM_SAVINGS_PROFILE_ENV).ok())
 }
@@ -710,6 +725,7 @@ mod tests {
             anthropic_api_url: None,
             permission_mode: None,
             savings_profile: None,
+            enable_tool_search: false,
             headroom_env: std::collections::BTreeMap::new(),
         };
         let plan = headroom_env_plan_for(
@@ -732,6 +748,7 @@ mod tests {
             anthropic_api_url: None,
             permission_mode: None,
             savings_profile: None,
+            enable_tool_search: false,
             headroom_env: std::collections::BTreeMap::new(),
         };
         let plan = headroom_env_plan_for(


### PR DESCRIPTION
## Summary

- Add an **Enable Tool Search** boolean setting that exports `ENABLE_TOOL_SEARCH=1` before launching so Claude Code turns on deferred-tool search. Stored per-project (`enable_tool_search` in `.claude/whetstone.json`) or globally, project-over-global — a project `false` overrides a global `true`. When off, whetstone exports nothing, so any externally-set `ENABLE_TOOL_SEARCH` passes through untouched. Not part of the per-config proxy fingerprint (a Claude Code concern, not a Headroom one).
- Surface two more `headroom_env` knobs in the settings TUI: **Headroom Rollout Channel** (`HEADROOM_ROLLOUT_CHANNEL`) and **Headroom Output Shaper** (`HEADROOM_OUTPUT_SHAPER`), each stored as ordinary `headroom_env` entries that follow the usual precedence and join the per-config proxy fingerprint.
- Update `CLAUDE.md` docs to describe the new settings.

## Test plan

- New `config.rs` tests cover project-over-global resolution, global fallback, off-when-unset, project-false-overrides-global, and JSON omission when unset.
- New `settings.rs` tests cover the Tool Search on/off toggle, scope toggle between global/project, and the rollout/shaper env value knobs.
- `just release-check` (fmt + clippy + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)